### PR TITLE
feat: auto-schema generation with example values (v0.4.2)

### DIFF
--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -6,6 +6,22 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+## [0.4.2] - 2026-03-12
+
+### Added
+
+- **Auto-schema generation** — `Input` and `Output` DTOs derive OpenAPI 3.0.3 schemas automatically from `schemaFields` getter + `SchemaField` metadata
+- `@Field` annotation — decorative per-field documentation (`@Field(description: 'x')`)
+- `SchemaField` class — metadata with factories: `.string()`, `.integer()`, `.number()`, `.boolean()`, `.array()`
+- `buildSchema()` utility — converts `List<SchemaField>` to OpenAPI 3.0.3-compatible `Map<String, dynamic>`
+- `Input` / `Output` base classes gain generative constructors and default `toSchema()` from `schemaFields`
+- Cross-language schema conformance tests against shared JSON fixtures
+
+### Changed
+
+- DTOs now use `extends Input` / `extends Output` instead of `implements` (for inherited `toSchema()` default)
+- Manual `toSchema()` override is deprecated — use `schemaFields` getter instead (removal in v0.5.0)
+
 ## [0.4.1] - 2026-03-12
 
 ### Changed

--- a/dart/README.md
+++ b/dart/README.md
@@ -51,7 +51,7 @@ See `example/example.dart` for the full implementation including Input, Output, 
 ## Features
 
 - `UseCase<I, O>` — pure business logic, no HTTP concerns
-- `Input` / `Output` — DTOs with `toJson()` and `toSchema()` for automatic OpenAPI
+- `Input` / `Output` — DTOs with automatic OpenAPI schema generation via `@Field` + `schemaFields`
 - `Output.statusCode` — custom HTTP status codes per response
 - `UseCaseException` — structured error handling (status code, message, error code, details)
 - `ModularApi` + `ModuleBuilder` — module registration and routing
@@ -69,7 +69,7 @@ See `example/example.dart` for the full implementation including Input, Output, 
 
 ```yaml
 dependencies:
-  modular_api: ^0.3.0
+  modular_api: ^0.4.2
 ```
 
 ```bash

--- a/dart/doc/testing_guide.md
+++ b/dart/doc/testing_guide.md
@@ -35,7 +35,10 @@ abstract class SumRepository {
 }
 
 class SumInput extends Input {
+  @Field(description: 'First operand')
   final int a;
+
+  @Field(description: 'Second operand')
   final int b;
   
   SumInput({required this.a, required this.b});
@@ -46,21 +49,17 @@ class SumInput extends Input {
   
   @override
   Map<String, dynamic> toJson() => {'a': a, 'b': b};
-  
+
   @override
-  Map<String, dynamic> toSchema() {
-    return {
-      'type': 'object',
-      'properties': {
-        'a': {'type': 'integer'},
-        'b': {'type': 'integer'},
-      },
-      'required': ['a', 'b'],
-    };
-  }
+  List<SchemaField> get schemaFields => [
+        SchemaField.integer('a', description: 'First operand'),
+        SchemaField.integer('b', description: 'Second operand'),
+      ];
+}
 }
 
 class SumOutput extends Output {
+  @Field(description: 'Sum result')
   final int result;
   
   SumOutput({required this.result});
@@ -74,17 +73,11 @@ class SumOutput extends Output {
   
   @override
   Map<String, dynamic> toJson() => {'result': result};
-  
+
   @override
-  Map<String, dynamic> toSchema() {
-    return {
-      'type': 'object',
-      'properties': {
-        'result': {'type': 'integer'},
-      },
-      'required': ['result'],
-    };
-  }
+  List<SchemaField> get schemaFields => [
+        SchemaField.integer('result', description: 'Sum result'),
+      ];
 }
 
 class SumNumbers implements UseCase<SumInput, SumOutput> {

--- a/dart/doc/usecase_dto_guide.md
+++ b/dart/doc/usecase_dto_guide.md
@@ -7,13 +7,15 @@ This guide provides clear and precise instructions for creating `Input` and `Out
 ## 📋 Overview
 
 Every use case requires two DTO classes:
-- **Input** — implements `Input` interface, represents the request data
-- **Output** — implements `Output` interface, represents the response data
+- **Input** — extends `Input` base class, represents the request data
+- **Output** — extends `Output` base class, represents the response data
 
 Each DTO must implement:
-1. `fromJson` — constructor to deserialize from JSON
+1. `fromJson` — factory constructor to deserialize from JSON
 2. `toJson` — method to serialize to JSON
-3. `toSchema` — method to generate OpenAPI schema definition
+3. `schemaFields` — getter that returns field metadata for automatic OpenAPI schema generation
+
+The `@Field` annotation is decorative — it documents intent per field. Schema generation is driven by the `schemaFields` getter and `SchemaField` metadata.
 
 ---
 
@@ -43,9 +45,14 @@ class CasoOutput {
 ```dart
 import 'package:modular_api/modular_api.dart';
 
-class CasoInput implements Input {
+class CasoInput extends Input {
+  @Field(description: 'Integer value')
   final int valor;
+
+  @Field(description: 'String value')
   final String valor2;
+
+  @Field(description: 'Double value')
   final double valor3;
 
   CasoInput({
@@ -54,7 +61,6 @@ class CasoInput implements Input {
     required this.valor3,
   });
 
-  // fromJson constructor - deserialize from JSON
   factory CasoInput.fromJson(Map<String, dynamic> json) {
     return CasoInput(
       valor: json['valor'] as int,
@@ -63,7 +69,6 @@ class CasoInput implements Input {
     );
   }
 
-  // toJson method - serialize to JSON
   @override
   Map<String, dynamic> toJson() {
     return {
@@ -73,19 +78,12 @@ class CasoInput implements Input {
     };
   }
 
-  // toSchema method - generate OpenAPI schema
   @override
-  Map<String, dynamic> toSchema() {
-    return {
-      'type': 'object',
-      'properties': {
-        'valor': {'type': 'integer', 'description': 'Integer value'},
-        'valor2': {'type': 'string', 'description': 'String value'},
-        'valor3': {'type': 'number', 'format': 'double', 'description': 'Double value'},
-      },
-      'required': ['valor', 'valor2', 'valor3'],
-    };
-  }
+  List<SchemaField> get schemaFields => [
+        SchemaField.integer('valor', description: 'Integer value'),
+        SchemaField.string('valor2', description: 'String value'),
+        SchemaField.number('valor3', description: 'Double value'),
+      ];
 }
 ```
 
@@ -94,9 +92,14 @@ class CasoInput implements Input {
 ```dart
 import 'package:modular_api/modular_api.dart';
 
-class CasoOutput implements Output {
+class CasoOutput extends Output {
+  @Field(description: 'Integer value')
   final int valor;
+
+  @Field(description: 'String value')
   final String valor2;
+
+  @Field(description: 'Double value')
   final double valor3;
 
   CasoOutput({
@@ -105,7 +108,6 @@ class CasoOutput implements Output {
     required this.valor3,
   });
 
-  // fromJson constructor - deserialize from JSON
   factory CasoOutput.fromJson(Map<String, dynamic> json) {
     return CasoOutput(
       valor: json['valor'] as int,
@@ -114,7 +116,9 @@ class CasoOutput implements Output {
     );
   }
 
-  // toJson method - serialize to JSON
+  @override
+  int get statusCode => 200;
+
   @override
   Map<String, dynamic> toJson() {
     return {
@@ -124,19 +128,12 @@ class CasoOutput implements Output {
     };
   }
 
-  // toSchema method - generate OpenAPI schema
   @override
-  Map<String, dynamic> toSchema() {
-    return {
-      'type': 'object',
-      'properties': {
-        'valor': {'type': 'integer', 'description': 'Integer value'},
-        'valor2': {'type': 'string', 'description': 'String value'},
-        'valor3': {'type': 'number', 'format': 'double', 'description': 'Double value'},
-      },
-      'required': ['valor', 'valor2', 'valor3'],
-    };
-  }
+  List<SchemaField> get schemaFields => [
+        SchemaField.integer('valor', description: 'Integer value'),
+        SchemaField.string('valor2', description: 'String value'),
+        SchemaField.number('valor3', description: 'Double value'),
+      ];
 }
 ```
 
@@ -144,120 +141,36 @@ class CasoOutput implements Output {
 
 ## 📚 Type Mapping Reference
 
-Use this table to map Dart types to OpenAPI schema types in `toSchema()`:
+Use this table to map Dart types to `SchemaField` factories:
 
-| Dart Type | OpenAPI Type | Format (optional) | Example |
-|-----------|--------------|-------------------|---------|
-| `int` | `'integer'` | `'int32'` or `'int64'` | `{'type': 'integer'}` |
-| `double` | `'number'` | `'double'` | `{'type': 'number', 'format': 'double'}` |
-| `num` | `'number'` | — | `{'type': 'number'}` |
-| `String` | `'string'` | — | `{'type': 'string'}` |
-| `bool` | `'boolean'` | — | `{'type': 'boolean'}` |
-| `DateTime` | `'string'` | `'date-time'` | `{'type': 'string', 'format': 'date-time'}` |
-| `List<T>` | `'array'` | — | `{'type': 'array', 'items': {...}}` |
-| `Map<String, dynamic>` | `'object'` | — | `{'type': 'object'}` |
-| Custom Object | `'object'` | — | `{'type': 'object', 'properties': {...}}` |
+| Dart Type | SchemaField Factory | OpenAPI Type |
+|-----------|-------------------|-------------|
+| `int` | `SchemaField.integer()` | `integer` |
+| `double` | `SchemaField.number()` | `number` |
+| `String` | `SchemaField.string()` | `string` |
+| `bool` | `SchemaField.boolean()` | `boolean` |
+| `List<T>` | `SchemaField.array()` | `array` with `items` |
+| Nullable (`T?`) | Add `nullable: true` to any factory | Excluded from `required[]`, `nullable: true` |
 
 ---
 
 ## 🔧 Advanced Examples
 
-### Example 1: Complex Input with Lists and Nested Objects
+### Example 1: Optional Fields
 
 ```dart
-class UserInput implements Input {
+class ProductInput extends Input {
+  @Field(description: 'Product name')
   final String name;
-  final int age;
-  final List<String> roles;
-  final Address address;
 
-  UserInput({
-    required this.name,
-    required this.age,
-    required this.roles,
-    required this.address,
-  });
-
-  factory UserInput.fromJson(Map<String, dynamic> json) {
-    return UserInput(
-      name: json['name'] as String,
-      age: json['age'] as int,
-      roles: (json['roles'] as List<dynamic>).map((e) => e as String).toList(),
-      address: Address.fromJson(json['address'] as Map<String, dynamic>),
-    );
-  }
-
-  @override
-  Map<String, dynamic> toJson() {
-    return {
-      'name': name,
-      'age': age,
-      'roles': roles,
-      'address': address.toJson(),
-    };
-  }
-
-  @override
-  Map<String, dynamic> toSchema() {
-    return {
-      'type': 'object',
-      'properties': {
-        'name': {'type': 'string', 'description': 'User name'},
-        'age': {'type': 'integer', 'description': 'User age'},
-        'roles': {
-          'type': 'array',
-          'items': {'type': 'string'},
-          'description': 'User roles'
-        },
-        'address': {
-          'type': 'object',
-          'properties': {
-            'street': {'type': 'string'},
-            'city': {'type': 'string'},
-            'zipCode': {'type': 'string'},
-          },
-          'required': ['street', 'city', 'zipCode'],
-          'description': 'User address'
-        },
-      },
-      'required': ['name', 'age', 'roles', 'address'],
-    };
-  }
-}
-
-class Address {
-  final String street;
-  final String city;
-  final String zipCode;
-
-  Address({required this.street, required this.city, required this.zipCode});
-
-  factory Address.fromJson(Map<String, dynamic> json) {
-    return Address(
-      street: json['street'] as String,
-      city: json['city'] as String,
-      zipCode: json['zipCode'] as String,
-    );
-  }
-
-  Map<String, dynamic> toJson() {
-    return {
-      'street': street,
-      'city': city,
-      'zipCode': zipCode,
-    };
-  }
-}
-```
-
-### Example 2: Optional Fields
-
-```dart
-class ProductInput implements Input {
-  final String name;
+  @Field(description: 'Product price')
   final double price;
-  final String? description; // Optional field
-  final int? stock; // Optional field
+
+  @Field(description: 'Product description (optional)')
+  final String? description;
+
+  @Field(description: 'Available stock (optional)')
+  final int? stock;
 
   ProductInput({
     required this.name,
@@ -286,120 +199,90 @@ class ProductInput implements Input {
   }
 
   @override
-  Map<String, dynamic> toSchema() {
-    return {
-      'type': 'object',
-      'properties': {
-        'name': {'type': 'string', 'description': 'Product name'},
-        'price': {'type': 'number', 'format': 'double', 'description': 'Product price'},
-        'description': {'type': 'string', 'description': 'Product description (optional)'},
-        'stock': {'type': 'integer', 'description': 'Available stock (optional)'},
-      },
-      'required': ['name', 'price'], // Only required fields listed
-    };
-  }
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('name', description: 'Product name'),
+        SchemaField.number('price', description: 'Product price'),
+        SchemaField.string('description', description: 'Product description (optional)', nullable: true),
+        SchemaField.integer('stock', description: 'Available stock (optional)', nullable: true),
+      ];
 }
 ```
 
-### Example 3: DateTime Fields
+### Example 2: Array Fields
 
 ```dart
-class EventInput implements Input {
-  final String title;
-  final DateTime startDate;
-  final DateTime? endDate; // Optional
+class UserInput extends Input {
+  @Field(description: 'User name')
+  final String name;
 
-  EventInput({
-    required this.title,
-    required this.startDate,
-    this.endDate,
-  });
+  @Field(description: 'User roles')
+  final List<String> roles;
 
-  factory EventInput.fromJson(Map<String, dynamic> json) {
-    return EventInput(
-      title: json['title'] as String,
-      startDate: DateTime.parse(json['startDate'] as String),
-      endDate: json['endDate'] != null ? DateTime.parse(json['endDate'] as String) : null,
+  UserInput({required this.name, required this.roles});
+
+  factory UserInput.fromJson(Map<String, dynamic> json) {
+    return UserInput(
+      name: json['name'] as String,
+      roles: (json['roles'] as List<dynamic>).map((e) => e as String).toList(),
     );
   }
 
   @override
-  Map<String, dynamic> toJson() {
-    return {
-      'title': title,
-      'startDate': startDate.toIso8601String(),
-      if (endDate != null) 'endDate': endDate!.toIso8601String(),
-    };
-  }
+  Map<String, dynamic> toJson() => {'name': name, 'roles': roles};
 
   @override
-  Map<String, dynamic> toSchema() {
-    return {
-      'type': 'object',
-      'properties': {
-        'title': {'type': 'string', 'description': 'Event title'},
-        'startDate': {
-          'type': 'string',
-          'format': 'date-time',
-          'description': 'Event start date and time'
-        },
-        'endDate': {
-          'type': 'string',
-          'format': 'date-time',
-          'description': 'Event end date and time (optional)'
-        },
-      },
-      'required': ['title', 'startDate'],
-    };
-  }
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('name', description: 'User name'),
+        SchemaField.array('roles', items: {'type': 'string'}, description: 'User roles'),
+      ];
 }
 ```
 
 ---
 
-## ⚠️ Important: Updating Existing toSchema
+## ⚠️ Migration from Manual `toSchema()`
 
-**If a `toSchema` method already exists**, you must update it to accurately reflect the current class properties:
+If your DTOs currently override `toSchema()` manually, you can migrate to the `schemaFields` pattern:
 
-1. **Add new properties** — Add entries in the `properties` map for any new fields
-2. **Remove obsolete properties** — Delete entries for fields that no longer exist
-3. **Update types** — Ensure the OpenAPI type matches the Dart type (see Type Mapping Reference)
-4. **Update required array** — Add/remove field names based on whether they are required or optional
-5. **Update descriptions** — Keep descriptions accurate and helpful
+1. **Add `schemaFields` getter** — Declare each field as a `SchemaField` with the appropriate factory
+2. **Remove `toSchema()` override** — The base class `toSchema()` calls `buildSchema(schemaFields)` automatically
+3. **Add `@Field` annotations** (optional) — Document intent per field
+4. **Change `implements` to `extends`** — Use `extends Input`/`extends Output` instead of `implements`
 
-**Example of updating an existing schema:**
-
-Before (outdated):
+**Before (manual):**
 ```dart
-@override
-Map<String, dynamic> toSchema() {
-  return {
-    'type': 'object',
-    'properties': {
-      'name': {'type': 'string'},
-      'age': {'type': 'integer'},
-    },
-    'required': ['name', 'age'],
-  };
+class MyInput implements Input {
+  final String name;
+  // ... fromJson, toJson ...
+  
+  @override
+  Map<String, dynamic> toSchema() {
+    return {
+      'type': 'object',
+      'properties': {
+        'name': {'type': 'string', 'description': 'User name'},
+      },
+      'required': ['name'],
+    };
+  }
 }
 ```
 
-After (updated with new fields):
+**After (auto-schema):**
 ```dart
-@override
-Map<String, dynamic> toSchema() {
-  return {
-    'type': 'object',
-    'properties': {
-      'name': {'type': 'string', 'description': 'User name'},
-      'age': {'type': 'integer', 'description': 'User age'},
-      'email': {'type': 'string', 'format': 'email', 'description': 'User email'}, // NEW
-      'verified': {'type': 'boolean', 'description': 'Email verification status'}, // NEW
-    },
-    'required': ['name', 'age', 'email'], // Updated to include 'email', 'verified' is optional
-  };
+class MyInput extends Input {
+  @Field(description: 'User name')
+  final String name;
+  // ... fromJson, toJson ...
+
+  @override
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('name', description: 'User name'),
+      ];
 }
 ```
+
+> **Note:** Manual `toSchema()` overrides still work in v0.4.2 — they are deprecated but not removed. When Dart macros stabilize, `@MacssSchema()` will replace the `schemaFields` getter entirely.
 
 ---
 
@@ -407,16 +290,16 @@ Map<String, dynamic> toSchema() {
 
 When creating or updating Input/Output DTOs, ensure:
 
-- [ ] Class implements `Input` or `Output`
+- [ ] Class extends `Input` or `Output` (not `implements`)
 - [ ] All properties are `final`
 - [ ] `fromJson` factory constructor is implemented
 - [ ] `toJson` method is implemented and overrides base class
-- [ ] `toSchema` method is implemented and overrides base class
-- [ ] All properties are included in `fromJson`, `toJson`, and `toSchema`
-- [ ] Type mapping in `toSchema` matches Dart types (see Type Mapping Reference)
-- [ ] `required` array in `toSchema` includes only non-nullable fields
-- [ ] Optional fields use nullable types (`Type?`) in Dart
-- [ ] Descriptions are provided for all properties in `toSchema`
+- [ ] `schemaFields` getter is implemented with `SchemaField` entries for each field
+- [ ] `@Field` annotation is present on each property (optional but recommended)
+- [ ] SchemaField factory matches Dart type (see Type Mapping Reference)
+- [ ] Nullable fields use `nullable: true` in their `SchemaField`
+- [ ] Optional fields use nullable Dart types (`Type?`)
+- [ ] Descriptions are provided for all fields
 - [ ] Nested objects implement their own `fromJson` and `toJson` methods
 - [ ] Lists are properly handled with `.map()` in `fromJson`
 - [ ] DateTime fields use `DateTime.parse()` and `.toIso8601String()`
@@ -430,78 +313,45 @@ Copy and adapt this template for new DTOs:
 ```dart
 import 'package:modular_api/modular_api.dart';
 
-class MyUseCaseInput implements Input {
+class MyUseCaseInput extends Input {
+  @Field(description: 'Description here')
   final String myField;
-  // Add more fields here
 
-  MyUseCaseInput({
-    required this.myField,
-    // Add more parameters here
-  });
+  MyUseCaseInput({required this.myField});
 
   factory MyUseCaseInput.fromJson(Map<String, dynamic> json) {
-    return MyUseCaseInput(
-      myField: json['myField'] as String,
-      // Parse more fields here
-    );
+    return MyUseCaseInput(myField: json['myField'] as String);
   }
 
   @override
-  Map<String, dynamic> toJson() {
-    return {
-      'myField': myField,
-      // Add more fields here
-    };
-  }
+  Map<String, dynamic> toJson() => {'myField': myField};
 
   @override
-  Map<String, dynamic> toSchema() {
-    return {
-      'type': 'object',
-      'properties': {
-        'myField': {'type': 'string', 'description': 'Description here'},
-        // Add more properties here
-      },
-      'required': ['myField'], // List required fields
-    };
-  }
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('myField', description: 'Description here'),
+      ];
 }
 
-class MyUseCaseOutput implements Output {
+class MyUseCaseOutput extends Output {
+  @Field(description: 'Description here')
   final String result;
-  // Add more fields here
 
-  MyUseCaseOutput({
-    required this.result,
-    // Add more parameters here
-  });
+  MyUseCaseOutput({required this.result});
 
   factory MyUseCaseOutput.fromJson(Map<String, dynamic> json) {
-    return MyUseCaseOutput(
-      result: json['result'] as String,
-      // Parse more fields here
-    );
+    return MyUseCaseOutput(result: json['result'] as String);
   }
 
   @override
-  Map<String, dynamic> toJson() {
-    return {
-      'result': result,
-      // Add more fields here
-    };
-  }
+  int get statusCode => 200;
 
   @override
-  Map<String, dynamic> toSchema() {
-    return {
-      'type': 'object',
-      'properties': {
-        'result': {'type': 'string', 'description': 'Description here'},
-        // Add more properties here
-      },
-      'required': ['result'], // List required fields
-    };
-  }
+  Map<String, dynamic> toJson() => {'result': result};
+
+  @override
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('result', description: 'Description here'),
+      ];
 }
 ```
 
@@ -511,8 +361,8 @@ class MyUseCaseOutput implements Output {
 
 - [OpenAPI Specification - Data Types](https://swagger.io/specification/#data-types)
 - [JSON Schema Validation](https://json-schema.org/understanding-json-schema/reference/type.html)
-- See `template/lib/modules/module1/hello_world.dart` for a working example in this repository
+- See `example/example.dart` for a working example in this repository
 
 ---
 
-**Remember:** The `toSchema` method is critical for automatic OpenAPI documentation generation. Always keep it synchronized with your class properties!
+**Remember:** The `schemaFields` getter is the single source of truth for OpenAPI schema generation. Keep it synchronized with your class properties!

--- a/dart/example/example.dart
+++ b/dart/example/example.dart
@@ -51,8 +51,9 @@ class HelloInput extends Input {
 
   HelloInput({required this.name});
 
-  factory HelloInput.fromJson(Map<String, dynamic> json) =>
-      HelloInput(name: (json['name'] ?? '').toString());
+  factory HelloInput.fromJson(Map<String, dynamic> json) => HelloInput(
+        name: (json['name'] ?? '').toString(),
+      );
 
   @override
   Map<String, dynamic> toJson() => {'name': name};

--- a/dart/example/example.dart
+++ b/dart/example/example.dart
@@ -51,10 +51,6 @@ class HelloInput extends Input {
 
   HelloInput({required this.name});
 
-  static final List<SchemaField> schema = [
-    SchemaField.string('name', description: 'Name to greet'),
-  ];
-
   factory HelloInput.fromJson(Map<String, dynamic> json) =>
       HelloInput(name: (json['name'] ?? '').toString());
 
@@ -62,7 +58,9 @@ class HelloInput extends Input {
   Map<String, dynamic> toJson() => {'name': name};
 
   @override
-  List<SchemaField> get schemaFields => schema;
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('name', description: 'Name to greet'),
+      ];
 }
 
 // ─── Output DTO ───────────────────────────────────────────────────────────────
@@ -72,10 +70,6 @@ class HelloOutput extends Output {
   final String message;
 
   HelloOutput({this.message = ''});
-
-  static final List<SchemaField> schema = [
-    SchemaField.string('message', description: 'Greeting message'),
-  ];
 
   factory HelloOutput.fromJson(Map<String, dynamic> json) =>
       HelloOutput(message: (json['message'] ?? '').toString());
@@ -87,7 +81,9 @@ class HelloOutput extends Output {
   Map<String, dynamic> toJson() => {'message': message};
 
   @override
-  List<SchemaField> get schemaFields => schema;
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('message', description: 'Greeting message'),
+      ];
 }
 
 // ─── UseCase ──────────────────────────────────────────────────────────────────

--- a/dart/example/example.dart
+++ b/dart/example/example.dart
@@ -45,7 +45,7 @@ void buildGreetingsModule(ModuleBuilder m) {
 
 // ─── Input DTO ────────────────────────────────────────────────────────────────
 
-class HelloInput implements Input {
+class HelloInput extends Input {
   final String name;
 
   HelloInput({required this.name});
@@ -68,7 +68,7 @@ class HelloInput implements Input {
 
 // ─── Output DTO ───────────────────────────────────────────────────────────────
 
-class HelloOutput implements Output {
+class HelloOutput extends Output {
   final String message;
 
   HelloOutput({this.message = ''});

--- a/dart/example/example.dart
+++ b/dart/example/example.dart
@@ -15,7 +15,6 @@ library;
 
 import 'package:modular_api/modular_api.dart';
 
-
 // ─── Server ───────────────────────────────────────────────────────────────────
 
 Future<void> main(List<String> args) async {
@@ -79,7 +78,8 @@ class HelloInput extends Input {
 
   @override
   List<SchemaField> get schemaFields => [
-        SchemaField.string('name', description: 'Name to greet', example: 'World'),
+        SchemaField.string('name',
+            description: 'Name to greet', example: 'World'),
       ];
 
   /// Example instance for schema extraction and Swagger UI.
@@ -105,7 +105,8 @@ class HelloOutput extends Output {
 
   @override
   List<SchemaField> get schemaFields => [
-        SchemaField.string('message', description: 'Greeting message', example: 'Hello, World!'),
+        SchemaField.string('message',
+            description: 'Greeting message', example: 'Hello, World!'),
       ];
 
   /// Example instance for schema extraction and Swagger UI.

--- a/dart/example/example.dart
+++ b/dart/example/example.dart
@@ -40,7 +40,10 @@ Future<void> main(List<String> args) async {
 //   lib/modules/greetings/greetings_builder.dart
 
 void buildGreetingsModule(ModuleBuilder m) {
-  m.usecase('hello', HelloWorld.fromJson);
+  m.usecase('hello', HelloWorld.fromJson,
+    inputFields: HelloInput.schema,
+    outputFields: HelloOutput.schema,
+  );
 }
 
 // ─── Input DTO ────────────────────────────────────────────────────────────────
@@ -49,19 +52,26 @@ class HelloInput extends Input {
   @Field(description: 'Name to greet')
   final String name;
 
+  /// Schema — shared between validation and OpenAPI generation.
+  static final List<SchemaField> schema = [
+    SchemaField.string('name', description: 'Name to greet'),
+  ];
+
   HelloInput({required this.name});
 
-  factory HelloInput.fromJson(Map<String, dynamic> json) => HelloInput(
-        name: (json['name'] ?? '').toString(),
-      );
+  /// Validates required fields and correct types before construction.
+  /// Throws [InputValidationException] on structural violations.
+  /// Business-rule validation belongs in [HelloWorld.validate].
+  factory HelloInput.fromJson(Map<String, dynamic> json) {
+    validateJsonFields(json, schema);
+    return HelloInput(name: json['name'] as String);
+  }
 
   @override
   Map<String, dynamic> toJson() => {'name': name};
 
   @override
-  List<SchemaField> get schemaFields => [
-        SchemaField.string('name', description: 'Name to greet'),
-      ];
+  List<SchemaField> get schemaFields => schema;
 }
 
 // ─── Output DTO ───────────────────────────────────────────────────────────────
@@ -70,10 +80,15 @@ class HelloOutput extends Output {
   @Field(description: 'Greeting message')
   final String message;
 
+  /// Schema — shared between OpenAPI generation and optional validation.
+  static final List<SchemaField> schema = [
+    SchemaField.string('message', description: 'Greeting message'),
+  ];
+
   HelloOutput({this.message = ''});
 
   factory HelloOutput.fromJson(Map<String, dynamic> json) =>
-      HelloOutput(message: (json['message'] ?? '').toString());
+      HelloOutput(message: (json['message'] ?? '') as String);
 
   @override
   int get statusCode => 200;
@@ -82,9 +97,7 @@ class HelloOutput extends Output {
   Map<String, dynamic> toJson() => {'message': message};
 
   @override
-  List<SchemaField> get schemaFields => [
-        SchemaField.string('message', description: 'Greeting message'),
-      ];
+  List<SchemaField> get schemaFields => schema;
 }
 
 // ─── UseCase ──────────────────────────────────────────────────────────────────

--- a/dart/example/example.dart
+++ b/dart/example/example.dart
@@ -52,7 +52,12 @@ Future<void> main(List<String> args) async {
 //   lib/modules/greetings/greetings_builder.dart
 
 void buildGreetingsModule(ModuleBuilder m) {
-  m.usecase('hello', HelloWorld.fromJson);
+  m.usecase(
+    'hello',
+    HelloWorld.fromJson,
+    inputExample: HelloInput.example,
+    outputExample: HelloOutput.example,
+  );
 }
 
 // ─── Input DTO ────────────────────────────────────────────────────────────────
@@ -63,8 +68,10 @@ class HelloInput extends Input {
 
   HelloInput({required this.name});
 
+  /// Strict factory — no coercion, no defaults.
+  /// Pre-validation in the handler ensures data is valid before this runs.
   factory HelloInput.fromJson(Map<String, dynamic> json) => HelloInput(
-        name: (json['name'] ?? '').toString(),
+        name: json['name'] as String,
       );
 
   @override
@@ -72,8 +79,11 @@ class HelloInput extends Input {
 
   @override
   List<SchemaField> get schemaFields => [
-        SchemaField.string('name', description: 'Name to greet'),
+        SchemaField.string('name', description: 'Name to greet', example: 'World'),
       ];
+
+  /// Example instance for schema extraction and Swagger UI.
+  static HelloInput get example => HelloInput(name: 'World');
 }
 
 // ─── Output DTO ───────────────────────────────────────────────────────────────
@@ -82,10 +92,10 @@ class HelloOutput extends Output {
   @Field(description: 'Greeting message')
   final String message;
 
-  HelloOutput({this.message = ''});
+  HelloOutput({required this.message});
 
   factory HelloOutput.fromJson(Map<String, dynamic> json) =>
-      HelloOutput(message: (json['message'] ?? '').toString());
+      HelloOutput(message: json['message'] as String);
 
   @override
   int get statusCode => 200;
@@ -95,8 +105,11 @@ class HelloOutput extends Output {
 
   @override
   List<SchemaField> get schemaFields => [
-        SchemaField.string('message', description: 'Greeting message'),
+        SchemaField.string('message', description: 'Greeting message', example: 'Hello, World!'),
       ];
+
+  /// Example instance for schema extraction and Swagger UI.
+  static HelloOutput get example => HelloOutput(message: 'Hello, World!');
 }
 
 // ─── UseCase ──────────────────────────────────────────────────────────────────
@@ -112,7 +125,7 @@ class HelloWorld implements UseCase<HelloInput, HelloOutput> {
   ModularLogger? logger;
 
   HelloWorld({required this.input}) {
-    output = HelloOutput();
+    output = HelloOutput(message: '');
   }
 
   static HelloWorld fromJson(Map<String, dynamic> json) {

--- a/dart/example/example.dart
+++ b/dart/example/example.dart
@@ -51,16 +51,20 @@ class HelloInput extends Input {
 
   HelloInput({required this.name});
 
-  factory HelloInput.fromJson(Map<String, dynamic> json) =>
-      HelloInput(name: (json['name'] ?? '').toString());
+  static final List<SchemaField> schema = [
+    SchemaField.string('name', description: 'Name to greet'),
+  ];
+
+  factory HelloInput.fromJson(Map<String, dynamic> json) {
+    validateJsonFields(json, schema);
+    return HelloInput(name: json['name'] as String);
+  }
 
   @override
   Map<String, dynamic> toJson() => {'name': name};
 
   @override
-  List<SchemaField> get schemaFields => [
-        SchemaField.string('name', description: 'Name to greet'),
-      ];
+  List<SchemaField> get schemaFields => schema;
 }
 
 // ─── Output DTO ───────────────────────────────────────────────────────────────
@@ -71,8 +75,14 @@ class HelloOutput extends Output {
 
   HelloOutput({this.message = ''});
 
-  factory HelloOutput.fromJson(Map<String, dynamic> json) =>
-      HelloOutput(message: (json['message'] ?? '').toString());
+  static final List<SchemaField> schema = [
+    SchemaField.string('message', description: 'Greeting message'),
+  ];
+
+  factory HelloOutput.fromJson(Map<String, dynamic> json) {
+    validateJsonFields(json, schema);
+    return HelloOutput(message: json['message'] as String);
+  }
 
   @override
   int get statusCode => 200;
@@ -81,9 +91,7 @@ class HelloOutput extends Output {
   Map<String, dynamic> toJson() => {'message': message};
 
   @override
-  List<SchemaField> get schemaFields => [
-        SchemaField.string('message', description: 'Greeting message'),
-      ];
+  List<SchemaField> get schemaFields => schema;
 }
 
 // ─── UseCase ──────────────────────────────────────────────────────────────────

--- a/dart/example/example.dart
+++ b/dart/example/example.dart
@@ -55,10 +55,8 @@ class HelloInput extends Input {
     SchemaField.string('name', description: 'Name to greet'),
   ];
 
-  factory HelloInput.fromJson(Map<String, dynamic> json) {
-    validateJsonFields(json, schema);
-    return HelloInput(name: json['name'] as String);
-  }
+  factory HelloInput.fromJson(Map<String, dynamic> json) =>
+      HelloInput(name: (json['name'] ?? '').toString());
 
   @override
   Map<String, dynamic> toJson() => {'name': name};
@@ -79,10 +77,8 @@ class HelloOutput extends Output {
     SchemaField.string('message', description: 'Greeting message'),
   ];
 
-  factory HelloOutput.fromJson(Map<String, dynamic> json) {
-    validateJsonFields(json, schema);
-    return HelloOutput(message: json['message'] as String);
-  }
+  factory HelloOutput.fromJson(Map<String, dynamic> json) =>
+      HelloOutput(message: (json['message'] ?? '').toString());
 
   @override
   int get statusCode => 200;

--- a/dart/example/example.dart
+++ b/dart/example/example.dart
@@ -1,4 +1,20 @@
+/// example/example.dart
+/// Minimal runnable example — mirrors example/example.dart from the Dart version.
+///
+/// Run:
+///   dart run example/example.dart
+///
+/// Then test:
+///   curl -X POST http://localhost:8080/api/greetings/hello \
+///        -H "Content-Type: application/json" \
+///        -d '{"name":"World"}'
+///
+/// Docs:
+///   http://localhost:8080/docs
+library;
+
 import 'package:modular_api/modular_api.dart';
+
 
 // ─── Server ───────────────────────────────────────────────────────────────────
 

--- a/dart/example/example.dart
+++ b/dart/example/example.dart
@@ -46,6 +46,7 @@ void buildGreetingsModule(ModuleBuilder m) {
 // ─── Input DTO ────────────────────────────────────────────────────────────────
 
 class HelloInput extends Input {
+  @Field(description: 'Name to greet')
   final String name;
 
   HelloInput({required this.name});
@@ -57,18 +58,15 @@ class HelloInput extends Input {
   Map<String, dynamic> toJson() => {'name': name};
 
   @override
-  Map<String, dynamic> toSchema() => {
-        'type': 'object',
-        'properties': {
-          'name': {'type': 'string', 'description': 'Name to greet'},
-        },
-        'required': ['name'],
-      };
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('name', description: 'Name to greet'),
+      ];
 }
 
 // ─── Output DTO ───────────────────────────────────────────────────────────────
 
 class HelloOutput extends Output {
+  @Field(description: 'Greeting message')
   final String message;
 
   HelloOutput({this.message = ''});
@@ -83,13 +81,9 @@ class HelloOutput extends Output {
   Map<String, dynamic> toJson() => {'message': message};
 
   @override
-  Map<String, dynamic> toSchema() => {
-        'type': 'object',
-        'properties': {
-          'message': {'type': 'string', 'description': 'Greeting message'},
-        },
-        'required': ['message'],
-      };
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('message', description: 'Greeting message'),
+      ];
 }
 
 // ─── UseCase ──────────────────────────────────────────────────────────────────

--- a/dart/example/example.dart
+++ b/dart/example/example.dart
@@ -45,10 +45,6 @@ Future<void> main(List<String> args) async {
   api.module('greetings', buildGreetingsModule);
 
   await api.serve(port: port);
-
-  print('====================================');
-  print('API     → http://localhost:$port/api/greetings/hello');
-  print('====================================');
 }
 
 // ─── Module Builder ───────────────────────────────────────────────────────────

--- a/dart/example/example.dart
+++ b/dart/example/example.dart
@@ -40,10 +40,7 @@ Future<void> main(List<String> args) async {
 //   lib/modules/greetings/greetings_builder.dart
 
 void buildGreetingsModule(ModuleBuilder m) {
-  m.usecase('hello', HelloWorld.fromJson,
-    inputFields: HelloInput.schema,
-    outputFields: HelloOutput.schema,
-  );
+  m.usecase('hello', HelloWorld.fromJson);
 }
 
 // ─── Input DTO ────────────────────────────────────────────────────────────────
@@ -52,26 +49,19 @@ class HelloInput extends Input {
   @Field(description: 'Name to greet')
   final String name;
 
-  /// Schema — shared between validation and OpenAPI generation.
-  static final List<SchemaField> schema = [
-    SchemaField.string('name', description: 'Name to greet'),
-  ];
-
   HelloInput({required this.name});
 
-  /// Validates required fields and correct types before construction.
-  /// Throws [InputValidationException] on structural violations.
-  /// Business-rule validation belongs in [HelloWorld.validate].
-  factory HelloInput.fromJson(Map<String, dynamic> json) {
-    validateJsonFields(json, schema);
-    return HelloInput(name: json['name'] as String);
-  }
+  factory HelloInput.fromJson(Map<String, dynamic> json) => HelloInput(
+        name: (json['name'] ?? '').toString(),
+      );
 
   @override
   Map<String, dynamic> toJson() => {'name': name};
 
   @override
-  List<SchemaField> get schemaFields => schema;
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('name', description: 'Name to greet'),
+      ];
 }
 
 // ─── Output DTO ───────────────────────────────────────────────────────────────
@@ -80,15 +70,10 @@ class HelloOutput extends Output {
   @Field(description: 'Greeting message')
   final String message;
 
-  /// Schema — shared between OpenAPI generation and optional validation.
-  static final List<SchemaField> schema = [
-    SchemaField.string('message', description: 'Greeting message'),
-  ];
-
   HelloOutput({this.message = ''});
 
   factory HelloOutput.fromJson(Map<String, dynamic> json) =>
-      HelloOutput(message: (json['message'] ?? '') as String);
+      HelloOutput(message: (json['message'] ?? '').toString());
 
   @override
   int get statusCode => 200;
@@ -97,7 +82,9 @@ class HelloOutput extends Output {
   Map<String, dynamic> toJson() => {'message': message};
 
   @override
-  List<SchemaField> get schemaFields => schema;
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('message', description: 'Greeting message'),
+      ];
 }
 
 // ─── UseCase ──────────────────────────────────────────────────────────────────

--- a/dart/lib/modular_api.dart
+++ b/dart/lib/modular_api.dart
@@ -10,6 +10,7 @@ export 'package:shelf/shelf.dart' show Middleware, Handler, Request, Response;
 export 'src/core/modular_api.dart' show ModularApi, ModuleBuilder;
 export 'src/core/usecase/usecase.dart' show UseCase, Input, Output;
 export 'src/core/usecase/use_case_exception.dart' show UseCaseException;
+export 'src/core/schema/field.dart' show Field, SchemaField, buildSchema;
 // Logger
 export 'src/core/logger/logger.dart' show LogLevel, ModularLogger;
 

--- a/dart/lib/modular_api.dart
+++ b/dart/lib/modular_api.dart
@@ -11,7 +11,12 @@ export 'src/core/modular_api.dart' show ModularApi, ModuleBuilder;
 export 'src/core/usecase/usecase.dart' show UseCase, Input, Output;
 export 'src/core/usecase/use_case_exception.dart' show UseCaseException;
 export 'src/core/schema/field.dart'
-    show Field, SchemaField, buildSchema, InputValidationException, validateJsonFields;
+    show
+        Field,
+        SchemaField,
+        buildSchema,
+        InputValidationException,
+        validateJsonFields;
 // Logger
 export 'src/core/logger/logger.dart' show LogLevel, ModularLogger;
 

--- a/dart/lib/modular_api.dart
+++ b/dart/lib/modular_api.dart
@@ -10,7 +10,8 @@ export 'package:shelf/shelf.dart' show Middleware, Handler, Request, Response;
 export 'src/core/modular_api.dart' show ModularApi, ModuleBuilder;
 export 'src/core/usecase/usecase.dart' show UseCase, Input, Output;
 export 'src/core/usecase/use_case_exception.dart' show UseCaseException;
-export 'src/core/schema/field.dart' show Field, SchemaField, buildSchema;
+export 'src/core/schema/field.dart'
+    show Field, SchemaField, buildSchema, InputValidationException, validateJsonFields;
 // Logger
 export 'src/core/logger/logger.dart' show LogLevel, ModularLogger;
 

--- a/dart/lib/src/core/modular_api.dart
+++ b/dart/lib/src/core/modular_api.dart
@@ -213,6 +213,8 @@ class ModuleBuilder {
     String method = 'POST',
     String? summary,
     String? description,
+    Input? inputExample,
+    Output? outputExample,
   }) {
     Handler h = useCaseHttpHandler(usecaseFactory);
 
@@ -260,6 +262,8 @@ class ModuleBuilder {
         path: '${_normalizeBase(basePath)}/$moduleName/$usecaseName',
         factory: usecaseFactory,
         doc: doc,
+        inputExample: inputExample,
+        outputExample: outputExample,
       ),
     );
 
@@ -296,6 +300,14 @@ class UseCaseRegistration {
   final UseCaseFactory factory;
   final UseCaseDocMeta? doc;
 
+  /// Example Input instance for schema extraction and Swagger UI.
+  /// When provided, the framework extracts schema from this instance
+  /// instead of calling `factory({})` — enabling strict `fromJson`.
+  final Input? inputExample;
+
+  /// Example Output instance for schema extraction and Swagger UI.
+  final Output? outputExample;
+
   UseCaseRegistration({
     required this.module,
     required this.name,
@@ -303,6 +315,8 @@ class UseCaseRegistration {
     required this.path,
     required this.factory,
     this.doc,
+    this.inputExample,
+    this.outputExample,
   });
 }
 

--- a/dart/lib/src/core/modular_api.dart
+++ b/dart/lib/src/core/modular_api.dart
@@ -216,7 +216,7 @@ class ModuleBuilder {
     Input? inputExample,
     Output? outputExample,
   }) {
-    Handler h = useCaseHttpHandler(usecaseFactory);
+    Handler h = useCaseHttpHandler(usecaseFactory, inputExample: inputExample);
 
     /// Clean usecase name
     usecaseName = usecaseName.trim();

--- a/dart/lib/src/core/modular_api.dart
+++ b/dart/lib/src/core/modular_api.dart
@@ -206,19 +206,13 @@ class ModuleBuilder {
     required Router root,
   }) : _root = root;
 
-  /// Registers a use case as an HTTP endpoint.
-  ///
-  /// When [inputFields] or [outputFields] are provided, schema extraction
-  /// uses them directly — no `factory({})` instantiation needed.
-  /// Required when `fromJson` validates input (the recommended pattern).
+  /// POST by default
   ModuleBuilder usecase(
     String usecaseName,
     UseCaseFactory usecaseFactory, {
     String method = 'POST',
     String? summary,
     String? description,
-    List<SchemaField>? inputFields,
-    List<SchemaField>? outputFields,
   }) {
     Handler h = useCaseHttpHandler(usecaseFactory);
 
@@ -266,8 +260,6 @@ class ModuleBuilder {
         path: '${_normalizeBase(basePath)}/$moduleName/$usecaseName',
         factory: usecaseFactory,
         doc: doc,
-        inputFields: inputFields,
-        outputFields: outputFields,
       ),
     );
 
@@ -304,13 +296,6 @@ class UseCaseRegistration {
   final UseCaseFactory factory;
   final UseCaseDocMeta? doc;
 
-  /// Pre-registered schema fields for the Input DTO.
-  /// When provided, OpenAPI schema is derived directly — no `factory({})` needed.
-  final List<SchemaField>? inputFields;
-
-  /// Pre-registered schema fields for the Output DTO.
-  final List<SchemaField>? outputFields;
-
   UseCaseRegistration({
     required this.module,
     required this.name,
@@ -318,8 +303,6 @@ class UseCaseRegistration {
     required this.path,
     required this.factory,
     this.doc,
-    this.inputFields,
-    this.outputFields,
   });
 }
 

--- a/dart/lib/src/core/modular_api.dart
+++ b/dart/lib/src/core/modular_api.dart
@@ -206,13 +206,19 @@ class ModuleBuilder {
     required Router root,
   }) : _root = root;
 
-  /// POST by default
+  /// Registers a use case as an HTTP endpoint.
+  ///
+  /// When [inputFields] or [outputFields] are provided, schema extraction
+  /// uses them directly — no `factory({})` instantiation needed.
+  /// Required when `fromJson` validates input (the recommended pattern).
   ModuleBuilder usecase(
     String usecaseName,
     UseCaseFactory usecaseFactory, {
     String method = 'POST',
     String? summary,
     String? description,
+    List<SchemaField>? inputFields,
+    List<SchemaField>? outputFields,
   }) {
     Handler h = useCaseHttpHandler(usecaseFactory);
 
@@ -260,6 +266,8 @@ class ModuleBuilder {
         path: '${_normalizeBase(basePath)}/$moduleName/$usecaseName',
         factory: usecaseFactory,
         doc: doc,
+        inputFields: inputFields,
+        outputFields: outputFields,
       ),
     );
 
@@ -296,6 +304,13 @@ class UseCaseRegistration {
   final UseCaseFactory factory;
   final UseCaseDocMeta? doc;
 
+  /// Pre-registered schema fields for the Input DTO.
+  /// When provided, OpenAPI schema is derived directly — no `factory({})` needed.
+  final List<SchemaField>? inputFields;
+
+  /// Pre-registered schema fields for the Output DTO.
+  final List<SchemaField>? outputFields;
+
   UseCaseRegistration({
     required this.module,
     required this.name,
@@ -303,6 +318,8 @@ class UseCaseRegistration {
     required this.path,
     required this.factory,
     this.doc,
+    this.inputFields,
+    this.outputFields,
   });
 }
 

--- a/dart/lib/src/core/schema/field.dart
+++ b/dart/lib/src/core/schema/field.dart
@@ -117,3 +117,58 @@ Map<String, dynamic> buildSchema(List<SchemaField> fields) {
   }
   return schema;
 }
+
+/// Thrown by [validateJsonFields] when a required field is missing
+/// or has the wrong JSON type.
+///
+/// Error messages follow the cross-SDK parity contract:
+///   - `"Missing required field: {name}"`
+///   - `"Field '{name}' must be of type {type}"`
+class InputValidationException implements Exception {
+  final String message;
+
+  InputValidationException(this.message);
+
+  @override
+  String toString() => 'InputValidationException: $message';
+}
+
+/// Validates raw JSON against a list of [SchemaField] entries.
+///
+/// Throws [InputValidationException] when a required field is missing
+/// or has the wrong JSON type. The handler catches this and returns 400.
+///
+/// Business-rule validation belongs in `UseCase.validate()` instead.
+void validateJsonFields(Map<String, dynamic> json, List<SchemaField> fields) {
+  for (final field in fields) {
+    if (!field.required) continue;
+
+    if (!json.containsKey(field.name) || json[field.name] == null) {
+      throw InputValidationException('Missing required field: ${field.name}');
+    }
+
+    if (!_isJsonTypeValid(json[field.name], field.type)) {
+      throw InputValidationException(
+        "Field '${field.name}' must be of type ${field.type}",
+      );
+    }
+  }
+}
+
+/// Checks whether a JSON value matches the expected OpenAPI type.
+bool _isJsonTypeValid(dynamic value, String expectedType) {
+  switch (expectedType) {
+    case 'string':
+      return value is String;
+    case 'integer':
+      return value is int;
+    case 'number':
+      return value is num;
+    case 'boolean':
+      return value is bool;
+    case 'array':
+      return value is List;
+    default:
+      return true;
+  }
+}

--- a/dart/lib/src/core/schema/field.dart
+++ b/dart/lib/src/core/schema/field.dart
@@ -58,16 +58,20 @@ class SchemaField {
     this.example,
   });
 
-  factory SchemaField.string(String name, {String? description, dynamic example}) =>
+  factory SchemaField.string(String name,
+          {String? description, dynamic example}) =>
       SchemaField(name, 'string', description: description, example: example);
 
-  factory SchemaField.integer(String name, {String? description, dynamic example}) =>
+  factory SchemaField.integer(String name,
+          {String? description, dynamic example}) =>
       SchemaField(name, 'integer', description: description, example: example);
 
-  factory SchemaField.number(String name, {String? description, dynamic example}) =>
+  factory SchemaField.number(String name,
+          {String? description, dynamic example}) =>
       SchemaField(name, 'number', description: description, example: example);
 
-  factory SchemaField.boolean(String name, {String? description, dynamic example}) =>
+  factory SchemaField.boolean(String name,
+          {String? description, dynamic example}) =>
       SchemaField(name, 'boolean', description: description, example: example);
 
   factory SchemaField.array(
@@ -76,7 +80,8 @@ class SchemaField {
     String? description,
     dynamic example,
   }) =>
-      SchemaField(name, 'array', description: description, items: itemType, example: example);
+      SchemaField(name, 'array',
+          description: description, items: itemType, example: example);
 
   factory SchemaField.optional(SchemaField inner) => SchemaField(
         inner.name,

--- a/dart/lib/src/core/schema/field.dart
+++ b/dart/lib/src/core/schema/field.dart
@@ -118,6 +118,58 @@ Map<String, dynamic> buildSchema(List<SchemaField> fields) {
   return schema;
 }
 
+/// Infers an OpenAPI 3.0.3 JSON Schema from example values in a `toJson()` map.
+///
+/// Maps Dart runtime types to OpenAPI types:
+///   - `String` → `string`
+///   - `int` → `integer`
+///   - `double` → `number`
+///   - `bool` → `boolean`
+///   - `List` → `array` (item type inferred from first element)
+///   - `null` → `string` + `nullable: true` (excluded from required)
+///
+/// Used as fallback when [schemaFields] is not provided on an Input/Output.
+Map<String, dynamic> inferSchemaFromExample(Map<String, dynamic> exampleJson) {
+  final properties = <String, Map<String, dynamic>>{};
+  final required = <String>[];
+
+  for (final entry in exampleJson.entries) {
+    final value = entry.value;
+    if (value == null) {
+      properties[entry.key] = {'type': 'string', 'nullable': true};
+      continue;
+    }
+
+    final prop = <String, dynamic>{'type': _inferOpenApiType(value)};
+    if (value is List) {
+      prop['items'] = {
+        'type': value.isEmpty ? 'string' : _inferOpenApiType(value.first),
+      };
+    }
+    properties[entry.key] = prop;
+    required.add(entry.key);
+  }
+
+  final schema = <String, dynamic>{
+    'type': 'object',
+    'properties': properties,
+  };
+  if (required.isNotEmpty) {
+    schema['required'] = required;
+  }
+  return schema;
+}
+
+/// Maps a Dart runtime value to its OpenAPI 3.0.3 type string.
+String _inferOpenApiType(dynamic value) {
+  if (value is String) return 'string';
+  if (value is int) return 'integer';
+  if (value is double) return 'number';
+  if (value is bool) return 'boolean';
+  if (value is List) return 'array';
+  return 'string';
+}
+
 /// Thrown by [validateJsonFields] when a required field is missing
 /// or has the wrong JSON type.
 ///

--- a/dart/lib/src/core/schema/field.dart
+++ b/dart/lib/src/core/schema/field.dart
@@ -23,6 +23,7 @@
 ///   // toSchema() → auto-derived from schemaFields!
 /// }
 /// ```
+library;
 
 /// Decorative annotation for field metadata.
 ///

--- a/dart/lib/src/core/schema/field.dart
+++ b/dart/lib/src/core/schema/field.dart
@@ -46,6 +46,7 @@ class SchemaField {
   final bool required;
   final bool nullable;
   final SchemaField? items;
+  final dynamic example;
 
   const SchemaField(
     this.name,
@@ -54,26 +55,28 @@ class SchemaField {
     this.required = true,
     this.nullable = false,
     this.items,
+    this.example,
   });
 
-  factory SchemaField.string(String name, {String? description}) =>
-      SchemaField(name, 'string', description: description);
+  factory SchemaField.string(String name, {String? description, dynamic example}) =>
+      SchemaField(name, 'string', description: description, example: example);
 
-  factory SchemaField.integer(String name, {String? description}) =>
-      SchemaField(name, 'integer', description: description);
+  factory SchemaField.integer(String name, {String? description, dynamic example}) =>
+      SchemaField(name, 'integer', description: description, example: example);
 
-  factory SchemaField.number(String name, {String? description}) =>
-      SchemaField(name, 'number', description: description);
+  factory SchemaField.number(String name, {String? description, dynamic example}) =>
+      SchemaField(name, 'number', description: description, example: example);
 
-  factory SchemaField.boolean(String name, {String? description}) =>
-      SchemaField(name, 'boolean', description: description);
+  factory SchemaField.boolean(String name, {String? description, dynamic example}) =>
+      SchemaField(name, 'boolean', description: description, example: example);
 
   factory SchemaField.array(
     String name,
     SchemaField itemType, {
     String? description,
+    dynamic example,
   }) =>
-      SchemaField(name, 'array', description: description, items: itemType);
+      SchemaField(name, 'array', description: description, items: itemType, example: example);
 
   factory SchemaField.optional(SchemaField inner) => SchemaField(
         inner.name,
@@ -82,6 +85,7 @@ class SchemaField {
         required: false,
         nullable: true,
         items: inner.items,
+        example: inner.example,
       );
 }
 
@@ -89,6 +93,8 @@ class SchemaField {
 Map<String, dynamic> buildSchema(List<SchemaField> fields) {
   final properties = <String, Map<String, dynamic>>{};
   final required = <String>[];
+
+  final exampleValues = <String, dynamic>{};
 
   for (final field in fields) {
     final prop = <String, dynamic>{'type': field.type};
@@ -100,6 +106,10 @@ Map<String, dynamic> buildSchema(List<SchemaField> fields) {
     }
     if (field.items != null) {
       prop['items'] = {'type': field.items!.type};
+    }
+    if (field.example != null) {
+      prop['example'] = field.example;
+      exampleValues[field.name] = field.example;
     }
     properties[field.name] = prop;
 
@@ -114,6 +124,9 @@ Map<String, dynamic> buildSchema(List<SchemaField> fields) {
   };
   if (required.isNotEmpty) {
     schema['required'] = required;
+  }
+  if (exampleValues.isNotEmpty) {
+    schema['example'] = exampleValues;
   }
   return schema;
 }

--- a/dart/lib/src/core/schema/field.dart
+++ b/dart/lib/src/core/schema/field.dart
@@ -1,0 +1,118 @@
+/// Schema field metadata for automatic `toSchema()` generation.
+///
+/// Dart does not have runtime reflection for annotations.
+/// Instead of macros (experimental in Dart 3.5+), we use a declarative
+/// `schemaFields` getter on Input/Output that lists field metadata.
+/// The base class `Input.toSchema()` / `Output.toSchema()` builds the
+/// OpenAPI 3.0.3-compatible JSON Schema automatically from this list.
+///
+/// The `@Field` annotation is decorative — it documents the field's purpose
+/// and will be consumed by `@MacssSchema()` macro when macros stabilize.
+///
+/// ```dart
+/// class HelloInput extends Input {
+///   @Field(description: 'Name to greet')
+///   final String name;
+///
+///   HelloInput({required this.name});
+///
+///   @override
+///   List<SchemaField> get schemaFields => [
+///     SchemaField.string('name', description: 'Name to greet'),
+///   ];
+///   // toSchema() → auto-derived from schemaFields!
+/// }
+/// ```
+
+/// Decorative annotation for field metadata.
+///
+/// Used for documentation, IDE support, and future macro consumption.
+/// Does NOT affect runtime behavior in the current version.
+class Field {
+  final String? description;
+
+  const Field({this.description});
+}
+
+/// Metadata for a single schema field.
+///
+/// Used by [Input.toSchema] and [Output.toSchema] to build
+/// OpenAPI 3.0.3-compatible JSON Schemas automatically.
+class SchemaField {
+  final String name;
+  final String type;
+  final String? description;
+  final bool required;
+  final bool nullable;
+  final SchemaField? items;
+
+  const SchemaField(
+    this.name,
+    this.type, {
+    this.description,
+    this.required = true,
+    this.nullable = false,
+    this.items,
+  });
+
+  factory SchemaField.string(String name, {String? description}) =>
+      SchemaField(name, 'string', description: description);
+
+  factory SchemaField.integer(String name, {String? description}) =>
+      SchemaField(name, 'integer', description: description);
+
+  factory SchemaField.number(String name, {String? description}) =>
+      SchemaField(name, 'number', description: description);
+
+  factory SchemaField.boolean(String name, {String? description}) =>
+      SchemaField(name, 'boolean', description: description);
+
+  factory SchemaField.array(
+    String name,
+    SchemaField itemType, {
+    String? description,
+  }) =>
+      SchemaField(name, 'array', description: description, items: itemType);
+
+  factory SchemaField.optional(SchemaField inner) => SchemaField(
+        inner.name,
+        inner.type,
+        description: inner.description,
+        required: false,
+        nullable: true,
+        items: inner.items,
+      );
+}
+
+/// Builds an OpenAPI 3.0.3 JSON Schema from a list of [SchemaField] entries.
+Map<String, dynamic> buildSchema(List<SchemaField> fields) {
+  final properties = <String, Map<String, dynamic>>{};
+  final required = <String>[];
+
+  for (final field in fields) {
+    final prop = <String, dynamic>{'type': field.type};
+    if (field.description != null) {
+      prop['description'] = field.description;
+    }
+    if (field.nullable) {
+      prop['nullable'] = true;
+    }
+    if (field.items != null) {
+      prop['items'] = {'type': field.items!.type};
+    }
+    properties[field.name] = prop;
+
+    if (field.required) {
+      required.add(field.name);
+    }
+  }
+
+  final schema = <String, dynamic>{
+    'type': 'object',
+    'properties': properties,
+  };
+  if (required.isNotEmpty) {
+    schema['required'] = required;
+  }
+  return schema;
+}

--- a/dart/lib/src/core/usecase/usecase.dart
+++ b/dart/lib/src/core/usecase/usecase.dart
@@ -95,7 +95,7 @@ abstract class Input {
       return buildSchema(fields);
     }
     throw UnimplementedError(
-      '${runtimeType}.toSchema() not implemented. '
+      '$runtimeType.toSchema() not implemented. '
       'Override schemaFields or toSchema().',
     );
   }
@@ -123,7 +123,7 @@ abstract class Output {
       return buildSchema(fields);
     }
     throw UnimplementedError(
-      '${runtimeType}.toSchema() not implemented. '
+      '$runtimeType.toSchema() not implemented. '
       'Override schemaFields or toSchema().',
     );
   }

--- a/dart/lib/src/core/usecase/usecase.dart
+++ b/dart/lib/src/core/usecase/usecase.dart
@@ -1,4 +1,5 @@
 import 'package:modular_api/src/core/logger/logger.dart';
+import 'package:modular_api/src/core/schema/field.dart';
 
 /// **Contract** — use `implements UseCase<I, O>`.
 ///
@@ -48,31 +49,84 @@ abstract class UseCase<I extends Input, O extends Output> {
 
 /// **Contract** — use `implements Input`.
 ///
-/// Pure interface: all members must be provided by the implementor.
-/// No default behavior is inherited — every Input is self-contained.
+/// When a subclass provides [schemaFields], [toSchema] is derived
+/// automatically. Manual overrides still work (deprecated — will be
+/// removed in v0.5.0).
+///
+/// ```dart
+/// class HelloInput implements Input {
+///   @Field(description: 'Name to greet')
+///   final String name;
+///
+///   HelloInput({required this.name});
+///
+///   factory HelloInput.fromJson(Map<String, dynamic> json) =>
+///       HelloInput(name: (json['name'] ?? '').toString());
+///
+///   @override
+///   Map<String, dynamic> toJson() => {'name': name};
+///
+///   @override
+///   List<SchemaField> get schemaFields => [
+///     SchemaField.string('name', description: 'Name to greet'),
+///   ];
+/// }
+/// ```
 abstract class Input {
+  /// Generative constructor — enables `extends Input` for auto-schema.
+  Input();
+
   /// El contrato no impone fromJson;
   factory Input.fromJson(Map<String, dynamic> json) {
     throw UnimplementedError('Must implement fromJson');
   }
   Map<String, dynamic> toJson();
 
-  /// Schema
-  /// Required for OpenApi specification
-  Map<String, dynamic> toSchema();
+  /// Override to provide field metadata for automatic schema generation.
+  /// When provided, [toSchema] is derived automatically.
+  /// Returns `null` by default (legacy path — manual toSchema required).
+  List<SchemaField>? get schemaFields => null;
+
+  /// Schema — required for OpenAPI specification.
+  /// When [schemaFields] is provided, the schema is derived automatically.
+  Map<String, dynamic> toSchema() {
+    final fields = schemaFields;
+    if (fields != null) {
+      return buildSchema(fields);
+    }
+    throw UnimplementedError(
+      '${runtimeType}.toSchema() not implemented. '
+      'Override schemaFields or toSchema().',
+    );
+  }
 }
 
 /// **Contract** — use `implements Output`.
 ///
-/// Pure interface: all members must be provided by the implementor.
-/// The implementor must define `statusCode` explicitly — this forces
-/// developers to think about HTTP status codes for every response.
+/// When a subclass provides [schemaFields], [toSchema] is derived
+/// automatically. The implementor must define `statusCode` explicitly —
+/// this forces developers to think about HTTP status codes for every response.
 abstract class Output {
+  /// Generative constructor — enables `extends Output` for auto-schema.
+  Output();
+
   Map<String, dynamic> toJson();
 
-  /// Schema
-  /// Required for OpenApi specification
-  Map<String, dynamic> toSchema();
+  /// Override to provide field metadata for automatic schema generation.
+  List<SchemaField>? get schemaFields => null;
+
+  /// Schema — required for OpenAPI specification.
+  /// When [schemaFields] is provided, the schema is derived automatically.
+  Map<String, dynamic> toSchema() {
+    final fields = schemaFields;
+    if (fields != null) {
+      return buildSchema(fields);
+    }
+    throw UnimplementedError(
+      '${runtimeType}.toSchema() not implemented. '
+      'Override schemaFields or toSchema().',
+    );
+  }
 
   /// HTTP status code to return.
   /// Must be implemented explicitly (e.g. 200, 201, 400, 404).

--- a/dart/lib/src/core/usecase/usecase.dart
+++ b/dart/lib/src/core/usecase/usecase.dart
@@ -89,15 +89,14 @@ abstract class Input {
 
   /// Schema — required for OpenAPI specification.
   /// When [schemaFields] is provided, the schema is derived automatically.
+  /// Otherwise, infers types from [toJson] values (less detail, no descriptions).
   Map<String, dynamic> toSchema() {
     final fields = schemaFields;
     if (fields != null) {
       return buildSchema(fields);
     }
-    throw UnimplementedError(
-      '$runtimeType.toSchema() not implemented. '
-      'Override schemaFields or toSchema().',
-    );
+    // Fallback: infer schema from toJson() value types
+    return inferSchemaFromExample(toJson());
   }
 }
 
@@ -117,15 +116,14 @@ abstract class Output {
 
   /// Schema — required for OpenAPI specification.
   /// When [schemaFields] is provided, the schema is derived automatically.
+  /// Otherwise, infers types from [toJson] values (less detail, no descriptions).
   Map<String, dynamic> toSchema() {
     final fields = schemaFields;
     if (fields != null) {
       return buildSchema(fields);
     }
-    throw UnimplementedError(
-      '$runtimeType.toSchema() not implemented. '
-      'Override schemaFields or toSchema().',
-    );
+    // Fallback: infer schema from toJson() value types
+    return inferSchemaFromExample(toJson());
   }
 
   /// HTTP status code to return.

--- a/dart/lib/src/core/usecase/usecase_http_handler.dart
+++ b/dart/lib/src/core/usecase/usecase_http_handler.dart
@@ -5,6 +5,7 @@ import 'package:shelf_router/shelf_router.dart';
 
 import '../logger/logger.dart';
 import '../logger/logging_middleware.dart';
+import '../schema/field.dart';
 import 'usecase.dart';
 import 'use_case_exception.dart';
 
@@ -50,6 +51,12 @@ Handler useCaseHttpHandler(UseCase Function(Map<String, dynamic>) fromJson) {
         e.statusCode,
         headers: jsonHeaders,
         body: jsonEncode(e.toJson()),
+      );
+    } on InputValidationException catch (e) {
+      return Response(
+        400,
+        headers: jsonHeaders,
+        body: jsonEncode({'error': e.message}),
       );
     } catch (e) {
       // Handle unexpected errors

--- a/dart/lib/src/core/usecase/usecase_http_handler.dart
+++ b/dart/lib/src/core/usecase/usecase_http_handler.dart
@@ -22,6 +22,14 @@ Handler useCaseHttpHandler(UseCase Function(Map<String, dynamic>) fromJson) {
 
       // 2. Build and validate the UseCase
       final useCase = fromJson(data);
+
+      // 2a. Auto-validate raw JSON against schemaFields on the Input DTO.
+      // Runs after fromJson (which may coerce) — validates the ORIGINAL payload.
+      final inputFields = useCase.input.schemaFields;
+      if (inputFields != null) {
+        validateJsonFields(data, inputFields);
+      }
+
       final validationError = useCase.validate();
       if (validationError != null) {
         return Response(

--- a/dart/lib/src/core/usecase/usecase_http_handler.dart
+++ b/dart/lib/src/core/usecase/usecase_http_handler.dart
@@ -10,8 +10,15 @@ import 'usecase.dart';
 import 'use_case_exception.dart';
 
 /// Generic handler for any UseCase
-Handler useCaseHttpHandler(UseCase Function(Map<String, dynamic>) fromJson) {
+Handler useCaseHttpHandler(
+  UseCase Function(Map<String, dynamic>) fromJson, {
+  Input? inputExample,
+}) {
   const jsonHeaders = {'content-type': 'application/json; charset=utf-8'};
+
+  // Capture schema at creation time — enables pre-validation
+  // before fromJson, so strict factories never crash.
+  final preValidationFields = inputExample?.schemaFields;
 
   return (Request req) async {
     try {
@@ -20,14 +27,20 @@ Handler useCaseHttpHandler(UseCase Function(Map<String, dynamic>) fromJson) {
           ? await _jsonFromUrl(req)
           : await _jsonFromBody(req);
 
-      // 2. Build and validate the UseCase
+      // 2. Pre-validate BEFORE fromJson (when example provides schema)
+      if (preValidationFields != null) {
+        validateJsonFields(data, preValidationFields);
+      }
+
+      // 3. Build and validate the UseCase
       final useCase = fromJson(data);
 
-      // 2a. Auto-validate raw JSON against schemaFields on the Input DTO.
-      // Runs after fromJson (which may coerce) — validates the ORIGINAL payload.
-      final inputFields = useCase.input.schemaFields;
-      if (inputFields != null) {
-        validateJsonFields(data, inputFields);
+      // 3a. Post-validate for legacy path (no inputExample)
+      if (preValidationFields == null) {
+        final inputFields = useCase.input.schemaFields;
+        if (inputFields != null) {
+          validateJsonFields(data, inputFields);
+        }
       }
 
       final validationError = useCase.validate();

--- a/dart/lib/src/openapi/openapi.dart
+++ b/dart/lib/src/openapi/openapi.dart
@@ -246,34 +246,47 @@ class OpenApi {
     return const JsonEncoder.withIndent('  ').convert(spec);
   }
 
-  /// Attempts to construct the UseCase with {} and read input.toSchema()
-  /// Requires fromJson to be tolerant (not throw).
+  /// Extracts the input schema, preferring the registered example instance.
+  ///
+  /// When [inputExample] is provided, the schema is built from the example
+  /// (via schemaFields or type inference) and `schema['example']` is set to
+  /// the example's serialized JSON. No `factory({})` call needed.
+  /// Falls back to `factory({})` when no example is registered.
   static Map<String, dynamic> _inferInputSchema(UseCaseRegistration r) {
+    if (r.inputExample != null) {
+      final schema = r.inputExample!.toSchema();
+      if (schema['type'] == null) schema['type'] = 'object';
+      final exampleJson = r.inputExample!.toJson();
+      if (exampleJson.isNotEmpty) schema['example'] = exampleJson;
+      return schema;
+    }
+
     try {
       final uc = r.factory(<String, dynamic>{});
       final schema = uc.input.toSchema();
-      // Sanitize: ensure at least 'type: object'
-      if (schema['type'] == null) {
-        schema['type'] = 'object';
-      }
+      if (schema['type'] == null) schema['type'] = 'object';
       return schema;
     } catch (_) {
-      // Fallback si fromJson lanza
       return {'type': 'object', 'properties': {}};
     }
   }
 
+  /// Extracts the output schema, preferring the registered example instance.
   static Map<String, dynamic> _inferOutputSchema(UseCaseRegistration r) {
+    if (r.outputExample != null) {
+      final schema = r.outputExample!.toSchema();
+      if (schema['type'] == null) schema['type'] = 'object';
+      final exampleJson = r.outputExample!.toJson();
+      if (exampleJson.isNotEmpty) schema['example'] = exampleJson;
+      return schema;
+    }
+
     try {
       final uc = r.factory(<String, dynamic>{});
       final schema = uc.output.toSchema();
-      // Sanitize: ensure at least 'type: object'
-      if (schema['type'] == null) {
-        schema['type'] = 'object';
-      }
+      if (schema['type'] == null) schema['type'] = 'object';
       return schema;
     } catch (_) {
-      // Fallback if fromJson throws
       return {'type': 'object', 'properties': {}};
     }
   }

--- a/dart/lib/src/openapi/openapi.dart
+++ b/dart/lib/src/openapi/openapi.dart
@@ -1,6 +1,7 @@
 // lib/src/swagger/swagger.dart
 import 'dart:convert';
 import 'package:modular_api/src/core/modular_api.dart';
+import 'package:modular_api/src/core/schema/field.dart';
 import 'package:shelf/shelf.dart';
 
 class OpenApi {
@@ -246,34 +247,49 @@ class OpenApi {
     return const JsonEncoder.withIndent('  ').convert(spec);
   }
 
-  /// Attempts to construct the UseCase with {} and read input.toSchema()
-  /// Requires fromJson to be tolerant (not throw).
+  /// Extracts the Input schema for OpenAPI generation.
+  ///
+  /// Strategy (in order of preference):
+  /// 1. Pre-registered [SchemaField] list — no instantiation needed.
+  ///    Required when `fromJson` validates input (the recommended pattern).
+  /// 2. Fallback: call `factory({})` and read `input.toSchema()` (legacy).
   static Map<String, dynamic> _inferInputSchema(UseCaseRegistration r) {
+    // Strategy 1: pre-registered schema fields — zero instantiation
+    if (r.inputFields != null && r.inputFields!.isNotEmpty) {
+      return buildSchema(r.inputFields!);
+    }
+
+    // Strategy 2: factory({}) fallback for backward compatibility
     try {
       final uc = r.factory(<String, dynamic>{});
       final schema = uc.input.toSchema();
-      // Sanitize: ensure at least 'type: object'
       if (schema['type'] == null) {
         schema['type'] = 'object';
       }
       return schema;
     } catch (_) {
-      // Fallback si fromJson lanza
       return {'type': 'object', 'properties': {}};
     }
   }
 
+  /// Extracts the Output schema for OpenAPI generation.
+  ///
+  /// Same dual strategy as [_inferInputSchema].
   static Map<String, dynamic> _inferOutputSchema(UseCaseRegistration r) {
+    // Strategy 1: pre-registered schema fields — zero instantiation
+    if (r.outputFields != null && r.outputFields!.isNotEmpty) {
+      return buildSchema(r.outputFields!);
+    }
+
+    // Strategy 2: factory({}) fallback for backward compatibility
     try {
       final uc = r.factory(<String, dynamic>{});
       final schema = uc.output.toSchema();
-      // Sanitize: ensure at least 'type: object'
       if (schema['type'] == null) {
         schema['type'] = 'object';
       }
       return schema;
     } catch (_) {
-      // Fallback if fromJson throws
       return {'type': 'object', 'properties': {}};
     }
   }

--- a/dart/lib/src/openapi/openapi.dart
+++ b/dart/lib/src/openapi/openapi.dart
@@ -1,7 +1,6 @@
 // lib/src/swagger/swagger.dart
 import 'dart:convert';
 import 'package:modular_api/src/core/modular_api.dart';
-import 'package:modular_api/src/core/schema/field.dart';
 import 'package:shelf/shelf.dart';
 
 class OpenApi {
@@ -247,49 +246,34 @@ class OpenApi {
     return const JsonEncoder.withIndent('  ').convert(spec);
   }
 
-  /// Extracts the Input schema for OpenAPI generation.
-  ///
-  /// Strategy (in order of preference):
-  /// 1. Pre-registered [SchemaField] list — no instantiation needed.
-  ///    Required when `fromJson` validates input (the recommended pattern).
-  /// 2. Fallback: call `factory({})` and read `input.toSchema()` (legacy).
+  /// Attempts to construct the UseCase with {} and read input.toSchema()
+  /// Requires fromJson to be tolerant (not throw).
   static Map<String, dynamic> _inferInputSchema(UseCaseRegistration r) {
-    // Strategy 1: pre-registered schema fields — zero instantiation
-    if (r.inputFields != null && r.inputFields!.isNotEmpty) {
-      return buildSchema(r.inputFields!);
-    }
-
-    // Strategy 2: factory({}) fallback for backward compatibility
     try {
       final uc = r.factory(<String, dynamic>{});
       final schema = uc.input.toSchema();
+      // Sanitize: ensure at least 'type: object'
       if (schema['type'] == null) {
         schema['type'] = 'object';
       }
       return schema;
     } catch (_) {
+      // Fallback si fromJson lanza
       return {'type': 'object', 'properties': {}};
     }
   }
 
-  /// Extracts the Output schema for OpenAPI generation.
-  ///
-  /// Same dual strategy as [_inferInputSchema].
   static Map<String, dynamic> _inferOutputSchema(UseCaseRegistration r) {
-    // Strategy 1: pre-registered schema fields — zero instantiation
-    if (r.outputFields != null && r.outputFields!.isNotEmpty) {
-      return buildSchema(r.outputFields!);
-    }
-
-    // Strategy 2: factory({}) fallback for backward compatibility
     try {
       final uc = r.factory(<String, dynamic>{});
       final schema = uc.output.toSchema();
+      // Sanitize: ensure at least 'type: object'
       if (schema['type'] == null) {
         schema['type'] = 'object';
       }
       return schema;
     } catch (_) {
+      // Fallback if fromJson throws
       return {'type': 'object', 'properties': {}};
     }
   }

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: modular_api
 description: Use-case centric API toolkit for Dart — Shelf UseCase base class, HTTP adapters, CORS middleware, and automatic OpenAPI documentation.
-version: 0.4.1
+version: 0.4.2
 
 repository: https://github.com/macss-dev/modular_api/tree/main/dart
 homepage: https://github.com/macss-dev/modular_api

--- a/dart/test/fromjson_validation_test.dart
+++ b/dart/test/fromjson_validation_test.dart
@@ -53,7 +53,8 @@ void main() {
 
     test('throws for wrong type — string where integer expected', () {
       expect(
-        () => validateJsonFields({'name': 'Alice', 'age': 'twenty-five'}, fields),
+        () =>
+            validateJsonFields({'name': 'Alice', 'age': 'twenty-five'}, fields),
         throwsA(isA<InputValidationException>().having(
           (e) => e.message,
           'message',

--- a/dart/test/fromjson_validation_test.dart
+++ b/dart/test/fromjson_validation_test.dart
@@ -1,0 +1,83 @@
+/// RED — fromJson must validate required fields and types, returning 400.
+///
+/// fromJson validates structure (field presence + JSON type correctness).
+/// validate() handles only business rules.
+///
+/// Error message contract (identical across all 3 SDKs for parity):
+///   - Missing required field: "Missing required field: {name}"
+///   - Wrong JSON type:        "Field '{name}' must be of type {type}"
+library;
+
+import 'package:modular_api/modular_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('validateJsonFields', () {
+    final fields = [
+      SchemaField.string('name', description: 'Name'),
+      SchemaField.integer('age', description: 'Age'),
+    ];
+
+    test('throws InputValidationException for missing required field', () {
+      expect(
+        () => validateJsonFields({}, fields),
+        throwsA(isA<InputValidationException>().having(
+          (e) => e.message,
+          'message',
+          'Missing required field: name',
+        )),
+      );
+    });
+
+    test('throws InputValidationException for null required field', () {
+      expect(
+        () => validateJsonFields({'name': null, 'age': 25}, fields),
+        throwsA(isA<InputValidationException>().having(
+          (e) => e.message,
+          'message',
+          'Missing required field: name',
+        )),
+      );
+    });
+
+    test('throws for wrong type — int where string expected', () {
+      expect(
+        () => validateJsonFields({'name': 123, 'age': 25}, fields),
+        throwsA(isA<InputValidationException>().having(
+          (e) => e.message,
+          'message',
+          "Field 'name' must be of type string",
+        )),
+      );
+    });
+
+    test('throws for wrong type — string where integer expected', () {
+      expect(
+        () => validateJsonFields({'name': 'Alice', 'age': 'twenty-five'}, fields),
+        throwsA(isA<InputValidationException>().having(
+          (e) => e.message,
+          'message',
+          "Field 'age' must be of type integer",
+        )),
+      );
+    });
+
+    test('does not throw for valid JSON', () {
+      expect(
+        () => validateJsonFields({'name': 'Alice', 'age': 25}, fields),
+        returnsNormally,
+      );
+    });
+
+    test('skips validation for optional fields', () {
+      final fieldsWithOptional = [
+        SchemaField.string('name', description: 'Name'),
+        SchemaField.optional(SchemaField.integer('age', description: 'Age')),
+      ];
+      expect(
+        () => validateJsonFields({'name': 'Alice'}, fieldsWithOptional),
+        returnsNormally,
+      );
+    });
+  });
+}

--- a/dart/test/handler/handler_pre_validation_test.dart
+++ b/dart/test/handler/handler_pre_validation_test.dart
@@ -1,0 +1,289 @@
+import 'dart:convert';
+import 'package:test/test.dart';
+import 'package:shelf/shelf.dart';
+import 'package:modular_api/src/core/schema/field.dart';
+import 'package:modular_api/src/core/logger/logger.dart';
+import 'package:modular_api/src/core/usecase/usecase.dart';
+import 'package:modular_api/src/core/usecase/usecase_http_handler.dart';
+
+// ── Strict UseCase: fromJson THROWS on missing/wrong types ──
+
+class StrictInput extends Input {
+  final String name;
+  final int age;
+  final double score;
+  final bool active;
+  final List<String> tags;
+
+  StrictInput({
+    required this.name,
+    required this.age,
+    required this.score,
+    required this.active,
+    required this.tags,
+  });
+
+  /// Strict factory — no coercion, no defaults.
+  /// Will throw if fields are missing or wrong type.
+  factory StrictInput.fromJson(Map<String, dynamic> json) {
+    return StrictInput(
+      name: json['name'] as String,
+      age: json['age'] as int,
+      score: json['score'] as double,
+      active: json['active'] as bool,
+      tags: (json['tags'] as List).cast<String>(),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'age': age,
+        'score': score,
+        'active': active,
+        'tags': tags,
+      };
+
+  @override
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('name', example: 'Alice'),
+        SchemaField.integer('age', example: 30),
+        SchemaField.number('score', example: 9.5),
+        SchemaField.boolean('active', example: true),
+        SchemaField.array('tags', SchemaField.string('item'), example: ['dart']),
+      ];
+
+  static StrictInput get example => StrictInput(
+        name: 'Alice',
+        age: 30,
+        score: 9.5,
+        active: true,
+        tags: ['dart'],
+      );
+}
+
+class StrictOutput extends Output {
+  final String greeting;
+
+  StrictOutput({required this.greeting});
+
+  @override
+  int get statusCode => 200;
+
+  @override
+  Map<String, dynamic> toJson() => {'greeting': greeting};
+
+  @override
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('greeting', example: 'Hello Alice'),
+      ];
+}
+
+class StrictUseCase implements UseCase<StrictInput, StrictOutput> {
+  @override
+  final StrictInput input;
+
+  @override
+  late StrictOutput output;
+
+  @override
+  ModularLogger? logger;
+
+  StrictUseCase({required this.input});
+
+  factory StrictUseCase.fromJson(Map<String, dynamic> json) {
+    return StrictUseCase(input: StrictInput.fromJson(json));
+  }
+
+  @override
+  String? validate() => null;
+
+  @override
+  Future<void> execute() async {
+    output = StrictOutput(greeting: 'Hello ${input.name}');
+  }
+
+  @override
+  Map<String, dynamic> toJson() => output.toJson();
+}
+
+// ── Helpers ──
+
+Request _postRequest(Map<String, dynamic> body) {
+  return Request(
+    'POST',
+    Uri.parse('http://localhost/test'),
+    body: jsonEncode(body),
+    headers: {'content-type': 'application/json'},
+  );
+}
+
+void main() {
+  group('Handler pre-validation with inputExample', () {
+    late Handler handler;
+
+    setUp(() {
+      handler = useCaseHttpHandler(
+        StrictUseCase.fromJson,
+        inputExample: StrictInput.example,
+      );
+    });
+
+    // ── Missing required fields ──
+
+    test('returns 400 when required field is missing', () async {
+      final res = await handler(_postRequest({
+        // 'name' is missing
+        'age': 30,
+        'score': 9.5,
+        'active': true,
+        'tags': ['dart'],
+      }));
+
+      expect(res.statusCode, equals(400));
+      final body = jsonDecode(await res.readAsString());
+      expect(body['error'], contains('Missing required field: name'));
+    });
+
+    // ── Wrong types ──
+
+    test('returns 400 when string field receives int', () async {
+      final res = await handler(_postRequest({
+        'name': 123, // should be String
+        'age': 30,
+        'score': 9.5,
+        'active': true,
+        'tags': ['dart'],
+      }));
+
+      expect(res.statusCode, equals(400));
+      final body = jsonDecode(await res.readAsString());
+      expect(body['error'], contains("Field 'name' must be of type string"));
+    });
+
+    test('returns 400 when integer field receives string', () async {
+      final res = await handler(_postRequest({
+        'name': 'Alice',
+        'age': 'thirty', // should be int
+        'score': 9.5,
+        'active': true,
+        'tags': ['dart'],
+      }));
+
+      expect(res.statusCode, equals(400));
+      final body = jsonDecode(await res.readAsString());
+      expect(body['error'], contains("Field 'age' must be of type integer"));
+    });
+
+    test('returns 400 when number field receives string', () async {
+      final res = await handler(_postRequest({
+        'name': 'Alice',
+        'age': 30,
+        'score': 'high', // should be double/num
+        'active': true,
+        'tags': ['dart'],
+      }));
+
+      expect(res.statusCode, equals(400));
+      final body = jsonDecode(await res.readAsString());
+      expect(body['error'], contains("Field 'score' must be of type number"));
+    });
+
+    test('returns 400 when boolean field receives string', () async {
+      final res = await handler(_postRequest({
+        'name': 'Alice',
+        'age': 30,
+        'score': 9.5,
+        'active': 'yes', // should be bool
+        'tags': ['dart'],
+      }));
+
+      expect(res.statusCode, equals(400));
+      final body = jsonDecode(await res.readAsString());
+      expect(body['error'], contains("Field 'active' must be of type boolean"));
+    });
+
+    test('returns 400 when array field receives string', () async {
+      final res = await handler(_postRequest({
+        'name': 'Alice',
+        'age': 30,
+        'score': 9.5,
+        'active': true,
+        'tags': 'dart', // should be List
+      }));
+
+      expect(res.statusCode, equals(400));
+      final body = jsonDecode(await res.readAsString());
+      expect(body['error'], contains("Field 'tags' must be of type array"));
+    });
+
+    // ── Valid data → success ──
+
+    test('returns 200 with valid data (strict fromJson works)', () async {
+      final res = await handler(_postRequest({
+        'name': 'Alice',
+        'age': 30,
+        'score': 9.5,
+        'active': true,
+        'tags': ['dart'],
+      }));
+
+      expect(res.statusCode, equals(200));
+      final body = jsonDecode(await res.readAsString());
+      expect(body['greeting'], equals('Hello Alice'));
+    });
+
+    // ── Pre-validation protects strict fromJson ──
+
+    test('pre-validates BEFORE fromJson — strict factory never crashes', () async {
+      // Without pre-validation, this would crash in StrictInput.fromJson
+      // because 'age' is a String, not int → `as int` would throw TypeError.
+      // With pre-validation, handler returns 400 cleanly.
+      final res = await handler(_postRequest({
+        'name': 'Alice',
+        'age': 'not-a-number',
+        'score': 9.5,
+        'active': true,
+        'tags': ['dart'],
+      }));
+
+      expect(res.statusCode, equals(400));
+      // Must NOT be 500 (which would mean fromJson crashed)
+      final body = jsonDecode(await res.readAsString());
+      expect(body['error'], isNot(contains('Internal server error')));
+    });
+
+    // ── Empty body → first missing field ──
+
+    test('returns 400 on empty body (first missing field)', () async {
+      final res = await handler(_postRequest({}));
+
+      expect(res.statusCode, equals(400));
+      final body = jsonDecode(await res.readAsString());
+      expect(body['error'], contains('Missing required field'));
+    });
+  });
+
+  group('Handler backward-compat — no inputExample', () {
+    late Handler handler;
+
+    setUp(() {
+      // No inputExample — old behavior (post-validation)
+      handler = useCaseHttpHandler(StrictUseCase.fromJson);
+    });
+
+    test('without inputExample, strict fromJson crashes yield 500', () async {
+      // Without pre-validation, wrong types cause TypeError in fromJson → 500
+      final res = await handler(_postRequest({
+        'name': 123, // wrong type → as String throws
+        'age': 30,
+        'score': 9.5,
+        'active': true,
+        'tags': ['dart'],
+      }));
+
+      // 500 because fromJson crashes before validation can run
+      expect(res.statusCode, equals(500));
+    });
+  });
+}

--- a/dart/test/handler/handler_pre_validation_test.dart
+++ b/dart/test/handler/handler_pre_validation_test.dart
@@ -50,7 +50,8 @@ class StrictInput extends Input {
         SchemaField.integer('age', example: 30),
         SchemaField.number('score', example: 9.5),
         SchemaField.boolean('active', example: true),
-        SchemaField.array('tags', SchemaField.string('item'), example: ['dart']),
+        SchemaField.array('tags', SchemaField.string('item'),
+            example: ['dart']),
       ];
 
   static StrictInput get example => StrictInput(
@@ -235,7 +236,8 @@ void main() {
 
     // ── Pre-validation protects strict fromJson ──
 
-    test('pre-validates BEFORE fromJson — strict factory never crashes', () async {
+    test('pre-validates BEFORE fromJson — strict factory never crashes',
+        () async {
       // Without pre-validation, this would crash in StrictInput.fromJson
       // because 'age' is a String, not int → `as int` would throw TypeError.
       // With pre-validation, handler returns 400 cleanly.

--- a/dart/test/logger/logging_integration_test.dart
+++ b/dart/test/logger/logging_integration_test.dart
@@ -7,7 +7,7 @@ import 'package:modular_api/src/core/logger/logger.dart';
 
 // ─── Fixtures ──────────────────────────────────────────────────────
 
-class EchoInput implements Input {
+class EchoInput extends Input {
   final String value;
   EchoInput({required this.value});
 
@@ -26,7 +26,7 @@ class EchoInput implements Input {
       };
 }
 
-class EchoOutput implements Output {
+class EchoOutput extends Output {
   final String echo;
   EchoOutput({required this.echo});
 

--- a/dart/test/metrics/metrics_integration_test.dart
+++ b/dart/test/metrics/metrics_integration_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart';
 
 // ── Minimal UseCase for integration tests ────────────────────────────────
 
-class _PingInput implements Input {
+class _PingInput extends Input {
   _PingInput();
   factory _PingInput.fromJson(Map<String, dynamic> json) => _PingInput();
   @override
@@ -16,7 +16,7 @@ class _PingInput implements Input {
   Map<String, dynamic> toSchema() => {'type': 'object', 'properties': {}};
 }
 
-class _PingOutput implements Output {
+class _PingOutput extends Output {
   _PingOutput();
   @override
   Map<String, dynamic> toJson() => {'pong': true};

--- a/dart/test/openapi/openapi_example_test.dart
+++ b/dart/test/openapi/openapi_example_test.dart
@@ -1,0 +1,203 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:http/http.dart' as http;
+import 'package:modular_api/modular_api.dart';
+import 'package:modular_api/src/core/modular_api.dart' show apiRegistry;
+import 'package:test/test.dart';
+
+// ── UseCase with examples (strict fromJson — no coercion) ────────────────
+
+class _GreetInput extends Input {
+  @Field(description: 'Name to greet')
+  final String name;
+  final int age;
+  final double score;
+  final bool active;
+  final List<String> tags;
+
+  _GreetInput({
+    required this.name,
+    required this.age,
+    required this.score,
+    required this.active,
+    required this.tags,
+  });
+
+  static final example = _GreetInput(
+    name: 'Sebastián',
+    age: 25,
+    score: 95.5,
+    active: true,
+    tags: ['dev', 'dart'],
+  );
+
+  factory _GreetInput.fromJson(Map<String, dynamic> json) => _GreetInput(
+        name: json['name'],
+        age: json['age'],
+        score: (json['score'] as num).toDouble(),
+        active: json['active'],
+        tags: (json['tags'] as List).cast<String>(),
+      );
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'age': age,
+        'score': score,
+        'active': active,
+        'tags': tags,
+      };
+
+  @override
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('name',
+            description: 'Name to greet', example: 'Sebastián'),
+        SchemaField.integer('age', example: 25),
+        SchemaField.number('score', example: 95.5),
+        SchemaField.boolean('active', example: true),
+        SchemaField.array('tags', SchemaField.string(''),
+            example: ['dev', 'dart']),
+      ];
+}
+
+class _GreetOutput extends Output {
+  final String message;
+
+  _GreetOutput({this.message = ''});
+
+  static final example = _GreetOutput(message: 'Hello, Sebastián!');
+
+  factory _GreetOutput.fromJson(Map<String, dynamic> json) =>
+      _GreetOutput(message: json['message']);
+
+  @override
+  int get statusCode => 200;
+
+  @override
+  Map<String, dynamic> toJson() => {'message': message};
+
+  @override
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('message',
+            description: 'Greeting message', example: 'Hello, Sebastián!'),
+      ];
+}
+
+class _GreetUseCase implements UseCase<_GreetInput, _GreetOutput> {
+  @override
+  final _GreetInput input;
+  @override
+  late _GreetOutput output;
+  @override
+  ModularLogger? logger;
+
+  _GreetUseCase({required this.input}) {
+    output = _GreetOutput();
+  }
+
+  static _GreetUseCase fromJson(Map<String, dynamic> json) =>
+      _GreetUseCase(input: _GreetInput.fromJson(json));
+
+  @override
+  String? validate() => null;
+
+  @override
+  Future<void> execute() async {
+    output = _GreetOutput(message: 'Hello, ${input.name}!');
+  }
+
+  @override
+  Map<String, dynamic> toJson() => output.toJson();
+}
+
+void main() {
+  group('ModuleBuilder.usecase with inputExample / outputExample', () {
+    late HttpServer server;
+    late int port;
+
+    setUp(() async {
+      apiRegistry.routes.clear();
+
+      final api = ModularApi(
+        basePath: '/api',
+        title: 'Example API',
+        version: '1.0.0',
+      );
+
+      api.module('greetings', (m) {
+        m.usecase(
+          'hello',
+          _GreetUseCase.fromJson,
+          inputExample: _GreetInput.example,
+          outputExample: _GreetOutput.example,
+        );
+      });
+
+      server = await api.serve(port: 0);
+      port = server.port;
+    });
+
+    tearDown(() async {
+      await server.close(force: true);
+      apiRegistry.routes.clear();
+    });
+
+    test('OpenAPI spec contains example on input schema', () async {
+      final resp =
+          await http.get(Uri.parse('http://localhost:$port/openapi.json'));
+      final spec = jsonDecode(resp.body) as Map<String, dynamic>;
+      final schemas = (spec['components'] as Map)['schemas'] as Map;
+      final inputSchema = schemas['greetings_hello_Input'] as Map;
+
+      expect(inputSchema['example'], {
+        'name': 'Sebastián',
+        'age': 25,
+        'score': 95.5,
+        'active': true,
+        'tags': ['dev', 'dart'],
+      });
+    });
+
+    test('OpenAPI spec contains example on output schema', () async {
+      final resp =
+          await http.get(Uri.parse('http://localhost:$port/openapi.json'));
+      final spec = jsonDecode(resp.body) as Map<String, dynamic>;
+      final schemas = (spec['components'] as Map)['schemas'] as Map;
+      final outputSchema = schemas['greetings_hello_Output'] as Map;
+
+      expect(outputSchema['example'], {
+        'message': 'Hello, Sebastián!',
+      });
+    });
+
+    test('OpenAPI schema has correct types for all fields', () async {
+      final resp =
+          await http.get(Uri.parse('http://localhost:$port/openapi.json'));
+      final spec = jsonDecode(resp.body) as Map<String, dynamic>;
+      final schemas = (spec['components'] as Map)['schemas'] as Map;
+      final props =
+          (schemas['greetings_hello_Input'] as Map)['properties'] as Map;
+
+      expect(props['name']['type'], 'string');
+      expect(props['age']['type'], 'integer');
+      expect(props['score']['type'], 'number');
+      expect(props['active']['type'], 'boolean');
+      expect(props['tags']['type'], 'array');
+      expect(props['tags']['items'], {'type': 'string'});
+    });
+
+    test('schema extraction uses example not factory({})', () async {
+      // _GreetInput.fromJson is STRICT (no ?? coercion).
+      // If OpenAPI tried factory({}) it would throw TypeError.
+      // Test passing proves schema came from the example instance.
+      final resp =
+          await http.get(Uri.parse('http://localhost:$port/openapi.json'));
+      final spec = jsonDecode(resp.body) as Map<String, dynamic>;
+      final schemas = (spec['components'] as Map)['schemas'] as Map;
+
+      final inputSchema = schemas['greetings_hello_Input'] as Map;
+      expect(inputSchema['properties'], isNotEmpty);
+      expect(inputSchema['required'], isNotEmpty);
+    });
+  });
+}

--- a/dart/test/openapi/openapi_example_test.dart
+++ b/dart/test/openapi/openapi_example_test.dart
@@ -67,9 +67,6 @@ class _GreetOutput extends Output {
 
   static final example = _GreetOutput(message: 'Hello, Sebastián!');
 
-  factory _GreetOutput.fromJson(Map<String, dynamic> json) =>
-      _GreetOutput(message: json['message']);
-
   @override
   int get statusCode => 200;
 

--- a/dart/test/openapi/openapi_spec_test.dart
+++ b/dart/test/openapi/openapi_spec_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart';
 
 // ── Minimal UseCase for integration tests ────────────────────────────────
 
-class _PingInput implements Input {
+class _PingInput extends Input {
   _PingInput();
   factory _PingInput.fromJson(Map<String, dynamic> json) => _PingInput();
   @override
@@ -19,7 +19,7 @@ class _PingInput implements Input {
       };
 }
 
-class _PingOutput implements Output {
+class _PingOutput extends Output {
   _PingOutput();
   @override
   Map<String, dynamic> toJson() => {'pong': true};

--- a/dart/test/openapi/swagger_docs_test.dart
+++ b/dart/test/openapi/swagger_docs_test.dart
@@ -87,7 +87,8 @@ void main() {
       expect(resp.body, contains('--bg-primary'));
     });
 
-    test('preserves HTTP method accent colors in dark mode (PRD-004)', () async {
+    test('preserves HTTP method accent colors in dark mode (PRD-004)',
+        () async {
       final resp = await http.get(Uri.parse('http://localhost:$port/docs'));
       expect(resp.body, contains('#49cc90'));
     });

--- a/dart/test/schema/auto_schema_test.dart
+++ b/dart/test/schema/auto_schema_test.dart
@@ -125,8 +125,8 @@ void main() {
         SchemaField.optional(SchemaField.string('nick')),
       ]);
       expect(schema['required'], ['name']);
-      expect(
-          (schema['properties'] as Map)['nick'], {'type': 'string', 'nullable': true});
+      expect((schema['properties'] as Map)['nick'],
+          {'type': 'string', 'nullable': true});
     });
   });
 
@@ -146,13 +146,11 @@ void main() {
       final input = OptionalInput(name: 'Carlos');
       final schema = input.toSchema();
       expect(schema['required'], ['name']);
-      expect(
-          (schema['properties'] as Map)['nickname'],
-          {
-            'type': 'string',
-            'description': 'Optional nickname',
-            'nullable': true,
-          });
+      expect((schema['properties'] as Map)['nickname'], {
+        'type': 'string',
+        'description': 'Optional nickname',
+        'nullable': true,
+      });
     });
   });
 

--- a/dart/test/schema/auto_schema_test.dart
+++ b/dart/test/schema/auto_schema_test.dart
@@ -1,0 +1,176 @@
+import 'package:test/test.dart';
+import 'package:modular_api/src/core/schema/field.dart';
+import 'package:modular_api/src/core/usecase/usecase.dart';
+
+// ── Test DTOs with schemaFields ──────────────────────────────
+
+class NameInput extends Input {
+  @Field(description: 'Name to greet')
+  final String name;
+
+  NameInput({required this.name});
+
+  factory NameInput.fromJson(Map<String, dynamic> json) =>
+      NameInput(name: (json['name'] ?? '').toString());
+
+  @override
+  Map<String, dynamic> toJson() => {'name': name};
+
+  @override
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('name', description: 'Name to greet'),
+      ];
+}
+
+class GreetOutput extends Output {
+  @Field(description: 'Greeting message')
+  final String message;
+
+  GreetOutput({this.message = ''});
+
+  @override
+  int get statusCode => 200;
+
+  @override
+  Map<String, dynamic> toJson() => {'message': message};
+
+  @override
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('message', description: 'Greeting message'),
+      ];
+}
+
+class OptionalInput extends Input {
+  @Field(description: 'Required name')
+  final String name;
+
+  @Field(description: 'Optional nickname')
+  final String? nickname;
+
+  OptionalInput({required this.name, this.nickname});
+
+  factory OptionalInput.fromJson(Map<String, dynamic> json) => OptionalInput(
+        name: (json['name'] ?? '').toString(),
+        nickname: json['nickname']?.toString(),
+      );
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        if (nickname != null) 'nickname': nickname,
+      };
+
+  @override
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('name', description: 'Required name'),
+        SchemaField.optional(
+            SchemaField.string('nickname', description: 'Optional nickname')),
+      ];
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+void main() {
+  group('SchemaField metadata', () {
+    test('SchemaField.string() creates correct metadata', () {
+      final field = SchemaField.string('name', description: 'test');
+      expect(field.name, 'name');
+      expect(field.type, 'string');
+      expect(field.description, 'test');
+      expect(field.required, true);
+      expect(field.nullable, false);
+    });
+
+    test('SchemaField.integer() creates correct metadata', () {
+      final field = SchemaField.integer('age', description: 'user age');
+      expect(field.type, 'integer');
+    });
+
+    test('SchemaField.optional() marks field as not required and nullable', () {
+      final field =
+          SchemaField.optional(SchemaField.string('nick', description: 'opt'));
+      expect(field.required, false);
+      expect(field.nullable, true);
+      expect(field.description, 'opt');
+    });
+
+    test('SchemaField.array() stores items type', () {
+      final field = SchemaField.array(
+        'tags',
+        SchemaField.string('_item'),
+        description: 'list of tags',
+      );
+      expect(field.type, 'array');
+      expect(field.items?.type, 'string');
+    });
+  });
+
+  group('buildSchema utility', () {
+    test('builds correct OpenAPI schema from field list', () {
+      final schema = buildSchema([
+        SchemaField.string('name', description: 'Name to greet'),
+      ]);
+      expect(schema, {
+        'type': 'object',
+        'properties': {
+          'name': {'type': 'string', 'description': 'Name to greet'},
+        },
+        'required': ['name'],
+      });
+    });
+
+    test('optional field excluded from required and marked nullable', () {
+      final schema = buildSchema([
+        SchemaField.string('name'),
+        SchemaField.optional(SchemaField.string('nick')),
+      ]);
+      expect(schema['required'], ['name']);
+      expect(
+          (schema['properties'] as Map)['nick'], {'type': 'string', 'nullable': true});
+    });
+  });
+
+  group('Input auto-schema from schemaFields', () {
+    test('toSchema() returns correct OpenAPI schema', () {
+      final input = NameInput(name: 'Carlos');
+      expect(input.toSchema(), {
+        'type': 'object',
+        'properties': {
+          'name': {'type': 'string', 'description': 'Name to greet'},
+        },
+        'required': ['name'],
+      });
+    });
+
+    test('optional field schema works correctly', () {
+      final input = OptionalInput(name: 'Carlos');
+      final schema = input.toSchema();
+      expect(schema['required'], ['name']);
+      expect(
+          (schema['properties'] as Map)['nickname'],
+          {
+            'type': 'string',
+            'description': 'Optional nickname',
+            'nullable': true,
+          });
+    });
+  });
+
+  group('Output auto-schema from schemaFields', () {
+    test('toSchema() returns correct OpenAPI schema', () {
+      final output = GreetOutput(message: 'Hello!');
+      expect(output.toSchema(), {
+        'type': 'object',
+        'properties': {
+          'message': {'type': 'string', 'description': 'Greeting message'},
+        },
+        'required': ['message'],
+      });
+    });
+
+    test('statusCode is still provided by subclass', () {
+      final output = GreetOutput();
+      expect(output.statusCode, 200);
+    });
+  });
+}

--- a/dart/test/schema/infer_schema_test.dart
+++ b/dart/test/schema/infer_schema_test.dart
@@ -1,0 +1,129 @@
+import 'package:test/test.dart';
+import 'package:modular_api/src/core/schema/field.dart';
+
+void main() {
+  group('inferSchemaFromExample', () {
+    test('String value infers type string', () {
+      final schema = inferSchemaFromExample({'name': 'Sebastián'});
+      expect(schema['properties']['name'], {'type': 'string'});
+      expect(schema['required'], ['name']);
+    });
+
+    test('int value infers type integer', () {
+      final schema = inferSchemaFromExample({'age': 25});
+      expect(schema['properties']['age'], {'type': 'integer'});
+      expect(schema['required'], ['age']);
+    });
+
+    test('double value infers type number', () {
+      final schema = inferSchemaFromExample({'weight': 72.5});
+      expect(schema['properties']['weight'], {'type': 'number'});
+      expect(schema['required'], ['weight']);
+    });
+
+    test('bool value infers type boolean', () {
+      final schema = inferSchemaFromExample({'active': true});
+      expect(schema['properties']['active'], {'type': 'boolean'});
+      expect(schema['required'], ['active']);
+    });
+
+    test('List<String> infers array with string items', () {
+      final schema = inferSchemaFromExample({
+        'tags': ['dart', 'flutter'],
+      });
+      expect(schema['properties']['tags'], {
+        'type': 'array',
+        'items': {'type': 'string'},
+      });
+      expect(schema['required'], ['tags']);
+    });
+
+    test('List<int> infers array with integer items', () {
+      final schema = inferSchemaFromExample({
+        'scores': [10, 20, 30],
+      });
+      expect(schema['properties']['scores'], {
+        'type': 'array',
+        'items': {'type': 'integer'},
+      });
+    });
+
+    test('List<double> infers array with number items', () {
+      final schema = inferSchemaFromExample({
+        'rates': [1.5, 2.5],
+      });
+      expect(schema['properties']['rates'], {
+        'type': 'array',
+        'items': {'type': 'number'},
+      });
+    });
+
+    test('List<bool> infers array with boolean items', () {
+      final schema = inferSchemaFromExample({
+        'flags': [true, false],
+      });
+      expect(schema['properties']['flags'], {
+        'type': 'array',
+        'items': {'type': 'boolean'},
+      });
+    });
+
+    test('empty List infers array with string items (default)', () {
+      final schema = inferSchemaFromExample({'items': <dynamic>[]});
+      expect(schema['properties']['items'], {
+        'type': 'array',
+        'items': {'type': 'string'},
+      });
+    });
+
+    test('null value infers nullable string not required', () {
+      final schema = inferSchemaFromExample({'nickname': null});
+      expect(schema['properties']['nickname'], {
+        'type': 'string',
+        'nullable': true,
+      });
+      expect(schema['required'], isNot(contains('nickname')));
+    });
+
+    test('mixed DTO with all types', () {
+      final schema = inferSchemaFromExample({
+        'name': 'Sebastián',
+        'age': 25,
+        'weight': 72.5,
+        'active': true,
+        'tags': ['dev', 'dart'],
+        'nickname': null,
+      });
+
+      expect(schema['type'], 'object');
+      expect(schema['properties']['name'], {'type': 'string'});
+      expect(schema['properties']['age'], {'type': 'integer'});
+      expect(schema['properties']['weight'], {'type': 'number'});
+      expect(schema['properties']['active'], {'type': 'boolean'});
+      expect(schema['properties']['tags'], {
+        'type': 'array',
+        'items': {'type': 'string'},
+      });
+      expect(schema['properties']['nickname'], {
+        'type': 'string',
+        'nullable': true,
+      });
+      expect(
+        schema['required'],
+        unorderedEquals(['name', 'age', 'weight', 'active', 'tags']),
+      );
+    });
+
+    test('schema always has type object', () {
+      final schema = inferSchemaFromExample({'x': 1});
+      expect(schema['type'], 'object');
+    });
+
+    test('empty map produces empty schema', () {
+      final schema = inferSchemaFromExample({});
+      expect(schema['type'], 'object');
+      expect(schema['properties'], {});
+      expect(schema.containsKey('required'), isFalse);
+    });
+  });
+}

--- a/dart/test/schema/schema_field_example_test.dart
+++ b/dart/test/schema/schema_field_example_test.dart
@@ -1,0 +1,116 @@
+import 'package:test/test.dart';
+import 'package:modular_api/src/core/schema/field.dart';
+
+void main() {
+  group('SchemaField example parameter', () {
+    test('SchemaField.string stores example', () {
+      final f = SchemaField.string('name', example: 'Sebastián');
+      expect(f.example, 'Sebastián');
+    });
+
+    test('SchemaField.integer stores example', () {
+      final f = SchemaField.integer('age', example: 25);
+      expect(f.example, 25);
+    });
+
+    test('SchemaField.number stores example', () {
+      final f = SchemaField.number('weight', example: 72.5);
+      expect(f.example, 72.5);
+    });
+
+    test('SchemaField.boolean stores example', () {
+      final f = SchemaField.boolean('active', example: true);
+      expect(f.example, true);
+    });
+
+    test('SchemaField.array stores example', () {
+      final f = SchemaField.array(
+        'tags',
+        SchemaField.string(''),
+        example: ['dart', 'flutter'],
+      );
+      expect(f.example, ['dart', 'flutter']);
+    });
+
+    test('SchemaField.optional propagates example from inner', () {
+      final inner = SchemaField.string('nick', example: 'Seb');
+      final f = SchemaField.optional(inner);
+      expect(f.example, 'Seb');
+      expect(f.required, isFalse);
+      expect(f.nullable, isTrue);
+    });
+
+    test('SchemaField without example has null', () {
+      final f = SchemaField.string('name');
+      expect(f.example, isNull);
+    });
+  });
+
+  group('buildSchema emits example', () {
+    test('includes example per property when present', () {
+      final schema = buildSchema([
+        SchemaField.string('name',
+            description: 'Name to greet', example: 'Sebastián'),
+        SchemaField.integer('age',
+            description: 'User age', example: 25),
+      ]);
+
+      final nameProps = schema['properties']['name'] as Map;
+      expect(nameProps['example'], 'Sebastián');
+
+      final ageProps = schema['properties']['age'] as Map;
+      expect(ageProps['example'], 25);
+    });
+
+    test('omits example when not provided', () {
+      final schema = buildSchema([
+        SchemaField.string('name', description: 'Name to greet'),
+      ]);
+
+      final nameProps = schema['properties']['name'] as Map;
+      expect(nameProps.containsKey('example'), isFalse);
+    });
+
+    test('includes example for all types', () {
+      final schema = buildSchema([
+        SchemaField.string('s', example: 'hello'),
+        SchemaField.integer('i', example: 42),
+        SchemaField.number('n', example: 3.14),
+        SchemaField.boolean('b', example: false),
+        SchemaField.array('a', SchemaField.string(''), example: ['x', 'y']),
+      ]);
+
+      expect((schema['properties']['s'] as Map)['example'], 'hello');
+      expect((schema['properties']['i'] as Map)['example'], 42);
+      expect((schema['properties']['n'] as Map)['example'], 3.14);
+      expect((schema['properties']['b'] as Map)['example'], false);
+      expect((schema['properties']['a'] as Map)['example'], ['x', 'y']);
+    });
+
+    test('composes top-level example from per-field examples', () {
+      final schema = buildSchema([
+        SchemaField.string('name', example: 'Sebastián'),
+        SchemaField.integer('age', example: 25),
+      ]);
+
+      expect(schema['example'], {'name': 'Sebastián', 'age': 25});
+    });
+
+    test('omits top-level example when no fields have examples', () {
+      final schema = buildSchema([
+        SchemaField.string('name'),
+      ]);
+
+      expect(schema.containsKey('example'), isFalse);
+    });
+
+    test('top-level example only includes fields that have examples', () {
+      final schema = buildSchema([
+        SchemaField.string('name', example: 'Sebastián'),
+        SchemaField.integer('age'),
+      ]);
+
+      expect(schema['example'], {'name': 'Sebastián'});
+    });
+  });
+}

--- a/dart/test/schema/schema_field_example_test.dart
+++ b/dart/test/schema/schema_field_example_test.dart
@@ -51,8 +51,7 @@ void main() {
       final schema = buildSchema([
         SchemaField.string('name',
             description: 'Name to greet', example: 'Sebastián'),
-        SchemaField.integer('age',
-            description: 'User age', example: 25),
+        SchemaField.integer('age', description: 'User age', example: 25),
       ]);
 
       final nameProps = schema['properties']['name'] as Map;

--- a/dart/test/schema/to_schema_fallback_test.dart
+++ b/dart/test/schema/to_schema_fallback_test.dart
@@ -1,7 +1,6 @@
 import 'package:test/test.dart';
 import 'package:modular_api/src/core/schema/field.dart';
 import 'package:modular_api/src/core/usecase/usecase.dart';
-import 'package:modular_api/src/core/logger/logger.dart';
 
 // ── Input WITHOUT schemaFields — relies on toJson() inference ─────────────
 

--- a/dart/test/schema/to_schema_fallback_test.dart
+++ b/dart/test/schema/to_schema_fallback_test.dart
@@ -1,0 +1,109 @@
+import 'package:test/test.dart';
+import 'package:modular_api/src/core/schema/field.dart';
+import 'package:modular_api/src/core/usecase/usecase.dart';
+import 'package:modular_api/src/core/logger/logger.dart';
+
+// ── Input WITHOUT schemaFields — relies on toJson() inference ─────────────
+
+class BareInput extends Input {
+  final String name;
+  final int age;
+  final double score;
+  final bool active;
+  final List<String> tags;
+
+  BareInput({
+    required this.name,
+    required this.age,
+    required this.score,
+    required this.active,
+    required this.tags,
+  });
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'age': age,
+        'score': score,
+        'active': active,
+        'tags': tags,
+      };
+}
+
+// ── Input WITH schemaFields — has descriptions ────────────────────────────
+
+class DescribedInput extends Input {
+  final String name;
+
+  DescribedInput({required this.name});
+
+  @override
+  Map<String, dynamic> toJson() => {'name': name};
+
+  @override
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('name', description: 'Name to greet'),
+      ];
+}
+
+// ── Output WITHOUT schemaFields ───────────────────────────────────────────
+
+class BareOutput extends Output {
+  final String message;
+
+  BareOutput({required this.message});
+
+  @override
+  int get statusCode => 200;
+
+  @override
+  Map<String, dynamic> toJson() => {'message': message};
+}
+
+void main() {
+  group('Input.toSchema() fallback to inferSchemaFromExample', () {
+    test('Input without schemaFields infers schema from toJson()', () {
+      final input = BareInput(
+        name: 'Sebastián',
+        age: 25,
+        score: 95.5,
+        active: true,
+        tags: ['dev', 'dart'],
+      );
+      final schema = input.toSchema();
+
+      expect(schema['type'], 'object');
+      expect(schema['properties']['name'], {'type': 'string'});
+      expect(schema['properties']['age'], {'type': 'integer'});
+      expect(schema['properties']['score'], {'type': 'number'});
+      expect(schema['properties']['active'], {'type': 'boolean'});
+      expect(schema['properties']['tags'], {
+        'type': 'array',
+        'items': {'type': 'string'},
+      });
+      expect(
+        schema['required'],
+        unorderedEquals(['name', 'age', 'score', 'active', 'tags']),
+      );
+    });
+
+    test('Input with schemaFields uses buildSchema (preferred path)', () {
+      final input = DescribedInput(name: 'World');
+      final schema = input.toSchema();
+
+      expect(schema['properties']['name']['description'], 'Name to greet');
+      expect(schema['properties']['name']['type'], 'string');
+    });
+  });
+
+  group('Output.toSchema() fallback to inferSchemaFromExample', () {
+    test('Output without schemaFields infers schema from toJson()', () {
+      final output = BareOutput(message: 'Hello!');
+      final schema = output.toSchema();
+
+      expect(schema['type'], 'object');
+      expect(schema['properties']['message'], {'type': 'string'});
+      expect(schema['required'], ['message']);
+    });
+  });
+}

--- a/dart/test/schema_conformance_test.dart
+++ b/dart/test/schema_conformance_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart';
 // Once @MacssSchema() lands, these become the macro-decorated versions.
 import 'package:modular_api/src/core/usecase/usecase.dart';
 
-class HelloInput implements Input {
+class HelloInput extends Input {
   final String name;
   HelloInput({required this.name});
 
@@ -27,7 +27,7 @@ class HelloInput implements Input {
       };
 }
 
-class HelloOutput implements Output {
+class HelloOutput extends Output {
   final String message;
   HelloOutput({this.message = ''});
 

--- a/dart/test/schema_conformance_test.dart
+++ b/dart/test/schema_conformance_test.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+// Replicate the example DTOs to test schema conformance.
+// Once @MacssSchema() lands, these become the macro-decorated versions.
+import 'package:modular_api/src/core/usecase/usecase.dart';
+
+class HelloInput implements Input {
+  final String name;
+  HelloInput({required this.name});
+
+  factory HelloInput.fromJson(Map<String, dynamic> json) =>
+      HelloInput(name: (json['name'] ?? '').toString());
+
+  @override
+  Map<String, dynamic> toJson() => {'name': name};
+
+  @override
+  Map<String, dynamic> toSchema() => {
+        'type': 'object',
+        'properties': {
+          'name': {'type': 'string', 'description': 'Name to greet'},
+        },
+        'required': ['name'],
+      };
+}
+
+class HelloOutput implements Output {
+  final String message;
+  HelloOutput({this.message = ''});
+
+  @override
+  int get statusCode => 200;
+
+  @override
+  Map<String, dynamic> toJson() => {'message': message};
+
+  @override
+  Map<String, dynamic> toSchema() => {
+        'type': 'object',
+        'properties': {
+          'message': {'type': 'string', 'description': 'Greeting message'},
+        },
+        'required': ['message'],
+      };
+}
+
+/// Loads a JSON fixture relative to the monorepo root.
+Map<String, dynamic> loadFixture(String name) {
+  // From dart/test/ → ../../tests/fixtures/
+  final path = '${Directory.current.path}/../tests/fixtures/$name';
+  final file = File(path);
+  if (!file.existsSync()) {
+    // When running from dart/ directory
+    final altPath = '${Directory.current.path}/tests/fixtures/$name';
+    final altFile = File(altPath);
+    if (altFile.existsSync()) {
+      return jsonDecode(altFile.readAsStringSync()) as Map<String, dynamic>;
+    }
+    throw FileSystemException('Fixture not found', path);
+  }
+  return jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+}
+
+void main() {
+  group('Schema Conformance', () {
+    test('HelloInput schema matches shared fixture', () {
+      final fixture = loadFixture('hello_input_schema.json');
+      final input = HelloInput(name: 'test');
+      expect(input.toSchema(), equals(fixture));
+    });
+
+    test('HelloOutput schema matches shared fixture', () {
+      final fixture = loadFixture('hello_output_schema.json');
+      final output = HelloOutput(message: 'test');
+      expect(output.toSchema(), equals(fixture));
+    });
+  });
+}

--- a/dart/test/schema_conformance_test.dart
+++ b/dart/test/schema_conformance_test.dart
@@ -19,7 +19,7 @@ class HelloInput extends Input {
 
   @override
   List<SchemaField> get schemaFields => [
-        SchemaField.string('name', description: 'Name to greet'),
+        SchemaField.string('name', description: 'Name to greet', example: 'World'),
       ];
 }
 
@@ -36,7 +36,7 @@ class HelloOutput extends Output {
 
   @override
   List<SchemaField> get schemaFields => [
-        SchemaField.string('message', description: 'Greeting message'),
+        SchemaField.string('message', description: 'Greeting message', example: 'Hello, World!'),
       ];
 }
 

--- a/dart/test/schema_conformance_test.dart
+++ b/dart/test/schema_conformance_test.dart
@@ -3,11 +3,11 @@ import 'dart:io';
 
 import 'package:test/test.dart';
 
-// Replicate the example DTOs to test schema conformance.
-// Once @MacssSchema() lands, these become the macro-decorated versions.
 import 'package:modular_api/src/core/usecase/usecase.dart';
+import 'package:modular_api/src/core/schema/field.dart';
 
 class HelloInput extends Input {
+  @Field(description: 'Name to greet')
   final String name;
   HelloInput({required this.name});
 
@@ -18,16 +18,13 @@ class HelloInput extends Input {
   Map<String, dynamic> toJson() => {'name': name};
 
   @override
-  Map<String, dynamic> toSchema() => {
-        'type': 'object',
-        'properties': {
-          'name': {'type': 'string', 'description': 'Name to greet'},
-        },
-        'required': ['name'],
-      };
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('name', description: 'Name to greet'),
+      ];
 }
 
 class HelloOutput extends Output {
+  @Field(description: 'Greeting message')
   final String message;
   HelloOutput({this.message = ''});
 
@@ -38,13 +35,9 @@ class HelloOutput extends Output {
   Map<String, dynamic> toJson() => {'message': message};
 
   @override
-  Map<String, dynamic> toSchema() => {
-        'type': 'object',
-        'properties': {
-          'message': {'type': 'string', 'description': 'Greeting message'},
-        },
-        'required': ['message'],
-      };
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('message', description: 'Greeting message'),
+      ];
 }
 
 /// Loads a JSON fixture relative to the monorepo root.

--- a/dart/test/schema_conformance_test.dart
+++ b/dart/test/schema_conformance_test.dart
@@ -19,7 +19,8 @@ class HelloInput extends Input {
 
   @override
   List<SchemaField> get schemaFields => [
-        SchemaField.string('name', description: 'Name to greet', example: 'World'),
+        SchemaField.string('name',
+            description: 'Name to greet', example: 'World'),
       ];
 }
 
@@ -36,7 +37,8 @@ class HelloOutput extends Output {
 
   @override
   List<SchemaField> get schemaFields => [
-        SchemaField.string('message', description: 'Greeting message', example: 'Hello, World!'),
+        SchemaField.string('message',
+            description: 'Greeting message', example: 'Hello, World!'),
       ];
 }
 

--- a/dart/test/use_case_exception_test.dart
+++ b/dart/test/use_case_exception_test.dart
@@ -106,7 +106,7 @@ void main() {
 }
 
 // Test UseCase
-class ThrowExceptionInput implements Input {
+class ThrowExceptionInput extends Input {
   final bool shouldThrow;
 
   ThrowExceptionInput({required this.shouldThrow});
@@ -131,7 +131,7 @@ class ThrowExceptionInput implements Input {
   }
 }
 
-class ThrowExceptionOutput implements Output {
+class ThrowExceptionOutput extends Output {
   final bool success;
 
   ThrowExceptionOutput({required this.success});

--- a/dart/test/usecase_test.dart
+++ b/dart/test/usecase_test.dart
@@ -42,7 +42,7 @@ class SumUseCase implements UseCase<SumInput, SumOutput> {
   Map<String, dynamic> toJson() => output.toJson();
 }
 
-class SumInput implements Input {
+class SumInput extends Input {
   final int? a;
   final int? b;
 
@@ -72,7 +72,7 @@ class SumInput implements Input {
       };
 }
 
-class SumOutput implements Output {
+class SumOutput extends Output {
   final int resultado;
 
   SumOutput({required this.resultado});

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,8 +148,8 @@ using the language's native type system.
 | Language | Mechanism | Example |
 |---|---|---|
 | Python | Pydantic `BaseModel` | `class HelloInput(BaseModel): name: str` |
-| Dart | `@MacssSchema()` macro | `@MacssSchema() class HelloInput implements Input { ... }` |
-| TypeScript | TypeBox `Type.Object()` | `const HelloInputSchema = Type.Object({ name: Type.String() })` |
+| Dart | `@Field` annotations + `schemaFields` getter | `class HelloInput extends Input { @Field(...) final String name; ... }` |
+| TypeScript | Stage 3 `@Field` decorators | `class HelloInput extends Input { @Field.string() name!: string; }` |
 
 **Rules:**
 
@@ -736,7 +736,7 @@ opt-in authentication middleware.
 | **HTTP framework** | [shelf](https://pub.dev/packages/shelf) | [Express](https://expressjs.com/) | [Starlette](https://www.starlette.io/) |
 | **Package** | `modular_api` (pub.dev) | `@macss/modular-api` (npm) | `modular-api` (PyPI) |
 | **Version** | 0.4.0 | 0.4.0 | — |
-| **Schema generation** | `@MacssSchema()` macro | TypeBox `Type.Object()` | Pydantic `BaseModel` |
+| **Schema generation** | `@Field` + `schemaFields` getter | Stage 3 `@Field` decorators | Pydantic `BaseModel` |
 | **Metrics** | Native implementation | Native implementation | Native implementation |
 | **Swagger UI** | `shelf_swagger_ui` | `swagger-ui-express` | Native or `starlette-swagger-ui` |
 | **YAML serializer** | Native (zero-dep) | Native (zero-dep) | Native (zero-dep) |

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.4.2] - 2026-03-12
+
+### Added
+
+- **Auto-schema generation** — `Input` and `Output` inherit from Pydantic `BaseModel`; schemas derived automatically from field declarations
+- `Field(description='x')` re-exported from Pydantic — uniform field metadata across all three SDKs
+- Class-level schema extraction in `ModuleBuilder` — no `factory({})` dummy call needed
+- `_normalize_schema()` — converts Pydantic JSON Schema Draft 2020-12 to OpenAPI 3.0.3 (`anyOf` → `nullable`, strip `title`/`default`)
+- Cross-language schema conformance tests against shared JSON fixtures
+
+### Changed
+
+- `Input` / `Output` now inherit from `BaseModel` — `to_json()`, `to_schema()`, `from_json()` are automatic
+- Manual `to_schema()` override is deprecated via `__init_subclass__()` detection — use field declarations instead (removal in v0.5.0)
+- `_extract_schemas()` uses return type hint introspection (Strategy 1) with `factory({})` fallback (Strategy 2)
+
 ## [0.4.1] - 2026-03-12
 
 ### Added

--- a/py/README.md
+++ b/py/README.md
@@ -46,7 +46,7 @@ See `example/example.py` for the full implementation including Input, Output, Us
 ## Features
 
 - `UseCase[I, O]` — pure business logic, no HTTP concerns
-- `Input` / `Output` — DTOs with `to_json()` and `to_schema()` for automatic OpenAPI
+- `Input` / `Output` — DTOs with automatic OpenAPI schema generation via Pydantic `Field()`
 - `Output.status_code` — custom HTTP status codes per response
 - `UseCaseException` — structured error handling (status_code, message, error_code, details)
 - `ModularApi` + `ModuleBuilder` — module registration and routing

--- a/py/example/example.py
+++ b/py/example/example.py
@@ -31,6 +31,7 @@ from modular_api import (
     ModuleBuilder,
     Output,
     UseCase,
+    Field,
 )
 
 
@@ -45,52 +46,18 @@ def build_greetings_module(m: ModuleBuilder) -> None:
 
 
 class HelloInput(Input):
-    def __init__(self, *, name: str) -> None:
-        self._name = name
-
-    @property
-    def name(self) -> str:
-        return self._name
-
-    @classmethod
-    def from_json(cls, json: dict[str, object]) -> HelloInput:
-        return cls(name=str(json.get("name", "")))
-
-    def to_json(self) -> dict[str, object]:
-        return {"name": self._name}
-
-    def to_schema(self) -> dict[str, object]:
-        return {
-            "type": "object",
-            "properties": {
-                "name": {"type": "string", "description": "Name to greet"},
-            },
-            "required": ["name"],
-        }
+    name: str = Field(description="Name to greet")
 
 
 # ── Output DTO ────────────────────────────────────────────────
 
 
 class HelloOutput(Output):
-    def __init__(self, *, message: str) -> None:
-        self._message = message
+    message: str = Field(description="Greeting message")
 
     @property
     def status_code(self) -> int:
         return 200
-
-    def to_json(self) -> dict[str, object]:
-        return {"message": self._message}
-
-    def to_schema(self) -> dict[str, object]:
-        return {
-            "type": "object",
-            "properties": {
-                "message": {"type": "string", "description": "Greeting message"},
-            },
-            "required": ["message"],
-        }
 
 
 # ── UseCase ───────────────────────────────────────────────────

--- a/py/example/example.py
+++ b/py/example/example.py
@@ -134,13 +134,8 @@ def main() -> None:
 
     api.module("greetings", build_greetings_module)
 
-    print("====================================")
-    print(f"API  → http://localhost:{port}/api/greetings/hello")
-    print(f"Docs → http://localhost:{port}/docs")
-    print("====================================")
-
     api.serve(port=port)
-
+    
 
 if __name__ == "__main__":
     main()

--- a/py/example/example.py
+++ b/py/example/example.py
@@ -46,14 +46,14 @@ def build_greetings_module(m: ModuleBuilder) -> None:
 
 
 class HelloInput(Input):
-    name: str = Field(description="Name to greet")
+    name: str = Field(description="Name to greet", examples=["World"])
 
 
 # ── Output DTO ────────────────────────────────────────────────
 
 
 class HelloOutput(Output):
-    message: str = Field(description="Greeting message")
+    message: str = Field(description="Greeting message", examples=["Hello, World!"])
 
     @property
     def status_code(self) -> int:
@@ -135,7 +135,7 @@ def main() -> None:
     api.module("greetings", build_greetings_module)
 
     api.serve(port=port)
-    
+
 
 if __name__ == "__main__":
     main()

--- a/py/publish.ps1
+++ b/py/publish.ps1
@@ -21,16 +21,9 @@ if (-not (Test-Path $envFile)) {
     exit 1
 }
 
-$token = $null
-$testToken = $null
-Get-Content $envFile | ForEach-Object {
-    if ($_ -match '^\s*TOKEN_PYPI\s*=\s*(.+)\s*$') {
-        $token = $Matches[1]
-    }
-    if ($_ -match '^\s*TOKEN_TEST_PYPI\s*=\s*(.+)\s*$') {
-        $testToken = $Matches[1]
-    }
-}
+$envLines = Get-Content $envFile
+$token     = ($envLines | Where-Object { $_ -match '^\s*TOKEN_PYPI\s*='     } | ForEach-Object { ($_ -split '=', 2)[1].Trim() }) | Select-Object -First 1
+$testToken = ($envLines | Where-Object { $_ -match '^\s*TOKEN_TEST_PYPI\s*=' } | ForEach-Object { ($_ -split '=', 2)[1].Trim() }) | Select-Object -First 1
 
 if ($TestPyPI) {
     if (-not $testToken) {

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "macss-modular-api"
-version = "0.4.1"
+version = "0.4.2"
 description = "Use-case-centric toolkit for building modular APIs with Starlette. Define UseCase classes (input → validate → execute → output), connect them to HTTP routes, and expose OpenAPI documentation automatically."
 readme = "README.md"
 license = "MIT"

--- a/py/src/modular_api/__init__.py
+++ b/py/src/modular_api/__init__.py
@@ -22,6 +22,7 @@ from modular_api.core.registry import ApiRegistry, UseCaseDocMeta, UseCaseRegist
 from modular_api.core.use_case_exception import UseCaseException
 from modular_api.core.usecase import Input, Output, UseCase
 from modular_api.core.usecase_handler import usecase_handler
+from pydantic import Field
 from modular_api.middlewares.cors import cors_middleware
 from modular_api.openapi.openapi import (
     build_openapi_spec,
@@ -34,6 +35,7 @@ from modular_api.openapi.swagger_docs import swagger_docs_handler
 __all__ = [
     "ApiRegistry",
     "Counter",
+    "Field",
     "Gauge",
     "HealthCheck",
     "HealthCheckResult",

--- a/py/src/modular_api/core/module_builder.py
+++ b/py/src/modular_api/core/module_builder.py
@@ -15,6 +15,8 @@ Mirror of ``ModuleBuilder`` in Dart and TypeScript.
 
 from __future__ import annotations
 
+import inspect
+import typing
 from typing import Any, Callable
 
 from starlette.routing import Route, Router
@@ -27,6 +29,50 @@ from modular_api.core.registry import (
 )
 from modular_api.core.usecase import Input, Output, UseCase
 from modular_api.core.usecase_handler import usecase_handler
+
+
+def _get_return_type_hint(factory: Callable) -> type | None:  # noqa: ANN401
+    """Extract the UseCase class from the factory callable.
+
+    Our convention: factories are classmethods like ``HelloWorld.from_json``.
+    A bound classmethod has ``__self__`` pointing to the class itself.
+    """
+    # Bound classmethod: StubUseCase.from_json → __self__ is StubUseCase
+    owner = getattr(factory, "__self__", None)
+    if isinstance(owner, type) and issubclass(owner, UseCase):
+        return owner
+
+    # Fallback: try return type hint resolution
+    try:
+        hints = typing.get_type_hints(factory)
+        ret = hints.get("return")
+        if isinstance(ret, type) and issubclass(ret, UseCase):
+            return ret
+    except Exception:
+        pass
+
+    return None
+
+
+def _extract_dto_classes(usecase_cls: type) -> tuple[type | None, type | None]:
+    """Walk a UseCase subclass's MRO to find its Input and Output type args.
+
+    Given ``class HelloWorld(UseCase[HelloInput, HelloOutput])``, returns
+    ``(HelloInput, HelloOutput)``.
+    """
+    input_cls: type | None = None
+    output_cls: type | None = None
+
+    for base in getattr(usecase_cls, "__orig_bases__", ()):
+        origin = getattr(base, "__origin__", None)
+        if origin is UseCase or (isinstance(origin, type) and issubclass(origin, UseCase)):
+            args = getattr(base, "__args__", ())
+            if len(args) >= 2:
+                input_cls = args[0] if isinstance(args[0], type) else None
+                output_cls = args[1] if isinstance(args[1], type) else None
+            break
+
+    return input_cls, output_cls
 
 
 class ModuleBuilder:
@@ -97,31 +143,52 @@ class ModuleBuilder:
 
     @staticmethod
     def _extract_schemas(factory: UseCaseFactory) -> dict[str, dict[str, Any]]:
-        """Capture Input and Output schemas independently from a dummy factory call.
+        """Capture Input and Output schemas from a UseCase factory.
 
-        Each DTO extraction has its own try/except so a failure in one
-        (e.g. Output not yet initialised) does not destroy the other.
-        This matches Dart's separate _inferInputSchema/_inferOutputSchema pattern.
+        Strategy (in order of preference):
+        1. Class-level extraction via ``to_schema()`` classmethod on BaseModel DTOs.
+           Inspects the factory's type hints to find the Input/Output classes.
+        2. Fallback: instantiate via ``factory({})`` and call ``to_schema()``
+           on the resulting UseCase's input/output (legacy pattern).
         """
         input_schema: dict[str, Any] = {}
         output_schema: dict[str, Any] = {}
 
+        # --- Strategy 1: class-level extraction from type hints ---
+        return_hint = _get_return_type_hint(factory)
+
+        if return_hint is not None:
+            input_cls, output_cls = _extract_dto_classes(return_hint)
+
+            if input_cls is not None and hasattr(input_cls, "to_schema"):
+                try:
+                    input_schema = input_cls.to_schema()
+                except Exception:
+                    pass
+
+            if output_cls is not None and hasattr(output_cls, "to_schema"):
+                try:
+                    output_schema = output_cls.to_schema()
+                except Exception:
+                    pass
+
+            if input_schema or output_schema:
+                return {"input": input_schema, "output": output_schema}
+
+        # --- Strategy 2: legacy factory({}) fallback ---
         try:
             instance = factory({})
         except Exception:
-            # Factory itself failed — both schemas fall back to empty.
             return {"input": input_schema, "output": output_schema}
 
         try:
             input_schema = instance.input.to_schema()
         except Exception:
-            # Input DTO inaccessible or to_schema() failed — keep empty fallback.
             pass
 
         try:
             output_schema = instance.output.to_schema()
         except Exception:
-            # Output not initialised until execute() — expected for most UseCases.
             pass
 
         return {"input": input_schema, "output": output_schema}

--- a/py/src/modular_api/core/usecase.py
+++ b/py/src/modular_api/core/usecase.py
@@ -9,6 +9,7 @@ Lifecycle (handled by the framework):
 
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
@@ -66,6 +67,16 @@ class Input(BaseModel):
 
     model_config = {"extra": "ignore"}
 
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+        if "to_schema" in cls.__dict__:
+            warnings.warn(
+                f"{cls.__name__}.to_schema() is deprecated. "
+                "Remove it — schema is derived automatically from field declarations.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
     @classmethod
     def from_json(cls, json: dict[str, object]) -> Input:
         """Deserialize from a plain dict. Type coercion handled by Pydantic."""
@@ -93,6 +104,16 @@ class Output(BaseModel):
     """
 
     model_config = {"extra": "ignore"}
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+        if "to_schema" in cls.__dict__:
+            warnings.warn(
+                f"{cls.__name__}.to_schema() is deprecated. "
+                "Remove it — schema is derived automatically from field declarations.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     @classmethod
     def from_json(cls, json: dict[str, object]) -> Output:

--- a/py/src/modular_api/core/usecase.py
+++ b/py/src/modular_api/core/usecase.py
@@ -43,8 +43,8 @@ def _normalize_schema(raw: dict[str, Any]) -> dict[str, object]:
                     required.remove(name)
                 continue
 
-        # Strip Pydantic's auto-generated ``title`` from properties
-        cleaned = {k: v for k, v in prop.items() if k != "title"}
+        # Strip Pydantic's auto-generated ``title`` and ``default`` from properties
+        cleaned = {k: v for k, v in prop.items() if k not in ("title", "default")}
         normalized_props[name] = cleaned
 
     result: dict[str, object] = {"type": "object", "properties": normalized_props}

--- a/py/src/modular_api/core/usecase.py
+++ b/py/src/modular_api/core/usecase.py
@@ -46,6 +46,9 @@ def _normalize_schema(raw: dict[str, Any]) -> dict[str, object]:
                 # Preserve description if present on the outer property
                 if "description" in prop:
                     collapsed["description"] = prop["description"]
+                # Convert examples → example (nullable fields)
+                if "examples" in prop and prop["examples"]:
+                    collapsed["example"] = prop["examples"][0]
                 normalized_props[name] = _reorder_type_first(collapsed)
                 if name in required:
                     required.remove(name)
@@ -53,11 +56,25 @@ def _normalize_schema(raw: dict[str, Any]) -> dict[str, object]:
 
         # Strip Pydantic's auto-generated ``title`` and ``default`` from properties
         cleaned = {k: v for k, v in prop.items() if k not in ("title", "default")}
+
+        # Convert Pydantic ``examples`` (list, Draft 2020-12) → OpenAPI ``example`` (singular)
+        if "examples" in cleaned and cleaned["examples"]:
+            cleaned["example"] = cleaned["examples"][0]
+            del cleaned["examples"]
+
         normalized_props[name] = _reorder_type_first(cleaned)
+
+    # Compose top-level example from per-field examples
+    example_values: dict[str, Any] = {}
+    for name, prop in normalized_props.items():
+        if "example" in prop:
+            example_values[name] = prop["example"]
 
     result: dict[str, object] = {"type": "object", "properties": normalized_props}
     if required:
         result["required"] = required
+    if example_values:
+        result["example"] = example_values
     return result
 
 

--- a/py/src/modular_api/core/usecase.py
+++ b/py/src/modular_api/core/usecase.py
@@ -10,41 +10,103 @@ Lifecycle (handled by the framework):
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
+
+from pydantic import BaseModel
 
 
-class Input(ABC):
+def _normalize_schema(raw: dict[str, Any]) -> dict[str, object]:
+    """Normalize Pydantic JSON Schema (Draft 2020-12) to OpenAPI 3.0.3.
+
+    Pydantic's ``model_json_schema()`` emits Draft 2020-12 constructs
+    (``anyOf``, ``$defs``, ``title``) that OpenAPI 3.0.3 does not support.
+    This function rewrites them into the ``nullable`` / ``required`` pattern.
+    """
+    props: dict[str, Any] = raw.get("properties", {})
+    required: list[str] = list(raw.get("required", []))
+    normalized_props: dict[str, Any] = {}
+
+    for name, prop in props.items():
+        # Pydantic emits {"anyOf": [{"type":"string"}, {"type":"null"}]}
+        # for Optional fields. Collapse to {"type":"string","nullable":true}
+        # and remove the field from required[].
+        if "anyOf" in prop:
+            non_null = [v for v in prop["anyOf"] if v != {"type": "null"}]
+            if len(non_null) == 1:
+                collapsed = dict(non_null[0])
+                collapsed["nullable"] = True
+                # Preserve description if present on the outer property
+                if "description" in prop:
+                    collapsed["description"] = prop["description"]
+                normalized_props[name] = collapsed
+                if name in required:
+                    required.remove(name)
+                continue
+
+        # Strip Pydantic's auto-generated ``title`` from properties
+        cleaned = {k: v for k, v in prop.items() if k != "title"}
+        normalized_props[name] = cleaned
+
+    result: dict[str, object] = {"type": "object", "properties": normalized_props}
+    if required:
+        result["required"] = required
+    return result
+
+
+class Input(BaseModel):
     """Contract for use-case input DTOs.
 
-    Every implementor must provide ``to_json`` and ``to_schema``.
-    No default behavior is inherited — every Input is self-contained.
+    Inherits from Pydantic ``BaseModel``. Subclasses declare typed fields
+    and get ``from_json``, ``to_json``, and ``to_schema`` automatically.
+    Manual overrides still work (deprecated — will be removed in v0.5.0).
+
+    Equivalent in Dart:  ``class HelloInput implements Input { ... }``
+    Equivalent in TS:    ``class HelloInput extends Input { ... }``
     """
 
-    @abstractmethod
+    model_config = {"extra": "ignore"}
+
+    @classmethod
+    def from_json(cls, json: dict[str, object]) -> Input:
+        """Deserialize from a plain dict. Type coercion handled by Pydantic."""
+        return cls.model_validate(json)
+
     def to_json(self) -> dict[str, object]:
-        ...
+        """Serialize to a plain dict."""
+        return self.model_dump()
 
-    @abstractmethod
-    def to_schema(self) -> dict[str, object]:
-        """Return an OpenAPI-compatible JSON Schema describing this input."""
-        ...
+    @classmethod
+    def to_schema(cls) -> dict[str, object]:
+        """Return an OpenAPI 3.0.3-compatible JSON Schema for this Input."""
+        return _normalize_schema(cls.model_json_schema())
 
 
-class Output(ABC):
+class Output(BaseModel):
     """Contract for use-case output DTOs.
 
-    The implementor must define ``status_code`` explicitly — this forces
-    developers to think about HTTP status codes for every response.
+    Inherits from Pydantic ``BaseModel``. The implementor must define
+    ``status_code`` explicitly — this forces developers to think about
+    HTTP status codes for every response.
+
+    Equivalent in Dart:  ``class HelloOutput implements Output { ... }``
+    Equivalent in TS:    ``class HelloOutput extends Output { ... }``
     """
 
-    @abstractmethod
-    def to_json(self) -> dict[str, object]:
-        ...
+    model_config = {"extra": "ignore"}
 
-    @abstractmethod
-    def to_schema(self) -> dict[str, object]:
-        """Return an OpenAPI-compatible JSON Schema describing this output."""
-        ...
+    @classmethod
+    def from_json(cls, json: dict[str, object]) -> Output:
+        """Deserialize from a plain dict. Type coercion handled by Pydantic."""
+        return cls.model_validate(json)
+
+    def to_json(self) -> dict[str, object]:
+        """Serialize to a plain dict."""
+        return self.model_dump()
+
+    @classmethod
+    def to_schema(cls) -> dict[str, object]:
+        """Return an OpenAPI 3.0.3-compatible JSON Schema for this Output."""
+        return _normalize_schema(cls.model_json_schema())
 
     @property
     @abstractmethod

--- a/py/src/modular_api/core/usecase.py
+++ b/py/src/modular_api/core/usecase.py
@@ -16,6 +16,13 @@ from typing import Any, Generic, TypeVar
 from pydantic import BaseModel
 
 
+def _reorder_type_first(prop: dict[str, Any]) -> dict[str, Any]:
+    """Ensure ``type`` is the first key — matches Dart/TS property order."""
+    if "type" not in prop:
+        return prop
+    return {"type": prop["type"], **{k: v for k, v in prop.items() if k != "type"}}
+
+
 def _normalize_schema(raw: dict[str, Any]) -> dict[str, object]:
     """Normalize Pydantic JSON Schema (Draft 2020-12) to OpenAPI 3.0.3.
 
@@ -39,14 +46,14 @@ def _normalize_schema(raw: dict[str, Any]) -> dict[str, object]:
                 # Preserve description if present on the outer property
                 if "description" in prop:
                     collapsed["description"] = prop["description"]
-                normalized_props[name] = collapsed
+                normalized_props[name] = _reorder_type_first(collapsed)
                 if name in required:
                     required.remove(name)
                 continue
 
         # Strip Pydantic's auto-generated ``title`` and ``default`` from properties
         cleaned = {k: v for k, v in prop.items() if k not in ("title", "default")}
-        normalized_props[name] = cleaned
+        normalized_props[name] = _reorder_type_first(cleaned)
 
     result: dict[str, object] = {"type": "object", "properties": normalized_props}
     if required:

--- a/py/src/modular_api/core/usecase.py
+++ b/py/src/modular_api/core/usecase.py
@@ -86,8 +86,13 @@ class Input(BaseModel):
 
     @classmethod
     def from_json(cls, json: dict[str, object]) -> Input:
-        """Deserialize from a plain dict. Type coercion handled by Pydantic."""
-        return cls.model_validate(json)
+        """Deserialize from a plain dict with strict type validation.
+
+        Uses Pydantic strict mode so JSON types must match field declarations
+        exactly — no implicit coercion (e.g. int → str is rejected).
+        Raises ``ValidationError`` for missing or wrongly-typed fields.
+        """
+        return cls.model_validate(json, strict=True)
 
     def to_json(self) -> dict[str, object]:
         """Serialize to a plain dict."""
@@ -124,8 +129,8 @@ class Output(BaseModel):
 
     @classmethod
     def from_json(cls, json: dict[str, object]) -> Output:
-        """Deserialize from a plain dict. Type coercion handled by Pydantic."""
-        return cls.model_validate(json)
+        """Deserialize from a plain dict with strict type validation."""
+        return cls.model_validate(json, strict=True)
 
     def to_json(self) -> dict[str, object]:
         """Serialize to a plain dict."""

--- a/py/src/modular_api/core/usecase_handler.py
+++ b/py/src/modular_api/core/usecase_handler.py
@@ -11,6 +11,7 @@ import json
 import sys
 from typing import Any, Callable
 
+from pydantic import ValidationError
 from starlette.requests import Request
 from starlette.responses import Response
 
@@ -91,6 +92,16 @@ def usecase_handler(factory: UseCaseFactory) -> Any:
             return Response(
                 content=json.dumps(exc.to_json()),
                 status_code=exc.status_code,
+                media_type=_JSON_CONTENT_TYPE,
+            )
+        except ValidationError as exc:
+            # Pydantic validation failure during from_json — missing/invalid fields.
+            # Return 400 with the first error message, matching Dart/TS behavior.
+            first_error = exc.errors()[0]
+            field = ".".join(str(loc) for loc in first_error["loc"])
+            return Response(
+                content=json.dumps({"error": f"{field} is required"}),
+                status_code=400,
                 media_type=_JSON_CONTENT_TYPE,
             )
         except Exception as exc:

--- a/py/src/modular_api/core/usecase_handler.py
+++ b/py/src/modular_api/core/usecase_handler.py
@@ -26,6 +26,32 @@ _JSON_CONTENT_TYPE = "application/json; charset=utf-8"
 # Type for the factory function that builds a UseCase from parsed JSON.
 UseCaseFactory = Callable[[dict[str, Any]], UseCase[Any, Any]]
 
+# Maps Pydantic error types to OpenAPI type names for the error message
+# "Field '{name}' must be of type {openapi_type}".
+_PYDANTIC_ERROR_TO_OPENAPI_TYPE: dict[str, str] = {
+    "string_type": "string",
+    "int_type": "integer",
+    "int_parsing": "integer",
+    "float_type": "number",
+    "float_parsing": "number",
+    "bool_type": "boolean",
+    "bool_parsing": "boolean",
+    "list_type": "array",
+}
+
+
+def _format_validation_message(field: str, error_type: str) -> str:
+    """Produce a parity-safe error message from a Pydantic validation error.
+
+    Returns one of two canonical forms (identical across all 3 SDKs):
+      - ``"Missing required field: {name}"``
+      - ``"Field '{name}' must be of type {type}"``
+    """
+    if error_type == "missing":
+        return f"Missing required field: {field}"
+    openapi_type = _PYDANTIC_ERROR_TO_OPENAPI_TYPE.get(error_type, "the correct type")
+    return f"Field '{field}' must be of type {openapi_type}"
+
 
 def usecase_handler(factory: UseCaseFactory) -> Any:
     """Wraps a UseCase factory into an async Starlette endpoint.
@@ -95,12 +121,12 @@ def usecase_handler(factory: UseCaseFactory) -> Any:
                 media_type=_JSON_CONTENT_TYPE,
             )
         except ValidationError as exc:
-            # Pydantic validation failure during from_json — missing/invalid fields.
-            # Return 400 with the first error message, matching Dart/TS behavior.
+            # Pydantic validation failure during from_json — missing or wrong type.
             first_error = exc.errors()[0]
             field = ".".join(str(loc) for loc in first_error["loc"])
+            message = _format_validation_message(field, first_error["type"])
             return Response(
-                content=json.dumps({"error": f"{field} is required"}),
+                content=json.dumps({"error": message}),
                 status_code=400,
                 media_type=_JSON_CONTENT_TYPE,
             )

--- a/py/tests/openapi/test_module_builder.py
+++ b/py/tests/openapi/test_module_builder.py
@@ -15,19 +15,11 @@ from modular_api.core.usecase import Input, Output, UseCase
 
 
 class _StubInput(Input):
-    def to_json(self) -> dict:
-        return {}
-
-    def to_schema(self) -> dict:
-        return {"type": "object", "properties": {"name": {"type": "string"}}}
+    name: str = ""
 
 
 class _StubOutput(Output):
-    def to_json(self) -> dict:
-        return {"ok": True}
-
-    def to_schema(self) -> dict:
-        return {"type": "object", "properties": {"ok": {"type": "boolean"}}}
+    ok: bool = True
 
     @property
     def status_code(self) -> int:
@@ -189,7 +181,7 @@ class TestModuleBuilderSchemaExtraction:
         assert schemas["output"] == {"type": "object", "properties": {"ok": {"type": "boolean"}}}
 
     def test_fallback_when_factory_raises(self) -> None:
-        """If the dummy factory call fails, empty fallback schemas are used."""
+        """Class-level extraction works even when factory raises."""
 
         def exploding_factory(json: dict) -> _StubUseCase:
             raise RuntimeError("cannot build from empty json")
@@ -198,8 +190,10 @@ class TestModuleBuilderSchemaExtraction:
         builder.usecase("create", exploding_factory)
 
         schemas = api_registry.routes[0].schemas
-        assert schemas["input"] == {}
-        assert schemas["output"] == {}
+        # Strategy 1 (class-level) resolves schemas from the return type hint,
+        # so the factory never needs to be instantiated.
+        assert schemas["input"] == {"type": "object", "properties": {"name": {"type": "string"}}}
+        assert schemas["output"] == {"type": "object", "properties": {"ok": {"type": "boolean"}}}
 
 
 class TestModuleBuilderFluent:

--- a/py/tests/test_auto_schema.py
+++ b/py/tests/test_auto_schema.py
@@ -1,0 +1,67 @@
+"""Tests for auto-schema: Input and Output as BaseModel subclasses."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from modular_api.core.usecase import Input, Output
+
+
+class TestInputIsBaseModel:
+    """Input must inherit from BaseModel so Pydantic drives serialization."""
+
+    def test_input_is_subclass_of_basemodel(self) -> None:
+        assert issubclass(Input, BaseModel)
+
+    def test_input_has_to_json(self) -> None:
+        assert hasattr(Input, "to_json")
+
+    def test_input_has_to_schema(self) -> None:
+        assert hasattr(Input, "to_schema")
+
+    def test_input_has_from_json(self) -> None:
+        assert hasattr(Input, "from_json")
+
+    def test_simple_input_auto_schema(self) -> None:
+        """A minimal Input subclass derives its schema from field declarations."""
+
+        class NameInput(Input):
+            name: str = Field(description="Name to greet")
+
+        schema = NameInput.to_schema()
+        assert schema["type"] == "object"
+        assert "name" in schema["properties"]
+        assert schema["properties"]["name"]["type"] == "string"
+        assert schema["properties"]["name"]["description"] == "Name to greet"
+        assert "name" in schema["required"]
+
+    def test_simple_input_from_json(self) -> None:
+        """from_json() builds an Input instance from a plain dict."""
+
+        class NameInput(Input):
+            name: str
+
+        instance = NameInput.from_json({"name": "Carlos"})
+        assert instance.name == "Carlos"
+
+    def test_simple_input_to_json(self) -> None:
+        """to_json() serializes an Input to a plain dict."""
+
+        class NameInput(Input):
+            name: str
+
+        instance = NameInput(name="Carlos")
+        result = instance.to_json()
+        assert result == {"name": "Carlos"}
+
+    def test_optional_field_schema(self) -> None:
+        """Optional fields are excluded from required[] and marked nullable."""
+
+        class OptInput(Input):
+            required_field: str
+            optional_field: str | None = None
+
+        schema = OptInput.to_schema()
+        assert "required_field" in schema["required"]
+        # optional_field should NOT be in required
+        assert "optional_field" not in schema.get("required", [])

--- a/py/tests/test_auto_schema.py
+++ b/py/tests/test_auto_schema.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 from pydantic import BaseModel, Field
 
 from modular_api.core.usecase import Input, Output
@@ -65,3 +67,50 @@ class TestInputIsBaseModel:
         assert "required_field" in schema["required"]
         # optional_field should NOT be in required
         assert "optional_field" not in schema.get("required", [])
+
+
+class TestManualToSchemaDeprecation:
+    """Overriding to_schema() should emit a DeprecationWarning."""
+
+    def test_manual_to_schema_on_input_emits_warning(self) -> None:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class LegacyInput(Input):
+                name: str
+
+                @classmethod
+                def to_schema(cls) -> dict[str, object]:
+                    return {"type": "object"}
+
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "LegacyInput.to_schema()" in str(w[0].message)
+
+    def test_manual_to_schema_on_output_emits_warning(self) -> None:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class LegacyOutput(Output):
+                message: str
+
+                @property
+                def status_code(self) -> int:
+                    return 200
+
+                @classmethod
+                def to_schema(cls) -> dict[str, object]:
+                    return {"type": "object"}
+
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "LegacyOutput.to_schema()" in str(w[0].message)
+
+    def test_no_warning_without_override(self) -> None:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class CleanInput(Input):
+                name: str
+
+        assert len(w) == 0

--- a/py/tests/test_field_example.py
+++ b/py/tests/test_field_example.py
@@ -1,0 +1,90 @@
+"""Tests for example values in OpenAPI schema — Python SDK.
+
+Verifies _normalize_schema converts Pydantic examples → OpenAPI 3.0.3 example,
+and composes a top-level example from per-field values.
+"""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from modular_api.core.usecase import Input, Output
+
+
+# ── DTOs with example values ──────────────────────────────────
+
+
+class ExampleInput(Input):
+    name: str = Field(description="User name", examples=["Alice"])
+    age: int = Field(description="User age", examples=[30])
+    score: float = Field(description="Score", examples=[9.5])
+    active: bool = Field(description="Active?", examples=[True])
+    tags: list[str] = Field(description="Tags", examples=[["dart", "ts"]])
+
+
+class ExampleOutput(Output):
+    greeting: str = Field(description="Greeting", examples=["Hello Alice"])
+
+    @property
+    def status_code(self) -> int:
+        return 200
+
+
+class NoExampleInput(Input):
+    name: str = Field(description="Just a name")
+
+
+# ── Tests ──────────────────────────────────────────────────────
+
+
+class TestFieldExampleMetadata:
+    """Verify per-property example values in schema."""
+
+    def test_string_field_example(self) -> None:
+        schema = ExampleInput.to_schema()
+        props = schema["properties"]
+        assert props["name"]["example"] == "Alice"
+
+    def test_integer_field_example(self) -> None:
+        schema = ExampleInput.to_schema()
+        props = schema["properties"]
+        assert props["age"]["example"] == 30
+
+    def test_number_field_example(self) -> None:
+        schema = ExampleInput.to_schema()
+        props = schema["properties"]
+        assert props["score"]["example"] == 9.5
+
+    def test_boolean_field_example(self) -> None:
+        schema = ExampleInput.to_schema()
+        props = schema["properties"]
+        assert props["active"]["example"] is True
+
+    def test_array_field_example(self) -> None:
+        schema = ExampleInput.to_schema()
+        props = schema["properties"]
+        assert props["tags"]["example"] == ["dart", "ts"]
+
+
+class TestTopLevelExample:
+    """Verify top-level example object in schema."""
+
+    def test_top_level_example(self) -> None:
+        schema = ExampleInput.to_schema()
+        assert schema["example"] == {
+            "name": "Alice",
+            "age": 30,
+            "score": 9.5,
+            "active": True,
+            "tags": ["dart", "ts"],
+        }
+
+    def test_output_top_level_example(self) -> None:
+        schema = ExampleOutput.to_schema()
+        assert schema["example"] == {"greeting": "Hello Alice"}
+
+    def test_no_example_omits_key(self) -> None:
+        schema = NoExampleInput.to_schema()
+        props = schema["properties"]
+        assert "example" not in props["name"]
+        assert "example" not in schema

--- a/py/tests/test_fromjson_validation.py
+++ b/py/tests/test_fromjson_validation.py
@@ -1,0 +1,130 @@
+"""RED — fromJson must validate required fields and types, returning 400.
+
+fromJson validates structure (field presence + JSON type correctness).
+validate() handles only business rules.
+
+Error message contract (identical across all 3 SDKs for parity):
+  - Missing required field: "Missing required field: {name}"
+  - Wrong JSON type:        "Field '{name}' must be of type {type}"
+"""
+
+import json
+
+import pytest
+from pydantic import Field, ValidationError
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from modular_api.core.usecase import Input, Output, UseCase
+from modular_api.core.usecase_handler import usecase_handler
+
+
+# ── Stubs ─────────────────────────────────────────────────────────────────
+
+
+class StrictInput(Input):
+    name: str = Field(description="Name")
+    age: int = Field(description="Age")
+
+
+class StrictOutput(Output):
+    greeting: str = ""
+
+    @property
+    def status_code(self) -> int:
+        return 200
+
+
+class StrictUseCase(UseCase[StrictInput, StrictOutput]):
+    """Minimal use case with strict string + int fields."""
+
+    def __init__(self, data: dict) -> None:
+        self._input = StrictInput.from_json(data)
+        self._output = StrictOutput()
+
+    @property
+    def input(self) -> StrictInput:
+        return self._input
+
+    @property
+    def output(self) -> StrictOutput:
+        return self._output
+
+    def validate(self) -> str | None:
+        if not self.input.name:
+            return "name is required"
+        return None
+
+    async def execute(self) -> None:
+        self._output = StrictOutput(greeting=f"Hi {self.input.name}, age {self.input.age}")
+
+    def to_json(self) -> dict:
+        return self._output.to_json()
+
+
+def _app():
+    return Starlette(routes=[
+        Route("/strict", usecase_handler(StrictUseCase), methods=["POST"]),
+    ])
+
+
+# ── Unit: from_json strict type validation ────────────────────────────────
+
+
+class TestFromJsonStrictValidation:
+    """from_json rejects missing fields and wrong JSON types."""
+
+    def test_missing_required_field_raises_validation_error(self) -> None:
+        with pytest.raises(ValidationError):
+            StrictInput.from_json({})
+
+    def test_wrong_type_for_string_field_raises_validation_error(self) -> None:
+        """Sending int where str expected must fail in strict mode."""
+        with pytest.raises(ValidationError):
+            StrictInput.from_json({"name": 123, "age": 25})
+
+    def test_wrong_type_for_int_field_raises_validation_error(self) -> None:
+        """Sending str where int expected must fail in strict mode."""
+        with pytest.raises(ValidationError):
+            StrictInput.from_json({"name": "Alice", "age": "twenty-five"})
+
+    def test_valid_json_succeeds(self) -> None:
+        result = StrictInput.from_json({"name": "Alice", "age": 25})
+        assert result.name == "Alice"
+        assert result.age == 25
+
+
+# ── Integration: handler returns 400 with specific error messages ─────────
+
+
+class TestFromJsonHandlerErrors:
+    """Handler returns 400 with field-specific error messages."""
+
+    def test_missing_field_returns_400_with_field_name(self) -> None:
+        client = TestClient(_app())
+        resp = client.post("/strict", json={})
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["error"] == "Missing required field: name"
+
+    def test_wrong_type_returns_400_with_expected_type(self) -> None:
+        client = TestClient(_app())
+        resp = client.post("/strict", json={"name": 123, "age": 25})
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["error"] == "Field 'name' must be of type string"
+
+    def test_wrong_int_type_returns_400_with_expected_type(self) -> None:
+        client = TestClient(_app())
+        resp = client.post("/strict", json={"name": "Alice", "age": "not-a-number"})
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["error"] == "Field 'age' must be of type integer"
+
+    def test_valid_json_returns_200(self) -> None:
+        client = TestClient(_app())
+        resp = client.post("/strict", json={"name": "Alice", "age": 25})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["greeting"] == "Hi Alice, age 25"

--- a/py/tests/test_modular_api.py
+++ b/py/tests/test_modular_api.py
@@ -18,19 +18,11 @@ from modular_api.core.usecase import Input, Output, UseCase
 
 
 class _PingInput(Input):
-    def to_json(self) -> dict:
-        return {}
-
-    def to_schema(self) -> dict:
-        return {"type": "object", "properties": {}}
+    pass
 
 
 class _PingOutput(Output):
-    def to_json(self) -> dict:
-        return {"pong": True}
-
-    def to_schema(self) -> dict:
-        return {"type": "object", "properties": {"pong": {"type": "boolean"}}}
+    pong: bool = True
 
     @property
     def status_code(self) -> int:

--- a/py/tests/test_module_builder.py
+++ b/py/tests/test_module_builder.py
@@ -7,58 +7,30 @@ must not destroy the already-computable Input schema.
 
 from __future__ import annotations
 
+from pydantic import Field
+
 from modular_api.core.module_builder import ModuleBuilder
 from modular_api.core.registry import api_registry
 from modular_api.core.usecase import Input, Output, UseCase
 
 
-# ── Stubs: Output uninitialized (mirrors real HelloWorld pattern) ─────────
+# ── Stubs: Using new BaseModel-based DTOs ─────────────────────
 
 
 class StubInput(Input):
-    def __init__(self, *, name: str) -> None:
-        self._name = name
-
-    @classmethod
-    def from_json(cls, json: dict) -> StubInput:
-        return cls(name=str(json.get("name", "")))
-
-    def to_json(self) -> dict:
-        return {"name": self._name}
-
-    def to_schema(self) -> dict:
-        return {
-            "type": "object",
-            "properties": {
-                "name": {"type": "string", "description": "Name to greet"},
-            },
-            "required": ["name"],
-        }
+    name: str = Field(description="Name to greet")
 
 
 class StubOutput(Output):
-    def __init__(self, *, message: str) -> None:
-        self._message = message
+    message: str = Field(description="Greeting message")
 
     @property
     def status_code(self) -> int:
         return 200
 
-    def to_json(self) -> dict:
-        return {"message": self._message}
 
-    def to_schema(self) -> dict:
-        return {
-            "type": "object",
-            "properties": {
-                "message": {"type": "string", "description": "Greeting message"},
-            },
-            "required": ["message"],
-        }
-
-
-class UninitializedOutputUseCase(UseCase[StubInput, StubOutput]):
-    """UseCase with output initialised to a default — matches Dart pattern."""
+class StubUseCase(UseCase[StubInput, StubOutput]):
+    """UseCase with BaseModel-based DTOs."""
 
     def __init__(self, input_dto: StubInput) -> None:
         self._input = input_dto
@@ -77,16 +49,16 @@ class UninitializedOutputUseCase(UseCase[StubInput, StubOutput]):
         self._output = value
 
     @classmethod
-    def from_json(cls, json: dict) -> UninitializedOutputUseCase:
+    def from_json(cls, json: dict) -> StubUseCase:
         return cls(StubInput.from_json(json))
 
     def validate(self) -> str | None:
-        if not self.input._name:
+        if not self.input.name:
             return "name is required"
         return None
 
     async def execute(self) -> None:
-        self.output = StubOutput(message=f"Hello, {self.input._name}!")
+        self.output = StubOutput(message=f"Hello, {self.input.name}!")
 
     def to_json(self) -> dict:
         return self.output.to_json()
@@ -104,28 +76,24 @@ class TestExtractSchemas:
     def teardown_method(self) -> None:
         api_registry.clear()
 
-    def test_input_schema_has_properties_when_output_uninitialized(self) -> None:
-        """Input schema must be captured even if Output extraction were to fail."""
-        schemas = ModuleBuilder._extract_schemas(UninitializedOutputUseCase.from_json)
+    def test_input_schema_has_properties(self) -> None:
+        schemas = ModuleBuilder._extract_schemas(StubUseCase.from_json)
         assert "name" in schemas["input"].get("properties", {}), (
             "Input schema lost its properties"
         )
 
     def test_output_schema_has_properties(self) -> None:
-        """Output schema must include properties.message when initialised to default."""
-        schemas = ModuleBuilder._extract_schemas(UninitializedOutputUseCase.from_json)
+        schemas = ModuleBuilder._extract_schemas(StubUseCase.from_json)
         assert "message" in schemas["output"].get("properties", {}), (
             "Output schema must have properties.message"
         )
 
     def test_input_schema_name_type_is_string(self) -> None:
-        """Input schema properties.name.type must be 'string'."""
-        schemas = ModuleBuilder._extract_schemas(UninitializedOutputUseCase.from_json)
-        name_prop = schemas["input"].get("properties", {}).get("name", {})
-        assert name_prop.get("type") == "string"
+        schemas = ModuleBuilder._extract_schemas(StubUseCase.from_json)
+        name_prop = schemas["input"]["properties"]["name"]  # type: ignore[index]
+        assert name_prop["type"] == "string"
 
     def test_output_schema_message_type_is_string(self) -> None:
-        """Output schema properties.message.type must be 'string'."""
-        schemas = ModuleBuilder._extract_schemas(UninitializedOutputUseCase.from_json)
-        message_prop = schemas["output"].get("properties", {}).get("message", {})
-        assert message_prop.get("type") == "string"
+        schemas = ModuleBuilder._extract_schemas(StubUseCase.from_json)
+        msg_prop = schemas["output"]["properties"]["message"]  # type: ignore[index]
+        assert msg_prop["type"] == "string"

--- a/py/tests/test_schema_conformance.py
+++ b/py/tests/test_schema_conformance.py
@@ -1,0 +1,37 @@
+"""Conformance tests: HelloInput/HelloOutput schemas match shared fixtures."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+# Import the example DTOs directly from the example module
+import sys
+
+# Add the example directory so we can import from it
+_EXAMPLE_DIR = Path(__file__).resolve().parent.parent / "example"
+sys.path.insert(0, str(_EXAMPLE_DIR))
+
+from example import HelloInput, HelloOutput  # type: ignore[import-untyped]
+
+_FIXTURES = Path(__file__).resolve().parent.parent.parent / "tests" / "fixtures"
+
+
+def _load_fixture(name: str) -> dict[str, object]:
+    return json.loads((_FIXTURES / name).read_text(encoding="utf-8"))
+
+
+class TestSchemaConformance:
+    """Verify our example DTOs produce schemas identical to the shared fixtures."""
+
+    def test_hello_input_schema_matches_fixture(self) -> None:
+        fixture = _load_fixture("hello_input_schema.json")
+        instance = HelloInput(name="test")
+        assert instance.to_schema() == fixture
+
+    def test_hello_output_schema_matches_fixture(self) -> None:
+        fixture = _load_fixture("hello_output_schema.json")
+        instance = HelloOutput(message="test")
+        assert instance.to_schema() == fixture

--- a/py/tests/test_schema_conformance.py
+++ b/py/tests/test_schema_conformance.py
@@ -5,12 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
-# Import the example DTOs directly from the example module
 import sys
 
-# Add the example directory so we can import from it
 _EXAMPLE_DIR = Path(__file__).resolve().parent.parent / "example"
 sys.path.insert(0, str(_EXAMPLE_DIR))
 
@@ -28,10 +24,27 @@ class TestSchemaConformance:
 
     def test_hello_input_schema_matches_fixture(self) -> None:
         fixture = _load_fixture("hello_input_schema.json")
-        instance = HelloInput(name="test")
-        assert instance.to_schema() == fixture
+        # to_schema() is now a classmethod — call on class, not instance
+        assert HelloInput.to_schema() == fixture
 
     def test_hello_output_schema_matches_fixture(self) -> None:
         fixture = _load_fixture("hello_output_schema.json")
-        instance = HelloOutput(message="test")
-        assert instance.to_schema() == fixture
+        assert HelloOutput.to_schema() == fixture
+
+    def test_hello_input_from_json(self) -> None:
+        """from_json populates fields correctly."""
+        instance = HelloInput.from_json({"name": "Carlos"})
+        assert instance.name == "Carlos"
+
+    def test_hello_input_to_json(self) -> None:
+        """to_json serializes correctly."""
+        instance = HelloInput(name="Carlos")
+        assert instance.to_json() == {"name": "Carlos"}
+
+    def test_hello_output_from_json(self) -> None:
+        instance = HelloOutput.from_json({"message": "Hello!"})
+        assert instance.message == "Hello!"
+
+    def test_hello_output_to_json(self) -> None:
+        instance = HelloOutput(message="Hello!")
+        assert instance.to_json() == {"message": "Hello!"}

--- a/py/tests/test_usecase.py
+++ b/py/tests/test_usecase.py
@@ -13,45 +13,18 @@ from modular_api.core.usecase import Input, Output, UseCase
 class SumInput(Input):
     """Two integers to sum."""
 
-    def __init__(self, *, a: int | None, b: int | None) -> None:
-        self.a = a
-        self.b = b
-
-    def to_json(self) -> dict[str, object]:
-        return {"a": self.a, "b": self.b}
-
-    def to_schema(self) -> dict[str, object]:
-        return {
-            "type": "object",
-            "properties": {
-                "a": {"type": "integer"},
-                "b": {"type": "integer"},
-            },
-            "required": ["a", "b"],
-        }
+    a: int | None = None
+    b: int | None = None
 
 
 class SumOutput(Output):
     """Result of the sum operation."""
 
-    def __init__(self, *, resultado: int) -> None:
-        self.resultado = resultado
+    resultado: int = 0
 
     @property
     def status_code(self) -> int:
         return 200
-
-    def to_json(self) -> dict[str, object]:
-        return {"resultado": self.resultado}
-
-    def to_schema(self) -> dict[str, object]:
-        return {
-            "type": "object",
-            "properties": {
-                "resultado": {"type": "integer"},
-            },
-            "required": ["resultado"],
-        }
 
 
 class SumUseCase(UseCase[SumInput, SumOutput]):
@@ -89,27 +62,27 @@ class SumUseCase(UseCase[SumInput, SumOutput]):
 
 
 class TestInput:
-    def test_cannot_instantiate_directly(self) -> None:
-        with pytest.raises(TypeError):
-            Input()  # type: ignore[abstract]
+    def test_bare_input_is_instantiable(self) -> None:
+        """Input with no fields can be instantiated (it's a BaseModel now)."""
+        instance = Input()
+        assert instance.to_json() == {}
 
     def test_concrete_input_to_json(self) -> None:
         inp = SumInput(a=3, b=4)
         assert inp.to_json() == {"a": 3, "b": 4}
 
     def test_concrete_input_to_schema(self) -> None:
-        inp = SumInput(a=1, b=2)
-        schema = inp.to_schema()
+        schema = SumInput.to_schema()
         assert schema["type"] == "object"
         assert "a" in schema["properties"]  # type: ignore[operator]
-        assert schema["required"] == ["a", "b"]
 
 
 # ── Output tests ────────────────────────────────────────────────────
 
 
 class TestOutput:
-    def test_cannot_instantiate_directly(self) -> None:
+    def test_cannot_instantiate_without_status_code(self) -> None:
+        """Output requires status_code — subclass must define it."""
         with pytest.raises(TypeError):
             Output()  # type: ignore[abstract]
 
@@ -118,8 +91,7 @@ class TestOutput:
         assert out.to_json() == {"resultado": 7}
 
     def test_concrete_output_to_schema(self) -> None:
-        out = SumOutput(resultado=0)
-        schema = out.to_schema()
+        schema = SumOutput.to_schema()
         assert schema["type"] == "object"
         assert "resultado" in schema["properties"]  # type: ignore[operator]
 

--- a/py/tests/test_usecase_handler.py
+++ b/py/tests/test_usecase_handler.py
@@ -16,29 +16,11 @@ from modular_api.core.usecase_handler import LOGGER_STATE_KEY, usecase_handler
 
 
 class GreetInput(Input):
-    def __init__(self, name: str) -> None:
-        self._name = name
-
-    def to_json(self) -> dict:
-        return {"name": self._name}
-
-    def to_schema(self) -> dict:
-        return {"type": "object", "properties": {"name": {"type": "string"}}}
-
-    @property
-    def status_code(self) -> int:
-        return 200
+    name: str = ""
 
 
 class GreetOutput(Output):
-    def __init__(self, greeting: str = "") -> None:
-        self._greeting = greeting
-
-    def to_json(self) -> dict:
-        return {"greeting": self._greeting}
-
-    def to_schema(self) -> dict:
-        return {"type": "object", "properties": {"greeting": {"type": "string"}}}
+    greeting: str = ""
 
     @property
     def status_code(self) -> int:
@@ -49,7 +31,7 @@ class GreetUseCase(UseCase[GreetInput, GreetOutput]):
     """Says hello — happy path."""
 
     def __init__(self, data: dict) -> None:
-        self._input = GreetInput(name=data.get("name", ""))
+        self._input = GreetInput.from_json(data)
         self._output = GreetOutput()
 
     @property
@@ -61,12 +43,12 @@ class GreetUseCase(UseCase[GreetInput, GreetOutput]):
         return self._output
 
     def validate(self) -> str | None:
-        if not self._input._name:
+        if not self._input.name:
             return "name is required"
         return None
 
     async def execute(self) -> None:
-        self._output = GreetOutput(greeting=f"Hello, {self._input._name}!")
+        self._output = GreetOutput(greeting=f"Hello, {self._input.name}!")
 
     def to_json(self) -> dict:
         return self._output.to_json()
@@ -76,7 +58,7 @@ class FailingUseCase(UseCase[GreetInput, GreetOutput]):
     """Raises UseCaseException during execute."""
 
     def __init__(self, data: dict) -> None:
-        self._input = GreetInput(name=data.get("name", ""))
+        self._input = GreetInput.from_json(data)
         self._output = GreetOutput()
 
     @property

--- a/tests/fixtures/hello_input_schema.json
+++ b/tests/fixtures/hello_input_schema.json
@@ -1,0 +1,7 @@
+{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string", "description": "Name to greet" }
+  },
+  "required": ["name"]
+}

--- a/tests/fixtures/hello_input_schema.json
+++ b/tests/fixtures/hello_input_schema.json
@@ -1,7 +1,8 @@
 {
   "type": "object",
   "properties": {
-    "name": { "type": "string", "description": "Name to greet" }
+    "name": { "type": "string", "description": "Name to greet", "example": "World" }
   },
-  "required": ["name"]
+  "required": ["name"],
+  "example": { "name": "World" }
 }

--- a/tests/fixtures/hello_output_schema.json
+++ b/tests/fixtures/hello_output_schema.json
@@ -1,0 +1,7 @@
+{
+  "type": "object",
+  "properties": {
+    "message": { "type": "string", "description": "Greeting message" }
+  },
+  "required": ["message"]
+}

--- a/tests/fixtures/hello_output_schema.json
+++ b/tests/fixtures/hello_output_schema.json
@@ -1,7 +1,8 @@
 {
   "type": "object",
   "properties": {
-    "message": { "type": "string", "description": "Greeting message" }
+    "message": { "type": "string", "description": "Greeting message", "example": "Hello, World!" }
   },
-  "required": ["message"]
+  "required": ["message"],
+  "example": { "message": "Hello, World!" }
 }

--- a/tests/integration_test/parity_test.ps1
+++ b/tests/integration_test/parity_test.ps1
@@ -371,6 +371,7 @@ function Test-UseCaseMissingBody {
     <#
     .SYNOPSIS
         POST /api/greetings/hello with empty object → 400.
+        fromJson validates required fields — returns "Missing required field: name".
     #>
     param([string]$ImplName, [string]$BaseUrl)
 
@@ -387,8 +388,35 @@ function Test-UseCaseMissingBody {
 
     $json = $response.Body | ConvertFrom-Json
 
-    Assert-True ($json.error -eq 'name is required') `
-        "$ImplName POST hello (empty object) error is 'name is required'"
+    Assert-True ($json.error -eq 'Missing required field: name') `
+        "$ImplName POST hello (empty object) error is 'Missing required field: name'"
+
+    return $json
+}
+
+function Test-UseCaseWrongType {
+    <#
+    .SYNOPSIS
+        POST /api/greetings/hello with wrong type → 400.
+        fromJson validates JSON types — returns "Field 'name' must be of type string".
+    #>
+    param([string]$ImplName, [string]$BaseUrl)
+
+    $response = Invoke-Endpoint -Uri "$BaseUrl/api/greetings/hello" `
+        -Method POST -Body '{"name":123}'
+
+    Assert-True ($response.StatusCode -eq 400) `
+        "$ImplName POST hello (wrong type) → 400"
+
+    if ($response.StatusCode -notin @(400, 422)) {
+        Write-Host "    Body was: $($response.Body)" -ForegroundColor DarkGray
+        return $null
+    }
+
+    $json = $response.Body | ConvertFrom-Json
+
+    Assert-True ($json.error -eq "Field 'name' must be of type string") `
+        "$ImplName POST hello (wrong type) error is 'Field ''name'' must be of type string'"
 
     return $json
 }
@@ -540,6 +568,7 @@ function Test-Implementation {
         UseCaseSuccess     = Test-UseCaseSuccess           -ImplName $Name -BaseUrl $BaseUrl
         UseCaseEmptyName   = Test-UseCaseValidationFailure -ImplName $Name -BaseUrl $BaseUrl
         UseCaseMissingBody = Test-UseCaseMissingBody       -ImplName $Name -BaseUrl $BaseUrl
+        UseCaseWrongType   = Test-UseCaseWrongType         -ImplName $Name -BaseUrl $BaseUrl
         OpenApiJson        = Test-OpenApiJson              -ImplName $Name -BaseUrl $BaseUrl
         OpenApiYaml        = Test-OpenApiYaml              -ImplName $Name -BaseUrl $BaseUrl
     }
@@ -614,6 +643,17 @@ function Compare-Implementations {
         Write-Fail 'UseCase missing-body error identical across implementations (skipped — missing data)'
         $script:totalTests++; $script:failedTests++
         $script:failures += 'UseCase missing-body error parity skipped — missing data'
+    }
+
+    if ($Dart.UseCaseWrongType -and $TypeScript.UseCaseWrongType -and $Python.UseCaseWrongType) {
+        Assert-True (
+            ($Dart.UseCaseWrongType.error -eq $TypeScript.UseCaseWrongType.error) -and
+            ($Dart.UseCaseWrongType.error -eq $Python.UseCaseWrongType.error)
+        ) 'UseCase wrong-type error identical across implementations'
+    } else {
+        Write-Fail 'UseCase wrong-type error identical across implementations (skipped — missing data)'
+        $script:totalTests++; $script:failedTests++
+        $script:failures += 'UseCase wrong-type error parity skipped — missing data'
     }
 
     # ── OpenAPI JSON structural parity ───────────────────────────────────────

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -7,6 +7,23 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+## [0.4.2] - 2026-03-12
+
+### Added
+
+- **Auto-schema generation** — `Input` and `Output` DTOs derive OpenAPI 3.0.3 schemas automatically from `@Field` decorator metadata
+- `@Field` decorators — Stage 3 decorators: `.string()`, `.integer()`, `.number()`, `.boolean()`, `.array()`, `.optional()`
+- `Symbol.metadata` polyfill for Node.js < 22 compatibility
+- `getFieldMetadata()` / `FieldMeta` / `FieldOptions` — public API for reading decorator metadata
+- `Input` / `Output` base classes provide concrete `toSchema()`, `toJson()`, `fromJson()` from decorator metadata
+- Cross-language schema conformance tests against shared JSON fixtures
+
+### Changed
+
+- TypeScript target changed from `ES2020` to `ES2022` for Stage 3 decorator support
+- Manual `toSchema()` override is deprecated — use `@Field` decorators instead (removal in v0.5.0)
+- `_extractSchemas` simplified — decorator metadata resolves schemas without manual methods
+
 ## [0.4.1] - 2026-03-12
 
 ### Removed

--- a/ts/README.md
+++ b/ts/README.md
@@ -47,7 +47,7 @@ See `example/example.ts` for the full implementation including Input, Output, Us
 ## Features
 
 - `UseCase<I, O>` — pure business logic, no HTTP concerns
-- `Input` / `Output` — DTOs with `toJson()` and `toSchema()` for automatic OpenAPI
+- `Input` / `Output` — DTOs with automatic OpenAPI schema generation via `@Field` decorators
 - `Output.statusCode` — custom HTTP status codes per response
 - `UseCaseException` — structured error handling (status code, message, error code, details)
 - `ModularApi` + `ModuleBuilder` — module registration and routing

--- a/ts/example/example.ts
+++ b/ts/example/example.ts
@@ -41,9 +41,8 @@ class HelloInput extends Input {
   name!: string;
 
   static fromJson(json: Record<string, unknown>): HelloInput {
-    Input.validateJson(json, HelloInput);
     const instance = new HelloInput();
-    instance.name = json['name'] as string;
+    instance.name = (json['name'] ?? '').toString();
     return instance;
   }
 }
@@ -59,9 +58,8 @@ class HelloOutput extends Output {
   }
 
   static fromJson(json: Record<string, unknown>): HelloOutput {
-    Input.validateJson(json, HelloOutput);
     const instance = new HelloOutput();
-    instance.message = json['message'] as string;
+    instance.message = (json['message'] ?? '').toString();
     return instance;
   }
 }

--- a/ts/example/example.ts
+++ b/ts/example/example.ts
@@ -41,8 +41,9 @@ class HelloInput extends Input {
   name!: string;
 
   static fromJson(json: Record<string, unknown>): HelloInput {
+    Input.validateJson(json, HelloInput);
     const instance = new HelloInput();
-    instance.name = (json['name'] ?? '').toString();
+    instance.name = json['name'] as string;
     return instance;
   }
 }
@@ -58,8 +59,9 @@ class HelloOutput extends Output {
   }
 
   static fromJson(json: Record<string, unknown>): HelloOutput {
+    Input.validateJson(json, HelloOutput);
     const instance = new HelloOutput();
-    instance.message = (json['message'] ?? '').toString();
+    instance.message = json['message'] as string;
     return instance;
   }
 }

--- a/ts/example/example.ts
+++ b/ts/example/example.ts
@@ -23,6 +23,7 @@ import {
   HealthCheck,
   HealthCheckResult,
   LogLevel,
+  Field,
 } from '../src/index';
 
 // ─── Module Builder ───────────────────────────────────────────────────────────
@@ -35,50 +36,31 @@ function buildGreetingsModule(m: ModuleBuilder): void {
 
 // ─── Input DTO ────────────────────────────────────────────────────────────────
 
-class HelloInput implements Input {
-  constructor(readonly name: string) {}
+class HelloInput extends Input {
+  @Field.string({ description: 'Name to greet' })
+  name!: string;
 
   static fromJson(json: Record<string, unknown>): HelloInput {
-    const name = (json['name'] ?? '').toString();
-    return new HelloInput(name);
-  }
-
-  toJson() {
-    return { name: this.name };
-  }
-
-  toSchema() {
-    return {
-      type: 'object',
-      properties: {
-        name: { type: 'string', description: 'Name to greet' },
-      },
-      required: ['name'],
-    };
+    const instance = new HelloInput();
+    instance.name = (json['name'] ?? '').toString();
+    return instance;
   }
 }
 
 // ─── Output DTO ───────────────────────────────────────────────────────────────
 
-class HelloOutput implements Output {
-  constructor(readonly message: string) {}
+class HelloOutput extends Output {
+  @Field.string({ description: 'Greeting message' })
+  message!: string;
 
   get statusCode() {
     return 200;
   }
 
-  toJson() {
-    return { message: this.message };
-  }
-
-  toSchema() {
-    return {
-      type: 'object',
-      properties: {
-        message: { type: 'string', description: 'Greeting message' },
-      },
-      required: ['message'],
-    };
+  static fromJson(json: Record<string, unknown>): HelloOutput {
+    const instance = new HelloOutput();
+    instance.message = (json['message'] ?? '').toString();
+    return instance;
   }
 }
 
@@ -91,7 +73,7 @@ class HelloWorld implements UseCase<HelloInput, HelloOutput> {
 
   constructor(input: HelloInput) {
     this.input = input;
-    this.output = new HelloOutput('');
+    this.output = new HelloOutput();
   }
 
   static fromJson(json: Record<string, unknown>): HelloWorld {
@@ -107,7 +89,9 @@ class HelloWorld implements UseCase<HelloInput, HelloOutput> {
 
   async execute(): Promise<void> {
     this.logger?.info(`Greeting user: ${this.input.name}`);
-    this.output = new HelloOutput(`Hello, ${this.input.name}!`);
+    const output = new HelloOutput();
+    output.message = `Hello, ${this.input.name}!`;
+    this.output = output;
   }
 
   toJson(): Record<string, unknown> {

--- a/ts/example/example.ts
+++ b/ts/example/example.ts
@@ -24,7 +24,6 @@ import {
   HealthCheckResult,
   LogLevel,
   Field,
-  InputValidationError,
 } from '../src/index';
 
 // ─── Module Builder ───────────────────────────────────────────────────────────
@@ -32,10 +31,7 @@ import {
 //   src/modules/greetings/greetings_builder.ts
 
 function buildGreetingsModule(m: ModuleBuilder): void {
-  m.usecase('hello', HelloWorld.fromJson, {
-    inputType: HelloInput,
-    outputType: HelloOutput,
-  });
+  m.usecase('hello', HelloWorld.fromJson);
 }
 
 // ─── Input DTO ────────────────────────────────────────────────────────────────
@@ -44,15 +40,9 @@ class HelloInput extends Input {
   @Field.string({ description: 'Name to greet' })
   name!: string;
 
-  /**
-   * Validates required fields and correct types before assignment.
-   * Throws {@link InputValidationError} on structural violations.
-   * Business-rule validation belongs in {@link HelloWorld.validate}.
-   */
   static fromJson(json: Record<string, unknown>): HelloInput {
-    Input.validateJson(json, HelloInput);
     const instance = new HelloInput();
-    instance.name = json['name'] as string;
+    instance.name = (json['name'] ?? '').toString();
     return instance;
   }
 }
@@ -69,7 +59,7 @@ class HelloOutput extends Output {
 
   static fromJson(json: Record<string, unknown>): HelloOutput {
     const instance = new HelloOutput();
-    instance.message = (json['message'] ?? '') as string;
+    instance.message = (json['message'] ?? '').toString();
     return instance;
   }
 }

--- a/ts/example/example.ts
+++ b/ts/example/example.ts
@@ -31,18 +31,23 @@ import {
 //   src/modules/greetings/greetings_builder.ts
 
 function buildGreetingsModule(m: ModuleBuilder): void {
-  m.usecase('hello', HelloWorld.fromJson);
+  m.usecase('hello', HelloWorld.fromJson, {
+    inputClass: HelloInput,
+    outputClass: HelloOutput,
+  });
 }
 
 // ─── Input DTO ────────────────────────────────────────────────────────────────
 
 class HelloInput extends Input {
-  @Field.string({ description: 'Name to greet' })
+  @Field.string({ description: 'Name to greet', example: 'World' })
   name!: string;
 
+  /// Strict factory — no coercion, no defaults.
+  /// Pre-validation in the handler ensures data is valid before this runs.
   static fromJson(json: Record<string, unknown>): HelloInput {
     const instance = new HelloInput();
-    instance.name = (json['name'] ?? '').toString();
+    instance.name = json['name'] as string;
     return instance;
   }
 }
@@ -50,17 +55,11 @@ class HelloInput extends Input {
 // ─── Output DTO ───────────────────────────────────────────────────────────────
 
 class HelloOutput extends Output {
-  @Field.string({ description: 'Greeting message' })
+  @Field.string({ description: 'Greeting message', example: 'Hello, World!' })
   message!: string;
 
   get statusCode() {
     return 200;
-  }
-
-  static fromJson(json: Record<string, unknown>): HelloOutput {
-    const instance = new HelloOutput();
-    instance.message = (json['message'] ?? '').toString();
-    return instance;
   }
 }
 

--- a/ts/example/example.ts
+++ b/ts/example/example.ts
@@ -136,8 +136,4 @@ if (api.metrics) {
 
 api.module('greetings', buildGreetingsModule);
 
-api.serve({ port }).then(() => {
-  console.log('====================================');
-  console.log(`API  → http://localhost:${port}/api/greetings/hello`);
-  console.log('====================================');
-});
+api.serve({ port });

--- a/ts/example/example.ts
+++ b/ts/example/example.ts
@@ -24,6 +24,7 @@ import {
   HealthCheckResult,
   LogLevel,
   Field,
+  InputValidationError,
 } from '../src/index';
 
 // ─── Module Builder ───────────────────────────────────────────────────────────
@@ -31,7 +32,10 @@ import {
 //   src/modules/greetings/greetings_builder.ts
 
 function buildGreetingsModule(m: ModuleBuilder): void {
-  m.usecase('hello', HelloWorld.fromJson);
+  m.usecase('hello', HelloWorld.fromJson, {
+    inputType: HelloInput,
+    outputType: HelloOutput,
+  });
 }
 
 // ─── Input DTO ────────────────────────────────────────────────────────────────
@@ -40,9 +44,15 @@ class HelloInput extends Input {
   @Field.string({ description: 'Name to greet' })
   name!: string;
 
+  /**
+   * Validates required fields and correct types before assignment.
+   * Throws {@link InputValidationError} on structural violations.
+   * Business-rule validation belongs in {@link HelloWorld.validate}.
+   */
   static fromJson(json: Record<string, unknown>): HelloInput {
+    Input.validateJson(json, HelloInput);
     const instance = new HelloInput();
-    instance.name = (json['name'] ?? '').toString();
+    instance.name = json['name'] as string;
     return instance;
   }
 }
@@ -59,7 +69,7 @@ class HelloOutput extends Output {
 
   static fromJson(json: Record<string, unknown>): HelloOutput {
     const instance = new HelloOutput();
-    instance.message = (json['message'] ?? '').toString();
+    instance.message = (json['message'] ?? '') as string;
     return instance;
   }
 }

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macss/modular-api",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Use-case-centric toolkit for building modular APIs with Express. Define UseCase classes (input → validate → execute → output), connect them to HTTP routes, and expose Swagger/OpenAPI documentation automatically.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/ts/src/core/input_validation_error.ts
+++ b/ts/src/core/input_validation_error.ts
@@ -1,0 +1,23 @@
+// ============================================================
+// core/input_validation_error.ts
+// Thrown by Input.validateJson when required fields are missing
+// or have the wrong JSON type.
+//
+// Error message contract (identical across all 3 SDKs for parity):
+//   - "Missing required field: {name}"
+//   - "Field '{name}' must be of type {type}"
+// ============================================================
+
+/**
+ * Signals that the raw JSON payload failed structural validation
+ * (missing required field or wrong JSON type).
+ *
+ * The handler catches this and returns HTTP 400 with `{ error: message }`.
+ * Business-rule validation belongs in `UseCase.validate()` instead.
+ */
+export class InputValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InputValidationError';
+  }
+}

--- a/ts/src/core/module_builder.ts
+++ b/ts/src/core/module_builder.ts
@@ -6,7 +6,7 @@
 
 import { Router } from 'express';
 import type { Input, Output, UseCaseFactory } from './usecase';
-import { UseCase } from './usecase';
+import { UseCase, buildSchemaFromMetadata } from './usecase';
 import { useCaseHandler } from './usecase_handler';
 import { apiRegistry } from './registry';
 import { getFieldMetadata } from './schema/field';
@@ -18,6 +18,21 @@ export interface UseCaseOptions {
   method?: HttpMethod;
   summary?: string;
   description?: string;
+
+  /**
+   * Input DTO class constructor (e.g. `HelloInput`).
+   * When provided, schema is extracted from `@Field` decorator metadata
+   * without calling `factory({})` — zero instantiation, zero concurrency risk.
+   *
+   * Required when `fromJson` validates input (the recommended pattern).
+   */
+  inputType?: abstract new (...args: unknown[]) => Input;
+  /**
+   * Output DTO class constructor (e.g. `HelloOutput`).
+   * Same benefit as `inputType` — schema extracted from class metadata.
+   */
+  outputType?: abstract new (...args: unknown[]) => Output;
+
   /** Override input schema for OpenAPI (if fromJson fails with empty data) */
   inputSchema?: Record<string, unknown>;
   /** Override output schema for OpenAPI (if fromJson fails with empty data) */
@@ -61,7 +76,7 @@ export class ModuleBuilder {
     factory: UseCaseFactory<I, O>,
     options: UseCaseOptions = {},
   ): this {
-    const { method = 'POST', summary, description, inputSchema, outputSchema } = options;
+    const { method = 'POST', summary, description, inputType, outputType, inputSchema, outputSchema } = options;
 
     // Normalize name: trim and remove leading slash
     const cleanName = name.trim().replace(/^\//, '');
@@ -71,8 +86,8 @@ export class ModuleBuilder {
     // Mount the Express handler
     this.router[methodL](subPath, useCaseHandler(factory));
 
-    // Try to capture schemas via dummy factory call, or use overrides
-    const extracted = this._extractSchemas(factory);
+    // Try to capture schemas: explicit types → decorator metadata → factory({}) fallback
+    const extracted = this._extractSchemas(factory, inputType, outputType);
     const schemas = {
       input: inputSchema ?? extracted.input,
       output: outputSchema ?? extracted.output,
@@ -100,37 +115,46 @@ export class ModuleBuilder {
    * Capture Input and Output schemas from decorator metadata or a dummy factory call.
    *
    * Strategy (in order of preference):
-   * 1. Class-level: inspect factory → UseCase class → Input/Output type args
-   *    → @Field metadata → build schema without instantiation.
-   * 2. Fallback: call factory({}) and invoke toSchema() on the result (legacy).
+   * 1. Class metadata: use `@Field` decorator metadata from the explicit
+   *    inputType/outputType class constructors — no instantiation needed.
+   *    Required when `fromJson` validates input (the recommended pattern).
+   * 2. Fallback: call factory({}) and invoke toSchema() on the result.
+   *    Works when `fromJson` is tolerant of empty data (legacy pattern).
    */
   private _extractSchemas<I extends Input, O extends Output>(
     factory: UseCaseFactory<I, O>,
+    inputType?: abstract new (...args: unknown[]) => Input,
+    outputType?: abstract new (...args: unknown[]) => Output,
   ): { input: Record<string, unknown>; output: Record<string, unknown> } {
-    // --- Strategy 1: class-level via factory({}) instance types ---
-    // For bound static methods, we can get the UseCase class and try
-    // to extract schemas from the Input/Output via decorator metadata.
-    let instance: UseCase<I, O> | undefined;
-    try {
-      instance = factory({});
-    } catch {
-      // Factory failed — that's fine, we still try class-level.
-    }
-
     let input: Record<string, unknown> = {};
     let output: Record<string, unknown> = {};
 
-    if (instance) {
+    // --- Strategy 1: class metadata — zero instantiation, zero concurrency risk ---
+    if (inputType) {
+      const fields = getFieldMetadata(inputType);
+      if (fields.length > 0) input = buildSchemaFromMetadata(fields);
+    }
+    if (outputType) {
+      const fields = getFieldMetadata(outputType);
+      if (fields.length > 0) output = buildSchemaFromMetadata(fields);
+    }
+
+    // --- Strategy 2: factory({}) fallback for backward compatibility ---
+    if (Object.keys(input).length === 0 || Object.keys(output).length === 0) {
+      let instance: UseCase<I, O> | undefined;
       try {
-        input = instance.input.toSchema();
+        instance = factory({});
       } catch {
-        // toSchema() not available — keep empty.
+        // factory({}) failed — keep partial results from Strategy 1.
       }
 
-      try {
-        output = instance.output.toSchema();
-      } catch {
-        // Output not initialised until execute() — expected for most UseCases.
+      if (instance) {
+        if (Object.keys(input).length === 0) {
+          try { input = instance.input.toSchema(); } catch { /* keep empty */ }
+        }
+        if (Object.keys(output).length === 0) {
+          try { output = instance.output.toSchema(); } catch { /* keep empty */ }
+        }
       }
     }
 

--- a/ts/src/core/module_builder.ts
+++ b/ts/src/core/module_builder.ts
@@ -22,6 +22,10 @@ export interface UseCaseOptions {
   inputSchema?: Record<string, unknown>;
   /** Override output schema for OpenAPI (if fromJson fails with empty data) */
   outputSchema?: Record<string, unknown>;
+  /** Input class for pre-validation and schema extraction (enables strict fromJson). */
+  inputClass?: abstract new (...args: unknown[]) => Input;
+  /** Output class for schema extraction. */
+  outputClass?: abstract new (...args: unknown[]) => Output;
 }
 
 /**
@@ -61,18 +65,18 @@ export class ModuleBuilder {
     factory: UseCaseFactory<I, O>,
     options: UseCaseOptions = {},
   ): this {
-    const { method = 'POST', summary, description, inputSchema, outputSchema } = options;
+    const { method = 'POST', summary, description, inputSchema, outputSchema, inputClass, outputClass } = options;
 
     // Normalize name: trim and remove leading slash
-    const cleanName = name.trim().replace(/^\//, '');
+    const cleanName = name.trim().replace(/^\//g, '');
     const subPath = `/${cleanName}`;
     const methodL = method.toLowerCase() as Lowercase<HttpMethod>;
 
-    // Mount the Express handler
-    this.router[methodL](subPath, useCaseHandler(factory));
+    // Mount the Express handler (with optional pre-validation)
+    this.router[methodL](subPath, useCaseHandler(factory, { inputClass }));
 
-    // Try to capture schemas via dummy factory call, or use overrides
-    const extracted = this._extractSchemas(factory);
+    // Try to capture schemas — prefer class-level metadata, then dummy factory
+    const extracted = this._extractSchemas(factory, inputClass, outputClass);
     const schemas = {
       input: inputSchema ?? extracted.input,
       output: outputSchema ?? extracted.output,
@@ -100,37 +104,55 @@ export class ModuleBuilder {
    * Capture Input and Output schemas from decorator metadata or a dummy factory call.
    *
    * Strategy (in order of preference):
-   * 1. Class-level: inspect factory → UseCase class → Input/Output type args
-   *    → @Field metadata → build schema without instantiation.
+   * 1. Class-level: inputClass/outputClass → @Field metadata → build schema.
    * 2. Fallback: call factory({}) and invoke toSchema() on the result (legacy).
    */
   private _extractSchemas<I extends Input, O extends Output>(
     factory: UseCaseFactory<I, O>,
+    inputClass?: abstract new (...args: unknown[]) => Input,
+    outputClass?: abstract new (...args: unknown[]) => Output,
   ): { input: Record<string, unknown>; output: Record<string, unknown> } {
-    // --- Strategy 1: class-level via factory({}) instance types ---
-    // For bound static methods, we can get the UseCase class and try
-    // to extract schemas from the Input/Output via decorator metadata.
-    let instance: UseCase<I, O> | undefined;
-    try {
-      instance = factory({});
-    } catch {
-      // Factory failed — that's fine, we still try class-level.
-    }
-
     let input: Record<string, unknown> = {};
     let output: Record<string, unknown> = {};
 
-    if (instance) {
+    // Strategy 1: class-level via @Field metadata (no instantiation needed)
+    if (inputClass) {
+      const fields = getFieldMetadata(inputClass);
+      if (fields.length > 0) {
+        input = new (inputClass as new () => Input)().toSchema();
+      }
+    }
+    if (outputClass) {
+      const fields = getFieldMetadata(outputClass);
+      if (fields.length > 0) {
+        output = new (outputClass as new () => Output)().toSchema();
+      }
+    }
+
+    // Strategy 2 fallback: dummy factory call
+    if (Object.keys(input).length === 0 || Object.keys(output).length === 0) {
+      let instance: UseCase<I, O> | undefined;
       try {
-        input = instance.input.toSchema();
+        instance = factory({});
       } catch {
-        // toSchema() not available — keep empty.
+        // Factory failed — that's fine.
       }
 
-      try {
-        output = instance.output.toSchema();
-      } catch {
-        // Output not initialised until execute() — expected for most UseCases.
+      if (instance) {
+        if (Object.keys(input).length === 0) {
+          try {
+            input = instance.input.toSchema();
+          } catch {
+            // toSchema() not available — keep empty.
+          }
+        }
+        if (Object.keys(output).length === 0) {
+          try {
+            output = instance.output.toSchema();
+          } catch {
+            // Output not initialised until execute() — expected for most UseCases.
+          }
+        }
       }
     }
 

--- a/ts/src/core/module_builder.ts
+++ b/ts/src/core/module_builder.ts
@@ -6,8 +6,10 @@
 
 import { Router } from 'express';
 import type { Input, Output, UseCaseFactory } from './usecase';
+import { UseCase } from './usecase';
 import { useCaseHandler } from './usecase_handler';
 import { apiRegistry } from './registry';
+import { getFieldMetadata } from './schema/field';
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
@@ -95,35 +97,41 @@ export class ModuleBuilder {
   }
 
   /**
-   * Capture Input and Output schemas independently from a dummy factory call.
+   * Capture Input and Output schemas from decorator metadata or a dummy factory call.
    *
-   * Each DTO extraction has its own try/catch so a failure in one
-   * (e.g. Output not yet initialised) does not destroy the other.
-   * Matches Dart's separate _inferInputSchema/_inferOutputSchema pattern.
+   * Strategy (in order of preference):
+   * 1. Class-level: inspect factory → UseCase class → Input/Output type args
+   *    → @Field metadata → build schema without instantiation.
+   * 2. Fallback: call factory({}) and invoke toSchema() on the result (legacy).
    */
   private _extractSchemas<I extends Input, O extends Output>(
     factory: UseCaseFactory<I, O>,
   ): { input: Record<string, unknown>; output: Record<string, unknown> } {
-    let instance: UseCase<I, O>;
+    // --- Strategy 1: class-level via factory({}) instance types ---
+    // For bound static methods, we can get the UseCase class and try
+    // to extract schemas from the Input/Output via decorator metadata.
+    let instance: UseCase<I, O> | undefined;
     try {
       instance = factory({});
     } catch {
-      // Factory itself failed — both schemas fall back to empty.
-      return { input: {}, output: {} };
+      // Factory failed — that's fine, we still try class-level.
     }
 
     let input: Record<string, unknown> = {};
-    try {
-      input = instance.input.toSchema();
-    } catch {
-      // Input DTO inaccessible or toSchema() failed — keep empty fallback.
-    }
-
     let output: Record<string, unknown> = {};
-    try {
-      output = instance.output.toSchema();
-    } catch {
-      // Output not initialised until execute() — expected for most UseCases.
+
+    if (instance) {
+      try {
+        input = instance.input.toSchema();
+      } catch {
+        // toSchema() not available — keep empty.
+      }
+
+      try {
+        output = instance.output.toSchema();
+      } catch {
+        // Output not initialised until execute() — expected for most UseCases.
+      }
     }
 
     return { input, output };

--- a/ts/src/core/module_builder.ts
+++ b/ts/src/core/module_builder.ts
@@ -6,7 +6,7 @@
 
 import { Router } from 'express';
 import type { Input, Output, UseCaseFactory } from './usecase';
-import { UseCase, buildSchemaFromMetadata } from './usecase';
+import { UseCase } from './usecase';
 import { useCaseHandler } from './usecase_handler';
 import { apiRegistry } from './registry';
 import { getFieldMetadata } from './schema/field';
@@ -18,21 +18,6 @@ export interface UseCaseOptions {
   method?: HttpMethod;
   summary?: string;
   description?: string;
-
-  /**
-   * Input DTO class constructor (e.g. `HelloInput`).
-   * When provided, schema is extracted from `@Field` decorator metadata
-   * without calling `factory({})` — zero instantiation, zero concurrency risk.
-   *
-   * Required when `fromJson` validates input (the recommended pattern).
-   */
-  inputType?: abstract new (...args: unknown[]) => Input;
-  /**
-   * Output DTO class constructor (e.g. `HelloOutput`).
-   * Same benefit as `inputType` — schema extracted from class metadata.
-   */
-  outputType?: abstract new (...args: unknown[]) => Output;
-
   /** Override input schema for OpenAPI (if fromJson fails with empty data) */
   inputSchema?: Record<string, unknown>;
   /** Override output schema for OpenAPI (if fromJson fails with empty data) */
@@ -76,7 +61,7 @@ export class ModuleBuilder {
     factory: UseCaseFactory<I, O>,
     options: UseCaseOptions = {},
   ): this {
-    const { method = 'POST', summary, description, inputType, outputType, inputSchema, outputSchema } = options;
+    const { method = 'POST', summary, description, inputSchema, outputSchema } = options;
 
     // Normalize name: trim and remove leading slash
     const cleanName = name.trim().replace(/^\//, '');
@@ -86,8 +71,8 @@ export class ModuleBuilder {
     // Mount the Express handler
     this.router[methodL](subPath, useCaseHandler(factory));
 
-    // Try to capture schemas: explicit types → decorator metadata → factory({}) fallback
-    const extracted = this._extractSchemas(factory, inputType, outputType);
+    // Try to capture schemas via dummy factory call, or use overrides
+    const extracted = this._extractSchemas(factory);
     const schemas = {
       input: inputSchema ?? extracted.input,
       output: outputSchema ?? extracted.output,
@@ -115,46 +100,37 @@ export class ModuleBuilder {
    * Capture Input and Output schemas from decorator metadata or a dummy factory call.
    *
    * Strategy (in order of preference):
-   * 1. Class metadata: use `@Field` decorator metadata from the explicit
-   *    inputType/outputType class constructors — no instantiation needed.
-   *    Required when `fromJson` validates input (the recommended pattern).
-   * 2. Fallback: call factory({}) and invoke toSchema() on the result.
-   *    Works when `fromJson` is tolerant of empty data (legacy pattern).
+   * 1. Class-level: inspect factory → UseCase class → Input/Output type args
+   *    → @Field metadata → build schema without instantiation.
+   * 2. Fallback: call factory({}) and invoke toSchema() on the result (legacy).
    */
   private _extractSchemas<I extends Input, O extends Output>(
     factory: UseCaseFactory<I, O>,
-    inputType?: abstract new (...args: unknown[]) => Input,
-    outputType?: abstract new (...args: unknown[]) => Output,
   ): { input: Record<string, unknown>; output: Record<string, unknown> } {
+    // --- Strategy 1: class-level via factory({}) instance types ---
+    // For bound static methods, we can get the UseCase class and try
+    // to extract schemas from the Input/Output via decorator metadata.
+    let instance: UseCase<I, O> | undefined;
+    try {
+      instance = factory({});
+    } catch {
+      // Factory failed — that's fine, we still try class-level.
+    }
+
     let input: Record<string, unknown> = {};
     let output: Record<string, unknown> = {};
 
-    // --- Strategy 1: class metadata — zero instantiation, zero concurrency risk ---
-    if (inputType) {
-      const fields = getFieldMetadata(inputType);
-      if (fields.length > 0) input = buildSchemaFromMetadata(fields);
-    }
-    if (outputType) {
-      const fields = getFieldMetadata(outputType);
-      if (fields.length > 0) output = buildSchemaFromMetadata(fields);
-    }
-
-    // --- Strategy 2: factory({}) fallback for backward compatibility ---
-    if (Object.keys(input).length === 0 || Object.keys(output).length === 0) {
-      let instance: UseCase<I, O> | undefined;
+    if (instance) {
       try {
-        instance = factory({});
+        input = instance.input.toSchema();
       } catch {
-        // factory({}) failed — keep partial results from Strategy 1.
+        // toSchema() not available — keep empty.
       }
 
-      if (instance) {
-        if (Object.keys(input).length === 0) {
-          try { input = instance.input.toSchema(); } catch { /* keep empty */ }
-        }
-        if (Object.keys(output).length === 0) {
-          try { output = instance.output.toSchema(); } catch { /* keep empty */ }
-        }
+      try {
+        output = instance.output.toSchema();
+      } catch {
+        // Output not initialised until execute() — expected for most UseCases.
       }
     }
 

--- a/ts/src/core/schema/field.ts
+++ b/ts/src/core/schema/field.ts
@@ -1,0 +1,144 @@
+// ============================================================
+// core/schema/field.ts
+// Stage 3 decorators that store OpenAPI-compatible field metadata.
+//
+// Usage:
+//   class HelloInput extends Input {
+//     @Field.string({ description: 'Name to greet' })
+//     name!: string;
+//
+//     @Field.optional(Field.integer({ description: 'Age' }))
+//     age?: number;
+//   }
+//
+// At runtime, `getFieldMetadata(HelloInput)` returns the list of
+// FieldMeta entries in declaration order, which Input.toSchema()
+// uses to build an OpenAPI 3.0.3-compatible JSON Schema.
+// ============================================================
+
+// Polyfill for runtimes that lack Symbol.metadata (Node < 22)
+(Symbol as Record<string, unknown>).metadata ??= Symbol('Symbol.metadata');
+
+/** Metadata stored per decorated field. */
+export interface FieldMeta {
+  name: string;
+  type: 'string' | 'integer' | 'number' | 'boolean' | 'array';
+  description?: string;
+  required: boolean;
+  nullable: boolean;
+  items?: { type: string };
+}
+
+/** Options accepted by every primitive Field decorator. */
+export interface FieldOptions {
+  description?: string;
+}
+
+// ── Internal storage key ─────────────────────────────────────
+
+const FIELD_KEY = Symbol('FieldMeta');
+
+// ── Stage 3 class field decorator factory ────────────────────
+
+type FieldDecorator = (
+  value: undefined,
+  context: ClassFieldDecoratorContext,
+) => void;
+
+function makeFieldDecorator(
+  type: FieldMeta['type'],
+  options: FieldOptions = {},
+  extra: Partial<FieldMeta> = {},
+): FieldDecorator {
+  return function (_value: undefined, context: ClassFieldDecoratorContext): void {
+    const meta: FieldMeta = {
+      name: String(context.name),
+      type,
+      description: options.description,
+      required: true,
+      nullable: false,
+      ...extra,
+    };
+
+    const metadata = context.metadata as Record<symbol, FieldMeta[]>;
+    if (!metadata[FIELD_KEY]) {
+      metadata[FIELD_KEY] = [];
+    }
+    metadata[FIELD_KEY].push(meta);
+  };
+}
+
+// ── Wrapper for optional fields ──────────────────────────────
+
+/** Internal marker returned by primitive Field methods for use with Field.optional(). */
+interface PendingField {
+  __pending: true;
+  type: FieldMeta['type'];
+  options: FieldOptions;
+  extra: Partial<FieldMeta>;
+}
+
+// ── Public API ───────────────────────────────────────────────
+
+export const Field = {
+  string(options: FieldOptions = {}): FieldDecorator & PendingField {
+    const decorator = makeFieldDecorator('string', options);
+    return Object.assign(decorator, { __pending: true as const, type: 'string' as const, options, extra: {} });
+  },
+
+  integer(options: FieldOptions = {}): FieldDecorator & PendingField {
+    const decorator = makeFieldDecorator('integer', options);
+    return Object.assign(decorator, { __pending: true as const, type: 'integer' as const, options, extra: {} });
+  },
+
+  number(options: FieldOptions = {}): FieldDecorator & PendingField {
+    const decorator = makeFieldDecorator('number', options);
+    return Object.assign(decorator, { __pending: true as const, type: 'number' as const, options, extra: {} });
+  },
+
+  boolean(options: FieldOptions = {}): FieldDecorator & PendingField {
+    const decorator = makeFieldDecorator('boolean', options);
+    return Object.assign(decorator, { __pending: true as const, type: 'boolean' as const, options, extra: {} });
+  },
+
+  /**
+   * Marks a field as optional (nullable, not required).
+   *
+   * ```ts
+   * @Field.optional(Field.string({ description: 'Nickname' }))
+   * nickname?: string;
+   * ```
+   */
+  optional(inner: PendingField): FieldDecorator {
+    return makeFieldDecorator(inner.type, inner.options, {
+      ...inner.extra,
+      required: false,
+      nullable: true,
+    });
+  },
+
+  /**
+   * Array field with typed items.
+   *
+   * ```ts
+   * @Field.array(Field.string(), { description: 'tags' })
+   * tags!: string[];
+   * ```
+   */
+  array(itemType: PendingField, options: FieldOptions = {}): FieldDecorator & PendingField {
+    const extra: Partial<FieldMeta> = { items: { type: itemType.type } };
+    const decorator = makeFieldDecorator('array', options, extra);
+    return Object.assign(decorator, { __pending: true as const, type: 'array' as const, options, extra });
+  },
+};
+
+// ── Public accessor ──────────────────────────────────────────
+
+/**
+ * Retrieves the `@Field` metadata registered on a class.
+ * Returns an empty array if the class has no decorated fields.
+ */
+export function getFieldMetadata(target: abstract new (...args: unknown[]) => unknown): FieldMeta[] {
+  const metadata = (target as Record<symbol, Record<symbol, FieldMeta[]>>)[Symbol.metadata];
+  return metadata?.[FIELD_KEY] ?? [];
+}

--- a/ts/src/core/schema/field.ts
+++ b/ts/src/core/schema/field.ts
@@ -32,11 +32,13 @@ export interface FieldMeta {
   required: boolean;
   nullable: boolean;
   items?: { type: string };
+  example?: unknown;
 }
 
 /** Options accepted by every primitive Field decorator. */
 export interface FieldOptions {
   description?: string;
+  example?: unknown;
 }
 
 // ── Internal storage key ─────────────────────────────────────
@@ -64,6 +66,9 @@ function makeFieldDecorator(
       nullable: false,
       ...extra,
     };
+    if (options.example !== undefined) {
+      meta.example = options.example;
+    }
 
     const metadata = context.metadata as Record<symbol, FieldMeta[]>;
     if (!metadata[FIELD_KEY]) {

--- a/ts/src/core/schema/field.ts
+++ b/ts/src/core/schema/field.ts
@@ -17,7 +17,12 @@
 // ============================================================
 
 // Polyfill for runtimes that lack Symbol.metadata (Node < 22)
-(Symbol as Record<string, unknown>).metadata ??= Symbol('Symbol.metadata');
+declare global {
+  interface SymbolConstructor {
+    readonly metadata: unique symbol;
+  }
+}
+(Symbol as unknown as Record<string, unknown>).metadata ??= Symbol('Symbol.metadata');
 
 /** Metadata stored per decorated field. */
 export interface FieldMeta {
@@ -139,6 +144,6 @@ export const Field = {
  * Returns an empty array if the class has no decorated fields.
  */
 export function getFieldMetadata(target: abstract new (...args: unknown[]) => unknown): FieldMeta[] {
-  const metadata = (target as Record<symbol, Record<symbol, FieldMeta[]>>)[Symbol.metadata];
+  const metadata = (target as unknown as Record<symbol, Record<symbol, FieldMeta[]>>)[Symbol.metadata];
   return metadata?.[FIELD_KEY] ?? [];
 }

--- a/ts/src/core/usecase.ts
+++ b/ts/src/core/usecase.ts
@@ -5,50 +5,127 @@
 // ============================================================
 
 import type { ModularLogger } from './logger/logger';
+import { getFieldMetadata, type FieldMeta } from './schema/field';
 
 /**
- * **Contract** — use `implements Input`.
+ * Build an OpenAPI 3.0.3 JSON Schema from `@Field` decorator metadata.
+ * Shared by both Input and Output base classes.
+ */
+function buildSchemaFromMetadata(fields: FieldMeta[]): Record<string, unknown> {
+  const properties: Record<string, Record<string, unknown>> = {};
+  const required: string[] = [];
+
+  for (const field of fields) {
+    const prop: Record<string, unknown> = { type: field.type };
+    if (field.description) prop.description = field.description;
+    if (field.nullable) prop.nullable = true;
+    if (field.items) prop.items = field.items;
+    properties[field.name] = prop;
+
+    if (field.required) {
+      required.push(field.name);
+    }
+  }
+
+  const schema: Record<string, unknown> = { type: 'object', properties };
+  if (required.length > 0) {
+    schema.required = required;
+  }
+  return schema;
+}
+
+/**
+ * Serialize decorated fields from an instance to a plain object.
+ * Shared by both Input and Output base classes.
+ */
+function serializeFromMetadata(instance: Record<string, unknown>, fields: FieldMeta[]): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const field of fields) {
+    const value = instance[field.name];
+    if (value !== undefined) {
+      result[field.name] = value;
+    }
+  }
+  return result;
+}
+
+/**
+ * **Contract** — use `extends Input`.
  *
- * Pure interface: all members must be provided by the implementor.
- * No default behavior is inherited — every Input is self-contained.
+ * When subclass fields are decorated with `@Field`, `toJson()` and
+ * `toSchema()` are provided automatically. Manual overrides still work
+ * (deprecated — will be removed in v0.5.0).
  *
  * ```ts
- * class HelloInput implements Input {
- *   constructor(readonly name: string) {}
- *   toJson()   { return { name: this.name }; }
- *   toSchema() { return { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] }; }
+ * class HelloInput extends Input {
+ *   @Field.string({ description: 'Name to greet' })
+ *   name!: string;
+ *
+ *   static fromJson(json: Record<string, unknown>) {
+ *     const instance = new HelloInput();
+ *     instance.name = (json['name'] ?? '').toString();
+ *     return instance;
+ *   }
  * }
  * ```
  */
 export abstract class Input {
-  abstract toJson(): Record<string, unknown>;
+  toJson(): Record<string, unknown> {
+    const fields = getFieldMetadata(this.constructor as abstract new (...args: unknown[]) => unknown);
+    if (fields.length > 0) {
+      return serializeFromMetadata(this as unknown as Record<string, unknown>, fields);
+    }
+    // No decorator metadata — subclass must override (legacy path)
+    throw new Error(`${this.constructor.name}.toJson() not implemented. Use @Field decorators or override toJson().`);
+  }
 
   /**
    * Returns an OpenAPI-compatible JSON Schema describing this input.
-   * Used to auto-generate Swagger documentation.
+   * Derived automatically from `@Field` decorators when present.
    */
-  abstract toSchema(): Record<string, unknown>;
+  toSchema(): Record<string, unknown> {
+    const fields = getFieldMetadata(this.constructor as abstract new (...args: unknown[]) => unknown);
+    if (fields.length > 0) {
+      return buildSchemaFromMetadata(fields);
+    }
+    // No decorator metadata — subclass must override (legacy path)
+    throw new Error(`${this.constructor.name}.toSchema() not implemented. Use @Field decorators or override toSchema().`);
+  }
 }
 
 /**
- * **Contract** — use `implements Output`.
+ * **Contract** — use `extends Output`.
  *
- * Pure interface: all members must be provided by the implementor.
- * The implementor must define `statusCode` explicitly — this forces
- * developers to think about HTTP status codes for every response.
+ * When subclass fields are decorated with `@Field`, `toJson()` and
+ * `toSchema()` are provided automatically. The implementor must define
+ * `statusCode` explicitly — this forces developers to think about
+ * HTTP status codes for every response.
  *
  * ```ts
- * class HelloOutput implements Output {
- *   constructor(readonly message: string) {}
+ * class HelloOutput extends Output {
+ *   @Field.string({ description: 'Greeting message' })
+ *   message!: string;
+ *
  *   get statusCode() { return 200; }
- *   toJson()   { return { message: this.message }; }
- *   toSchema() { return { type: 'object', properties: { message: { type: 'string' } }, required: ['message'] }; }
  * }
  * ```
  */
 export abstract class Output {
-  abstract toJson(): Record<string, unknown>;
-  abstract toSchema(): Record<string, unknown>;
+  toJson(): Record<string, unknown> {
+    const fields = getFieldMetadata(this.constructor as abstract new (...args: unknown[]) => unknown);
+    if (fields.length > 0) {
+      return serializeFromMetadata(this as unknown as Record<string, unknown>, fields);
+    }
+    throw new Error(`${this.constructor.name}.toJson() not implemented. Use @Field decorators or override toJson().`);
+  }
+
+  toSchema(): Record<string, unknown> {
+    const fields = getFieldMetadata(this.constructor as abstract new (...args: unknown[]) => unknown);
+    if (fields.length > 0) {
+      return buildSchemaFromMetadata(fields);
+    }
+    throw new Error(`${this.constructor.name}.toSchema() not implemented. Use @Field decorators or override toSchema().`);
+  }
 
   /**
    * HTTP status code for the response.

--- a/ts/src/core/usecase.ts
+++ b/ts/src/core/usecase.ts
@@ -16,11 +16,17 @@ function buildSchemaFromMetadata(fields: FieldMeta[]): Record<string, unknown> {
   const properties: Record<string, Record<string, unknown>> = {};
   const required: string[] = [];
 
+  const exampleValues: Record<string, unknown> = {};
+
   for (const field of fields) {
     const prop: Record<string, unknown> = { type: field.type };
     if (field.description) prop.description = field.description;
     if (field.nullable) prop.nullable = true;
     if (field.items) prop.items = field.items;
+    if (field.example !== undefined) {
+      prop.example = field.example;
+      exampleValues[field.name] = field.example;
+    }
     properties[field.name] = prop;
 
     if (field.required) {
@@ -31,6 +37,9 @@ function buildSchemaFromMetadata(fields: FieldMeta[]): Record<string, unknown> {
   const schema: Record<string, unknown> = { type: 'object', properties };
   if (required.length > 0) {
     schema.required = required;
+  }
+  if (Object.keys(exampleValues).length > 0) {
+    schema.example = exampleValues;
   }
   return schema;
 }

--- a/ts/src/core/usecase.ts
+++ b/ts/src/core/usecase.ts
@@ -49,6 +49,10 @@ function serializeFromMetadata(instance: Record<string, unknown>, fields: FieldM
   return result;
 }
 
+// Track classes that have already emitted a deprecation warning (once per class)
+const _warnedInputClasses = new Set<Function>();
+const _warnedOutputClasses = new Set<Function>();
+
 /**
  * **Contract** — use `extends Input`.
  *
@@ -70,6 +74,19 @@ function serializeFromMetadata(instance: Record<string, unknown>, fields: FieldM
  * ```
  */
 export abstract class Input {
+  constructor() {
+    const cls = this.constructor;
+    if (
+      !_warnedInputClasses.has(cls) &&
+      cls.prototype.toSchema !== Input.prototype.toSchema
+    ) {
+      _warnedInputClasses.add(cls);
+      console.warn(
+        `${cls.name}.toSchema() is deprecated. Remove it — schema is derived automatically from @Field decorators.`,
+      );
+    }
+  }
+
   toJson(): Record<string, unknown> {
     const fields = getFieldMetadata(this.constructor as abstract new (...args: unknown[]) => unknown);
     if (fields.length > 0) {
@@ -111,6 +128,19 @@ export abstract class Input {
  * ```
  */
 export abstract class Output {
+  constructor() {
+    const cls = this.constructor;
+    if (
+      !_warnedOutputClasses.has(cls) &&
+      cls.prototype.toSchema !== Output.prototype.toSchema
+    ) {
+      _warnedOutputClasses.add(cls);
+      console.warn(
+        `${cls.name}.toSchema() is deprecated. Remove it — schema is derived automatically from @Field decorators.`,
+      );
+    }
+  }
+
   toJson(): Record<string, unknown> {
     const fields = getFieldMetadata(this.constructor as abstract new (...args: unknown[]) => unknown);
     if (fields.length > 0) {

--- a/ts/src/core/usecase.ts
+++ b/ts/src/core/usecase.ts
@@ -6,6 +6,7 @@
 
 import type { ModularLogger } from './logger/logger';
 import { getFieldMetadata, type FieldMeta } from './schema/field';
+import { InputValidationError } from './input_validation_error';
 
 /**
  * Build an OpenAPI 3.0.3 JSON Schema from `@Field` decorator metadata.
@@ -52,6 +53,18 @@ function serializeFromMetadata(instance: Record<string, unknown>, fields: FieldM
 // Track classes that have already emitted a deprecation warning (once per class)
 const _warnedInputClasses = new Set<Function>();
 const _warnedOutputClasses = new Set<Function>();
+
+/** Checks whether a JSON value matches the expected OpenAPI type. */
+function isJsonTypeValid(value: unknown, expectedType: string): boolean {
+  switch (expectedType) {
+    case 'string':  return typeof value === 'string';
+    case 'integer': return typeof value === 'number' && Number.isInteger(value);
+    case 'number':  return typeof value === 'number';
+    case 'boolean': return typeof value === 'boolean';
+    case 'array':   return Array.isArray(value);
+    default:        return true;
+  }
+}
 
 /**
  * **Contract** — use `extends Input`.
@@ -107,6 +120,34 @@ export abstract class Input {
     }
     // No decorator metadata — subclass must override (legacy path)
     throw new Error(`${this.constructor.name}.toSchema() not implemented. Use @Field decorators or override toSchema().`);
+  }
+
+  /**
+   * Validates raw JSON against `@Field` metadata of `targetClass`.
+   *
+   * Throws {@link InputValidationError} when a required field is missing
+   * or has the wrong JSON type. The handler catches this and returns 400.
+   *
+   * Error messages follow the cross-SDK parity contract:
+   *   - `"Missing required field: {name}"`
+   *   - `"Field '{name}' must be of type {type}"`
+   */
+  static validateJson(
+    json: Record<string, unknown>,
+    targetClass: abstract new (...args: unknown[]) => unknown,
+  ): void {
+    const fields = getFieldMetadata(targetClass);
+    for (const field of fields) {
+      if (!field.required) continue;
+
+      if (!(field.name in json) || json[field.name] === undefined || json[field.name] === null) {
+        throw new InputValidationError(`Missing required field: ${field.name}`);
+      }
+
+      if (!isJsonTypeValid(json[field.name], field.type)) {
+        throw new InputValidationError(`Field '${field.name}' must be of type ${field.type}`);
+      }
+    }
   }
 }
 

--- a/ts/src/core/usecase.ts
+++ b/ts/src/core/usecase.ts
@@ -11,12 +11,8 @@ import { InputValidationError } from './input_validation_error';
 /**
  * Build an OpenAPI 3.0.3 JSON Schema from `@Field` decorator metadata.
  * Shared by both Input and Output base classes.
- *
- * Also used by ModuleBuilder to extract schemas from class metadata
- * without instantiation — eliminating the need for `factory({})`
- * when input/output types are registered explicitly.
  */
-export function buildSchemaFromMetadata(fields: FieldMeta[]): Record<string, unknown> {
+function buildSchemaFromMetadata(fields: FieldMeta[]): Record<string, unknown> {
   const properties: Record<string, Record<string, unknown>> = {};
   const required: string[] = [];
 

--- a/ts/src/core/usecase.ts
+++ b/ts/src/core/usecase.ts
@@ -11,8 +11,12 @@ import { InputValidationError } from './input_validation_error';
 /**
  * Build an OpenAPI 3.0.3 JSON Schema from `@Field` decorator metadata.
  * Shared by both Input and Output base classes.
+ *
+ * Also used by ModuleBuilder to extract schemas from class metadata
+ * without instantiation — eliminating the need for `factory({})`
+ * when input/output types are registered explicitly.
  */
-function buildSchemaFromMetadata(fields: FieldMeta[]): Record<string, unknown> {
+export function buildSchemaFromMetadata(fields: FieldMeta[]): Record<string, unknown> {
   const properties: Record<string, Record<string, unknown>> = {};
   const required: string[] = [];
 

--- a/ts/src/core/usecase_handler.ts
+++ b/ts/src/core/usecase_handler.ts
@@ -7,6 +7,7 @@
 import type { Request, Response, RequestHandler } from 'express';
 import type { UseCaseFactory, Input, Output } from './usecase';
 import { UseCaseException } from './use_case_exception';
+import { InputValidationError } from './input_validation_error';
 import { LOGGER_LOCALS_KEY } from './logger/logging_middleware';
 import type { ModularLogger } from './logger/logger';
 
@@ -64,6 +65,10 @@ export function useCaseHandler<I extends Input, O extends Output>(
       // 5. Respond
       res.status(useCase.output.statusCode).set(JSON_HEADERS).json(useCase.toJson());
     } catch (err) {
+      if (err instanceof InputValidationError) {
+        res.status(400).set(JSON_HEADERS).json({ error: err.message });
+        return;
+      }
       if (err instanceof UseCaseException) {
         console.error('UseCaseException:', err.toString());
         res.status(err.statusCode).set(JSON_HEADERS).json(err.toJson());

--- a/ts/src/core/usecase_handler.ts
+++ b/ts/src/core/usecase_handler.ts
@@ -5,7 +5,8 @@
 // ============================================================
 
 import type { Request, Response, RequestHandler } from 'express';
-import type { UseCaseFactory, Input, Output } from './usecase';
+import type { UseCaseFactory, Output } from './usecase';
+import { Input } from './usecase';
 import { UseCaseException } from './use_case_exception';
 import { InputValidationError } from './input_validation_error';
 import { LOGGER_LOCALS_KEY } from './logger/logging_middleware';
@@ -45,6 +46,13 @@ export function useCaseHandler<I extends Input, O extends Output>(
 
       // 2. Build use case
       const useCase = factory(data);
+
+      // 2a. Auto-validate raw JSON against @Field metadata on the Input DTO.
+      // Runs after fromJson (which may coerce) — validates the ORIGINAL payload.
+      Input.validateJson(
+        data,
+        useCase.input.constructor as abstract new (...args: unknown[]) => unknown,
+      );
 
       // 2b. Inject request-scoped logger (if logging middleware is active)
       const logger = res.locals[LOGGER_LOCALS_KEY] as ModularLogger | undefined;

--- a/ts/src/core/usecase_handler.ts
+++ b/ts/src/core/usecase_handler.ts
@@ -14,27 +14,36 @@ import type { ModularLogger } from './logger/logger';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json; charset=utf-8' };
 
+export interface UseCaseHandlerOptions {
+  /** Input class for pre-validation before fromJson (enables strict factories). */
+  inputClass?: abstract new (...args: unknown[]) => Input;
+}
+
 /**
  * Wraps any UseCase factory into an Express RequestHandler.
  *
  * Lifecycle (mirrors Dart useCaseHttpHandler):
  *   1. Parse body (POST/PUT/PATCH) or query params (GET/DELETE)
- *   2. Build UseCase via factory(json)
- *   3. Call validate() — return 400 if error string returned
- *   4. Call execute()
- *   5. Return output.toJson() with output.statusCode
+ *   2. Pre-validate against @Field metadata (when inputClass provided)
+ *   3. Build UseCase via factory(json)
+ *   4. Post-validate (legacy fallback when no inputClass)
+ *   5. Call validate() — return 400 if error string returned
+ *   6. Call execute()
+ *   7. Return output.toJson() with output.statusCode
  *
  * Errors:
- *   - UseCaseException  → statusCode from exception, structured JSON body
- *   - Any other Error   → 500 Internal Server Error
+ *   - InputValidationError → 400 with structured error message
+ *   - UseCaseException     → statusCode from exception, structured JSON body
+ *   - Any other Error      → 500 Internal Server Error
  *
  * Usage:
  * ```ts
- * router.post('/hello', useCaseHandler(SayHello.fromJson));
+ * router.post('/hello', useCaseHandler(SayHello.fromJson, { inputClass: HelloInput }));
  * ```
  */
 export function useCaseHandler<I extends Input, O extends Output>(
   factory: UseCaseFactory<I, O>,
+  options: UseCaseHandlerOptions = {},
 ): RequestHandler {
   return async (req: Request, res: Response): Promise<void> => {
     try {
@@ -44,15 +53,21 @@ export function useCaseHandler<I extends Input, O extends Output>(
           ? { ...req.query, ...req.params }
           : ((req.body as Record<string, unknown>) ?? {});
 
-      // 2. Build use case
+      // 2. Pre-validate BEFORE fromJson (when inputClass provided)
+      if (options.inputClass) {
+        Input.validateJson(data, options.inputClass);
+      }
+
+      // 3. Build use case
       const useCase = factory(data);
 
-      // 2a. Auto-validate raw JSON against @Field metadata on the Input DTO.
-      // Runs after fromJson (which may coerce) — validates the ORIGINAL payload.
-      Input.validateJson(
-        data,
-        useCase.input.constructor as abstract new (...args: unknown[]) => unknown,
-      );
+      // 3a. Post-validate for legacy path (no inputClass)
+      if (!options.inputClass) {
+        Input.validateJson(
+          data,
+          useCase.input.constructor as abstract new (...args: unknown[]) => unknown,
+        );
+      }
 
       // 2b. Inject request-scoped logger (if logging middleware is active)
       const logger = res.locals[LOGGER_LOCALS_KEY] as ModularLogger | undefined;

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -14,6 +14,7 @@ export type { FieldMeta, FieldOptions } from './core/schema/field';
 
 // Controlled error responses
 export { UseCaseException } from './core/use_case_exception';
+export { InputValidationError } from './core/input_validation_error';
 
 // Main orchestrator
 export { ModularApi } from './core/modular_api';

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -8,6 +8,10 @@
 export { Input, Output, UseCase } from './core/usecase';
 export type { UseCaseFactory } from './core/usecase';
 
+// Schema decorators
+export { Field, getFieldMetadata } from './core/schema/field';
+export type { FieldMeta, FieldOptions } from './core/schema/field';
+
 // Controlled error responses
 export { UseCaseException } from './core/use_case_exception';
 

--- a/ts/test/fromjson_validation.test.ts
+++ b/ts/test/fromjson_validation.test.ts
@@ -1,0 +1,74 @@
+/**
+ * RED — fromJson must validate required fields and types, returning 400.
+ *
+ * fromJson validates structure (field presence + JSON type correctness).
+ * validate() handles only business rules.
+ *
+ * Error message contract (identical across all 3 SDKs for parity):
+ *   - Missing required field: "Missing required field: {name}"
+ *   - Wrong JSON type:        "Field '{name}' must be of type {type}"
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Input, Field, InputValidationError } from '../src/index';
+
+// ── Stubs ────────────────────────────────────────────────────────────────
+
+class StrictInput extends Input {
+  @Field.string({ description: 'Name' })
+  name!: string;
+
+  @Field.integer({ description: 'Age' })
+  age!: number;
+
+  static fromJson(json: Record<string, unknown>): StrictInput {
+    Input.validateJson(json, StrictInput);
+    const instance = new StrictInput();
+    instance.name = json['name'] as string;
+    instance.age = json['age'] as number;
+    return instance;
+  }
+}
+
+// ── Unit: validateJson rejects missing fields and wrong types ────────────
+
+describe('Input.validateJson', () => {
+  it('throws InputValidationError for missing required field', () => {
+    expect(() => Input.validateJson({}, StrictInput)).toThrow(
+      InputValidationError,
+    );
+    expect(() => Input.validateJson({}, StrictInput)).toThrow(
+      'Missing required field: name',
+    );
+  });
+
+  it('throws InputValidationError for wrong type (int where string expected)', () => {
+    expect(
+      () => Input.validateJson({ name: 123, age: 25 }, StrictInput),
+    ).toThrow(InputValidationError);
+    expect(
+      () => Input.validateJson({ name: 123, age: 25 }, StrictInput),
+    ).toThrow("Field 'name' must be of type string");
+  });
+
+  it('throws InputValidationError for wrong type (string where integer expected)', () => {
+    expect(
+      () => Input.validateJson({ name: 'Alice', age: 'twenty-five' }, StrictInput),
+    ).toThrow(InputValidationError);
+    expect(
+      () => Input.validateJson({ name: 'Alice', age: 'twenty-five' }, StrictInput),
+    ).toThrow("Field 'age' must be of type integer");
+  });
+
+  it('does not throw for valid JSON', () => {
+    expect(
+      () => Input.validateJson({ name: 'Alice', age: 25 }, StrictInput),
+    ).not.toThrow();
+  });
+
+  it('fromJson returns valid instance', () => {
+    const input = StrictInput.fromJson({ name: 'Alice', age: 25 });
+    expect(input.name).toBe('Alice');
+    expect(input.age).toBe(25);
+  });
+});

--- a/ts/test/handler/handler_pre_validation.test.ts
+++ b/ts/test/handler/handler_pre_validation.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { Input, Output, UseCase, type UseCaseFactory } from '../../src/core/usecase';
+import { Field } from '../../src/core/schema/field';
+import { useCaseHandler } from '../../src/core/usecase_handler';
+
+// ── Strict UseCase: fromJson THROWS on missing/wrong types ──
+
+class StrictInput extends Input {
+  @Field.string({ description: 'User name', example: 'Alice' })
+  name!: string;
+
+  @Field.integer({ description: 'User age', example: 30 })
+  age!: number;
+
+  @Field.number({ description: 'Score', example: 9.5 })
+  score!: number;
+
+  @Field.boolean({ description: 'Active?', example: true })
+  active!: boolean;
+
+  @Field.array(Field.string(), { description: 'Tags', example: ['dart'] })
+  tags!: string[];
+
+  static fromJson(json: Record<string, unknown>): StrictInput {
+    const i = new StrictInput();
+    // Strict — no coercion, will throw on wrong types
+    i.name = json['name'] as string;
+    i.age = json['age'] as number;
+    i.score = json['score'] as number;
+    i.active = json['active'] as boolean;
+    i.tags = json['tags'] as string[];
+    return i;
+  }
+}
+
+class StrictOutput extends Output {
+  @Field.string({ description: 'Greeting', example: 'Hello Alice' })
+  greeting!: string;
+
+  get statusCode() {
+    return 200;
+  }
+}
+
+class StrictUseCase extends UseCase<StrictInput, StrictOutput> {
+  readonly input: StrictInput;
+  output!: StrictOutput;
+
+  constructor(input: StrictInput) {
+    super();
+    this.input = input;
+  }
+
+  static fromJson(json: Record<string, unknown>): StrictUseCase {
+    return new StrictUseCase(StrictInput.fromJson(json));
+  }
+
+  validate() {
+    return null;
+  }
+
+  async execute() {
+    const out = new StrictOutput();
+    out.greeting = `Hello ${this.input.name}`;
+    this.output = out;
+  }
+
+  toJson() {
+    return this.output.toJson();
+  }
+}
+
+// ── Express app helpers ──
+
+function makeApp(handler: express.RequestHandler) {
+  const app = express();
+  app.use(express.json());
+  app.post('/test', handler);
+  return app;
+}
+
+// ── Tests ──
+
+describe('Handler pre-validation with inputClass', () => {
+  const app = makeApp(
+    useCaseHandler(StrictUseCase.fromJson as UseCaseFactory, {
+      inputClass: StrictInput,
+    }),
+  );
+
+  it('returns 400 when required field is missing', async () => {
+    const res = await request(app)
+      .post('/test')
+      .send({ age: 30, score: 9.5, active: true, tags: ['dart'] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('Missing required field: name');
+  });
+
+  it('returns 400 when string field receives int', async () => {
+    const res = await request(app)
+      .post('/test')
+      .send({ name: 123, age: 30, score: 9.5, active: true, tags: ['dart'] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Field 'name' must be of type string");
+  });
+
+  it('returns 400 when integer field receives string', async () => {
+    const res = await request(app)
+      .post('/test')
+      .send({ name: 'Alice', age: 'thirty', score: 9.5, active: true, tags: ['dart'] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Field 'age' must be of type integer");
+  });
+
+  it('returns 400 when number field receives string', async () => {
+    const res = await request(app)
+      .post('/test')
+      .send({ name: 'Alice', age: 30, score: 'high', active: true, tags: ['dart'] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Field 'score' must be of type number");
+  });
+
+  it('returns 400 when boolean field receives string', async () => {
+    const res = await request(app)
+      .post('/test')
+      .send({ name: 'Alice', age: 30, score: 9.5, active: 'yes', tags: ['dart'] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Field 'active' must be of type boolean");
+  });
+
+  it('returns 400 when array field receives string', async () => {
+    const res = await request(app)
+      .post('/test')
+      .send({ name: 'Alice', age: 30, score: 9.5, active: true, tags: 'dart' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Field 'tags' must be of type array");
+  });
+
+  it('returns 200 with valid data (strict fromJson works)', async () => {
+    const res = await request(app)
+      .post('/test')
+      .send({ name: 'Alice', age: 30, score: 9.5, active: true, tags: ['dart'] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.greeting).toBe('Hello Alice');
+  });
+
+  it('returns 400 on empty body (first missing field)', async () => {
+    const res = await request(app)
+      .post('/test')
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('Missing required field');
+  });
+
+  it('pre-validates BEFORE fromJson — factory is never called on invalid data', async () => {
+    let factoryCalled = false;
+    const crashingFactory: UseCaseFactory = (_json) => {
+      factoryCalled = true;
+      throw new Error('factory should not be called');
+    };
+
+    const appCrash = makeApp(
+      useCaseHandler(crashingFactory, { inputClass: StrictInput }),
+    );
+    const res = await request(appCrash).post('/test').send({});
+
+    expect(res.status).toBe(400);
+    expect(factoryCalled).toBe(false);
+  });
+});
+
+describe('Handler backward-compat — no inputClass', () => {
+  it('without inputClass, still validates via post-validation (lenient factory)', async () => {
+    // TS handler currently always post-validates — but with lenient fromJson it works
+    const app = makeApp(useCaseHandler(StrictUseCase.fromJson as UseCaseFactory));
+
+    // With strict fromJson + no inputClass, wrong type causes crash → 500
+    const res = await request(app)
+      .post('/test')
+      .send({ name: 123, age: 30, score: 9.5, active: true, tags: ['dart'] });
+
+    // If name is 123 (number), `as string` still "works" in JS (no crash),
+    // but validateJson after factory catches the type mismatch → 400
+    // Actually in JS, `as string` is erased at runtime. So name === 123 and
+    // post-validation catches it. This demonstrates backward-compat still works.
+    expect(res.status).toBe(400);
+  });
+});

--- a/ts/test/schema/auto_schema.test.ts
+++ b/ts/test/schema/auto_schema.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { Input, Output } from '../../src/core/usecase';
+import { Field } from '../../src/core/schema/field';
+
+// ── Test DTOs with @Field decorators ─────────────────────────
+
+class NameInput extends Input {
+  @Field.string({ description: 'Name to greet' })
+  name!: string;
+
+  static fromJson(json: Record<string, unknown>): NameInput {
+    const instance = new NameInput();
+    instance.name = (json['name'] ?? '').toString();
+    return instance;
+  }
+}
+
+class GreetOutput extends Output {
+  @Field.string({ description: 'Greeting message' })
+  message!: string;
+
+  get statusCode() {
+    return 200;
+  }
+
+  static fromJson(json: Record<string, unknown>): GreetOutput {
+    const instance = new GreetOutput();
+    instance.message = (json['message'] ?? '').toString();
+    return instance;
+  }
+}
+
+class OptionalInput extends Input {
+  @Field.string({ description: 'Required name' })
+  name!: string;
+
+  @Field.optional(Field.string({ description: 'Optional nickname' }))
+  nickname?: string;
+
+  static fromJson(json: Record<string, unknown>): OptionalInput {
+    const instance = new OptionalInput();
+    instance.name = (json['name'] ?? '').toString();
+    if (json['nickname'] != null) {
+      instance.nickname = json['nickname'].toString();
+    }
+    return instance;
+  }
+}
+
+// ── Input auto-schema tests ──────────────────────────────────
+
+describe('Input auto-schema from @Field decorators', () => {
+  it('toSchema() returns correct OpenAPI schema', () => {
+    const schema = new NameInput().toSchema();
+    expect(schema).toEqual({
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Name to greet' },
+      },
+      required: ['name'],
+    });
+  });
+
+  it('toJson() serializes decorated fields', () => {
+    const input = NameInput.fromJson({ name: 'Carlos' });
+    expect(input.toJson()).toEqual({ name: 'Carlos' });
+  });
+
+  it('fromJson() populates fields', () => {
+    const input = NameInput.fromJson({ name: 'Maria' });
+    expect(input.name).toBe('Maria');
+  });
+
+  it('optional field excluded from required and marked nullable', () => {
+    const schema = new OptionalInput().toSchema();
+    expect(schema).toEqual({
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Required name' },
+        nickname: { type: 'string', description: 'Optional nickname', nullable: true },
+      },
+      required: ['name'],
+    });
+  });
+});
+
+// ── Output auto-schema tests ─────────────────────────────────
+
+describe('Output auto-schema from @Field decorators', () => {
+  it('toSchema() returns correct OpenAPI schema', () => {
+    const schema = new GreetOutput().toSchema();
+    expect(schema).toEqual({
+      type: 'object',
+      properties: {
+        message: { type: 'string', description: 'Greeting message' },
+      },
+      required: ['message'],
+    });
+  });
+
+  it('toJson() serializes decorated fields', () => {
+    const output = GreetOutput.fromJson({ message: 'Hello!' });
+    expect(output.toJson()).toEqual({ message: 'Hello!' });
+  });
+
+  it('statusCode is still abstract and implemented by subclass', () => {
+    const output = new GreetOutput();
+    expect(output.statusCode).toBe(200);
+  });
+});

--- a/ts/test/schema/deprecation.test.ts
+++ b/ts/test/schema/deprecation.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Input, Output } from '../../src/core/usecase';
+import { Field } from '../../src/core/schema/field';
+
+describe('Manual toSchema() deprecation warning', () => {
+  it('warns when Input subclass overrides toSchema() manually', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    class LegacyInput extends Input {
+      name!: string;
+
+      toJson() {
+        return { name: this.name };
+      }
+
+      toSchema() {
+        return { type: 'object' };
+      }
+    }
+
+    const input = new LegacyInput();
+    const schema = input.toSchema();
+
+    // The override still works
+    expect(schema).toEqual({ type: 'object' });
+
+    // But a deprecation warning was emitted
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('toSchema() is deprecated'),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('warns when Output subclass overrides toSchema() manually', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    class LegacyOutput extends Output {
+      message!: string;
+
+      get statusCode() {
+        return 200;
+      }
+
+      toJson() {
+        return { message: this.message };
+      }
+
+      toSchema() {
+        return { type: 'object' };
+      }
+    }
+
+    const output = new LegacyOutput();
+    const schema = output.toSchema();
+
+    expect(schema).toEqual({ type: 'object' });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('toSchema() is deprecated'),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('does NOT warn when using @Field decorators (no manual override)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    class ModernInput extends Input {
+      @Field.string({ description: 'name' })
+      name!: string;
+    }
+
+    const input = new ModernInput();
+    input.toSchema();
+
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('warns only once per class (not on every call)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    class RepeatedInput extends Input {
+      toJson() {
+        return {};
+      }
+
+      toSchema() {
+        return { type: 'object' };
+      }
+    }
+
+    const a = new RepeatedInput();
+    a.toSchema();
+    a.toSchema();
+    new RepeatedInput().toSchema();
+
+    // Only warned once for the class, not per call
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+});

--- a/ts/test/schema/field.test.ts
+++ b/ts/test/schema/field.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { Field, getFieldMetadata, type FieldMeta } from '../../src/core/schema/field';
+
+// ── Test classes ─────────────────────────────────────────────
+
+class NameInput {
+  @Field.string({ description: 'Name to greet' })
+  name!: string;
+}
+
+class AgeInput {
+  @Field.integer({ description: 'User age' })
+  age!: number;
+}
+
+class MultiFieldInput {
+  @Field.string({ description: 'First name' })
+  firstName!: string;
+
+  @Field.integer({ description: 'Birth year' })
+  year!: number;
+
+  @Field.boolean()
+  active!: boolean;
+
+  @Field.number({ description: 'Score' })
+  score!: number;
+}
+
+class OptionalFieldInput {
+  @Field.string({ description: 'Required name' })
+  name!: string;
+
+  @Field.optional(Field.string({ description: 'Optional nickname' }))
+  nickname?: string;
+}
+
+class ArrayFieldInput {
+  @Field.array(Field.string(), { description: 'List of tags' })
+  tags!: string[];
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe('@Field decorator metadata storage', () => {
+  it('stores string field metadata', () => {
+    const fields = getFieldMetadata(NameInput);
+    expect(fields).toHaveLength(1);
+    expect(fields[0]).toEqual<FieldMeta>({
+      name: 'name',
+      type: 'string',
+      description: 'Name to greet',
+      required: true,
+      nullable: false,
+    });
+  });
+
+  it('stores integer field metadata', () => {
+    const fields = getFieldMetadata(AgeInput);
+    expect(fields).toHaveLength(1);
+    expect(fields[0]).toEqual<FieldMeta>({
+      name: 'age',
+      type: 'integer',
+      description: 'User age',
+      required: true,
+      nullable: false,
+    });
+  });
+
+  it('stores number field metadata', () => {
+    const fields = getFieldMetadata(MultiFieldInput);
+    const score = fields.find((f) => f.name === 'score');
+    expect(score).toEqual<FieldMeta>({
+      name: 'score',
+      type: 'number',
+      description: 'Score',
+      required: true,
+      nullable: false,
+    });
+  });
+
+  it('stores boolean field metadata', () => {
+    const fields = getFieldMetadata(MultiFieldInput);
+    const active = fields.find((f) => f.name === 'active');
+    expect(active).toEqual<FieldMeta>({
+      name: 'active',
+      type: 'boolean',
+      description: undefined,
+      required: true,
+      nullable: false,
+    });
+  });
+
+  it('stores multiple fields in declaration order', () => {
+    const fields = getFieldMetadata(MultiFieldInput);
+    expect(fields).toHaveLength(4);
+    expect(fields.map((f) => f.name)).toEqual(['firstName', 'year', 'active', 'score']);
+  });
+
+  it('marks optional fields as not required and nullable', () => {
+    const fields = getFieldMetadata(OptionalFieldInput);
+    expect(fields).toHaveLength(2);
+
+    const name = fields.find((f) => f.name === 'name');
+    expect(name!.required).toBe(true);
+    expect(name!.nullable).toBe(false);
+
+    const nickname = fields.find((f) => f.name === 'nickname');
+    expect(nickname!.required).toBe(false);
+    expect(nickname!.nullable).toBe(true);
+    expect(nickname!.description).toBe('Optional nickname');
+  });
+
+  it('stores array field metadata with items', () => {
+    const fields = getFieldMetadata(ArrayFieldInput);
+    expect(fields).toHaveLength(1);
+    expect(fields[0]).toEqual<FieldMeta>({
+      name: 'tags',
+      type: 'array',
+      description: 'List of tags',
+      required: true,
+      nullable: false,
+      items: { type: 'string' },
+    });
+  });
+
+  it('returns empty array for class with no decorators', () => {
+    class PlainClass {
+      foo = 42;
+    }
+    expect(getFieldMetadata(PlainClass)).toEqual([]);
+  });
+});

--- a/ts/test/schema/field_example.test.ts
+++ b/ts/test/schema/field_example.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { Field, getFieldMetadata, type FieldMeta } from '../../src/core/schema/field';
+import { Input, Output } from '../../src/core/usecase';
+
+// ── Test DTOs with example values ──────────────────────────────
+
+class ExampleInput extends Input {
+  @Field.string({ description: 'User name', example: 'Alice' })
+  name!: string;
+
+  @Field.integer({ description: 'User age', example: 30 })
+  age!: number;
+
+  @Field.number({ description: 'Score', example: 9.5 })
+  score!: number;
+
+  @Field.boolean({ description: 'Active?', example: true })
+  active!: boolean;
+
+  @Field.array(Field.string(), { description: 'Tags', example: ['dart', 'ts'] })
+  tags!: string[];
+
+  static fromJson(json: Record<string, unknown>): ExampleInput {
+    const i = new ExampleInput();
+    i.name = json['name'] as string;
+    i.age = json['age'] as number;
+    i.score = json['score'] as number;
+    i.active = json['active'] as boolean;
+    i.tags = json['tags'] as string[];
+    return i;
+  }
+}
+
+class ExampleOutput extends Output {
+  @Field.string({ description: 'Greeting', example: 'Hello Alice' })
+  greeting!: string;
+
+  get statusCode() {
+    return 200;
+  }
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe('@Field example metadata', () => {
+  it('stores example on string field', () => {
+    const fields = getFieldMetadata(ExampleInput);
+    const nameField = fields.find(f => f.name === 'name');
+    expect(nameField?.example).toBe('Alice');
+  });
+
+  it('stores example on integer field', () => {
+    const fields = getFieldMetadata(ExampleInput);
+    const ageField = fields.find(f => f.name === 'age');
+    expect(ageField?.example).toBe(30);
+  });
+
+  it('stores example on number field', () => {
+    const fields = getFieldMetadata(ExampleInput);
+    const scoreField = fields.find(f => f.name === 'score');
+    expect(scoreField?.example).toBe(9.5);
+  });
+
+  it('stores example on boolean field', () => {
+    const fields = getFieldMetadata(ExampleInput);
+    const activeField = fields.find(f => f.name === 'active');
+    expect(activeField?.example).toBe(true);
+  });
+
+  it('stores example on array field', () => {
+    const fields = getFieldMetadata(ExampleInput);
+    const tagsField = fields.find(f => f.name === 'tags');
+    expect(tagsField?.example).toEqual(['dart', 'ts']);
+  });
+});
+
+describe('buildSchemaFromMetadata with example', () => {
+  it('emits per-property example in schema', () => {
+    const schema = new ExampleInput().toSchema();
+    const props = schema['properties'] as Record<string, Record<string, unknown>>;
+    expect(props['name']['example']).toBe('Alice');
+    expect(props['age']['example']).toBe(30);
+    expect(props['score']['example']).toBe(9.5);
+    expect(props['active']['example']).toBe(true);
+    expect(props['tags']['example']).toEqual(['dart', 'ts']);
+  });
+
+  it('emits top-level example object', () => {
+    const schema = new ExampleInput().toSchema();
+    expect(schema['example']).toEqual({
+      name: 'Alice',
+      age: 30,
+      score: 9.5,
+      active: true,
+      tags: ['dart', 'ts'],
+    });
+  });
+
+  it('Output schema also has example', () => {
+    const schema = new ExampleOutput().toSchema();
+    const props = schema['properties'] as Record<string, Record<string, unknown>>;
+    expect(props['greeting']['example']).toBe('Hello Alice');
+    expect(schema['example']).toEqual({ greeting: 'Hello Alice' });
+  });
+
+  it('schemas without example omit the example key', () => {
+    // FieldOptions without example → no example in schema
+    class NoExampleInput extends Input {
+      @Field.string({ description: 'Just a name' })
+      name!: string;
+    }
+    const schema = new NoExampleInput().toSchema();
+    const props = schema['properties'] as Record<string, Record<string, unknown>>;
+    expect(props['name']).not.toHaveProperty('example');
+    expect(schema).not.toHaveProperty('example');
+  });
+});

--- a/ts/test/schema_conformance.test.ts
+++ b/ts/test/schema_conformance.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// Import example DTOs — we need their toSchema() output
+// The example file doesn't export, so we replicate the DTO definitions here
+// to test against the shared fixture. Once auto-schema lands, these become
+// the @Field-decorated versions.
+
+import { Input, Output } from '../../src/core/usecase';
+
+class HelloInput implements Input {
+  constructor(readonly name: string) {}
+
+  static fromJson(json: Record<string, unknown>): HelloInput {
+    return new HelloInput((json['name'] ?? '').toString());
+  }
+
+  toJson() {
+    return { name: this.name };
+  }
+
+  toSchema() {
+    return {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Name to greet' },
+      },
+      required: ['name'],
+    };
+  }
+}
+
+class HelloOutput implements Output {
+  constructor(readonly message: string) {}
+
+  get statusCode() {
+    return 200;
+  }
+
+  toJson() {
+    return { message: this.message };
+  }
+
+  toSchema() {
+    return {
+      type: 'object',
+      properties: {
+        message: { type: 'string', description: 'Greeting message' },
+      },
+      required: ['message'],
+    };
+  }
+}
+
+const fixturesDir = resolve(__dirname, '../..', 'tests', 'fixtures');
+
+function loadFixture(name: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(resolve(fixturesDir, name), 'utf-8'));
+}
+
+describe('Schema Conformance', () => {
+  it('HelloInput schema matches shared fixture', () => {
+    const fixture = loadFixture('hello_input_schema.json');
+    const input = new HelloInput('test');
+    expect(input.toSchema()).toEqual(fixture);
+  });
+
+  it('HelloOutput schema matches shared fixture', () => {
+    const fixture = loadFixture('hello_output_schema.json');
+    const output = new HelloOutput('test');
+    expect(output.toSchema()).toEqual(fixture);
+  });
+});

--- a/ts/test/schema_conformance.test.ts
+++ b/ts/test/schema_conformance.test.ts
@@ -2,54 +2,34 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
-// Import example DTOs — we need their toSchema() output
-// The example file doesn't export, so we replicate the DTO definitions here
-// to test against the shared fixture. Once auto-schema lands, these become
-// the @Field-decorated versions.
+// Input/Output with @Field decorators — the new auto-schema pattern
 
-import { Input, Output } from '../../src/core/usecase';
+import { Input, Output } from '../src/core/usecase';
+import { Field } from '../src/core/schema/field';
 
-class HelloInput implements Input {
-  constructor(readonly name: string) {}
+class HelloInput extends Input {
+  @Field.string({ description: 'Name to greet' })
+  name!: string;
 
   static fromJson(json: Record<string, unknown>): HelloInput {
-    return new HelloInput((json['name'] ?? '').toString());
-  }
-
-  toJson() {
-    return { name: this.name };
-  }
-
-  toSchema() {
-    return {
-      type: 'object',
-      properties: {
-        name: { type: 'string', description: 'Name to greet' },
-      },
-      required: ['name'],
-    };
+    const instance = new HelloInput();
+    instance.name = (json['name'] ?? '').toString();
+    return instance;
   }
 }
 
-class HelloOutput implements Output {
-  constructor(readonly message: string) {}
+class HelloOutput extends Output {
+  @Field.string({ description: 'Greeting message' })
+  message!: string;
 
   get statusCode() {
     return 200;
   }
 
-  toJson() {
-    return { message: this.message };
-  }
-
-  toSchema() {
-    return {
-      type: 'object',
-      properties: {
-        message: { type: 'string', description: 'Greeting message' },
-      },
-      required: ['message'],
-    };
+  static fromJson(json: Record<string, unknown>): HelloOutput {
+    const instance = new HelloOutput();
+    instance.message = (json['message'] ?? '').toString();
+    return instance;
   }
 }
 
@@ -62,13 +42,13 @@ function loadFixture(name: string): Record<string, unknown> {
 describe('Schema Conformance', () => {
   it('HelloInput schema matches shared fixture', () => {
     const fixture = loadFixture('hello_input_schema.json');
-    const input = new HelloInput('test');
+    const input = new HelloInput();
     expect(input.toSchema()).toEqual(fixture);
   });
 
   it('HelloOutput schema matches shared fixture', () => {
     const fixture = loadFixture('hello_output_schema.json');
-    const output = new HelloOutput('test');
+    const output = new HelloOutput();
     expect(output.toSchema()).toEqual(fixture);
   });
 });

--- a/ts/test/schema_conformance.test.ts
+++ b/ts/test/schema_conformance.test.ts
@@ -8,7 +8,7 @@ import { Input, Output } from '../src/core/usecase';
 import { Field } from '../src/core/schema/field';
 
 class HelloInput extends Input {
-  @Field.string({ description: 'Name to greet' })
+  @Field.string({ description: 'Name to greet', example: 'World' })
   name!: string;
 
   static fromJson(json: Record<string, unknown>): HelloInput {
@@ -19,7 +19,7 @@ class HelloInput extends Input {
 }
 
 class HelloOutput extends Output {
-  @Field.string({ description: 'Greeting message' })
+  @Field.string({ description: 'Greeting message', example: 'Hello, World!' })
   message!: string;
 
   get statusCode() {

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "commonjs",
-    "lib": ["ES2020"],
+    "lib": ["ES2022"],
     "outDir": "./dist",
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
## Summary

Auto-generate OpenAPI schemas with realistic example values across all 3 SDKs (Dart, TypeScript, Python) — like FastAPI shows `name: "Sebastián"` instead of `name: "string"`.

## What changed

### Schema & Examples
- **Dart**: `SchemaField` gains `example` param; `inferSchemaFromExample()` infers OpenAPI types from `toJson()` values; `toSchema()` falls back to inference when `schemaFields` is null
- **TypeScript**: `@Field.string({ example: 'World' })` stores example in `FieldMeta`; `buildSchemaFromMetadata` emits per-property + top-level `example`
- **Python**: `_normalize_schema` converts Pydantic `Field(examples=['World'])` → OpenAPI singular `example`

### Handler Pre-validation (strict fromJson)
- **Dart**: `useCaseHttpHandler` accepts optional `inputExample`; validates BEFORE `fromJson` — enables strict factories (no `?? ''` coercion)
- **TypeScript**: `useCaseHandler` accepts optional `inputClass`; pre-validates via `Input.validateJson()` before factory call
- **Python**: Already strict via `model_validate(strict=True)` — no handler changes needed

### Registration & OpenAPI
- **Dart**: `ModuleBuilder.usecase()` gains `inputExample`/`outputExample`; OpenAPI extracts schema from example instead of `factory({})`
- **TypeScript**: `UseCaseOptions` gains `inputClass`/`outputClass`; schema extraction prefers class-level metadata
- Shared fixtures updated with `example` values; parity conformance tests aligned

### Examples updated (all 3 SDKs)
- Strict `fromJson` (no coercion)
- `@Field` / `SchemaField` with example values
- Registration passes example/class references

## Tests

| SDK | Tests | Status |
|-----|-------|--------|
| Dart | 287 | ✅ |
| TypeScript | 207 | ✅ |
| Python | 315 | ✅ |
| Parity | 195 | ✅ |

## Breaking changes

Example `fromJson` factories in all 3 SDKs are now strict (no coercion). This is acceptable in 0.x.x per semver.
