### PR TITLE
feat: v0.4.3 — execute() returns Output + naming convention

### DIFF
--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -16,6 +16,10 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 - **`inputExample` / `outputExample` now required** in `ModuleBuilder.usecase()` — OpenAPI schema extraction uses them directly
 - **Removed Strategy 2 fallback** in OpenAPI schema extraction — no `factory({}).output` path
 
+### Removed
+
+- **`@Field` annotation** — was decorative only (no runtime effect in Dart); `schemaFields` getter is the sole schema source
+
 ## [0.4.2] - 2026-03-12
 
 ### Added

--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -6,6 +6,16 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+## [0.4.3] - 2026-03-13
+
+### Changed (BREAKING)
+
+- **`execute()` returns `Future<O>`** — no longer `Future<void>`; the handler reads the returned Output directly
+- **Removed `output` field** from `UseCase` — no mutable state; `execute()` returns the result
+- **Removed `toJson()`** from `UseCase` — the handler calls `output.toJson()` on the returned value
+- **`inputExample` / `outputExample` now required** in `ModuleBuilder.usecase()` — OpenAPI schema extraction uses them directly
+- **Removed Strategy 2 fallback** in OpenAPI schema extraction — no `factory({}).output` path
+
 ## [0.4.2] - 2026-03-12
 
 ### Added

--- a/dart/README.md
+++ b/dart/README.md
@@ -51,7 +51,7 @@ See `example/example.dart` for the full implementation including Input, Output, 
 ## Features
 
 - `UseCase<I, O>` — pure business logic, no HTTP concerns
-- `Input` / `Output` — DTOs with automatic OpenAPI schema generation via `@Field` + `schemaFields`
+- `Input` / `Output` — DTOs with automatic OpenAPI schema generation via `schemaFields`
 - `Output.statusCode` — custom HTTP status codes per response
 - `UseCaseException` — structured error handling (status code, message, error code, details)
 - `ModularApi` + `ModuleBuilder` — module registration and routing

--- a/dart/doc/logger_guide.md
+++ b/dart/doc/logger_guide.md
@@ -67,7 +67,7 @@ class CreateUser extends UseCase<CreateUserInput, CreateUserOutput> {
       CreateUser(input: CreateUserInput.fromJson(json));
 
   @override
-  Future<void> execute() async {
+  Future<CreateUserOutput> execute() async {
     logger?.info('Creating user: ${input.email}');
     
     // ... business logic ...
@@ -77,7 +77,7 @@ class CreateUser extends UseCase<CreateUserInput, CreateUserOutput> {
       'email': input.email,
     });
     
-    output = CreateUserOutput(id: newUser.id);
+    return CreateUserOutput(id: newUser.id);
   }
 }
 ```

--- a/dart/doc/naming_guide.md
+++ b/dart/doc/naming_guide.md
@@ -41,7 +41,7 @@ file:     hello_world.dart
 class:    HelloWorld
 input:    HelloWorldInput
 output:   HelloWorldOutput
-schema:   greetings_hello-world_Input / greetings_hello-world_Output
+schema:   greetings_hello_world_Input / greetings_hello_world_Output
 ```
 
 ---

--- a/dart/doc/naming_guide.md
+++ b/dart/doc/naming_guide.md
@@ -1,0 +1,58 @@
+# Naming Guide
+
+Naming conventions for commands, classes, and files in `modular_api`.
+
+---
+
+## Core Rule
+
+The **command**, the **UseCase class**, and the **file** share the same root:
+
+| Layer | Format | Example |
+|---|---|---|
+| Command (route segment) | `kebab-case` | `'hello-world'` |
+| UseCase class | `PascalCase` | `HelloWorld` |
+| File | `snake_case` | `hello_world.dart` |
+
+The command string passed to `m.usecase(command, ...)` becomes the URL segment
+(`/module/command`) and the root for every related symbol.
+
+---
+
+## Input / Output DTOs
+
+Append `Input` and `Output` to the UseCase class name:
+
+```dart
+class HelloWorldInput extends Input { ... }
+class HelloWorldOutput extends Output { ... }
+class HelloWorld implements UseCase<HelloWorldInput, HelloWorldOutput> { ... }
+```
+
+---
+
+## Full Example
+
+```
+command:  'hello-world'
+route:    POST /api/v1/greetings/hello-world
+
+file:     hello_world.dart
+class:    HelloWorld
+input:    HelloWorldInput
+output:   HelloWorldOutput
+schema:   greetings_hello-world_Input / greetings_hello-world_Output
+```
+
+---
+
+## Why "Command"?
+
+Use cases are **commands** — explicit, validated operations that change state
+(POST, PUT, PATCH, DELETE). This terminology aligns with the CQRS architecture
+planned for v0.6.0, where:
+
+- **Commands** → REST endpoints (use cases) — write operations
+- **Queries** → GraphQL plugin — read operations
+
+See [roadmap.md](../../docs/roadmap.md) for the full CQRS vision.

--- a/dart/doc/testing_guide.md
+++ b/dart/doc/testing_guide.md
@@ -103,14 +103,11 @@ class SumNumbers implements UseCase<SumInput, SumOutput> {
   }
 
   @override
-  Future<void> execute() async {
+  Future<SumOutput> execute() async {
     final result = input.a + input.b;
     await repository.saveResult(result);
-    output = SumOutput(result: result);
+    return SumOutput(result: result);
   }
-
-  @override
-  Map<String, dynamic> toJson() => output.toJson();
 }
 ```
 

--- a/dart/doc/testing_guide.md
+++ b/dart/doc/testing_guide.md
@@ -35,10 +35,8 @@ abstract class SumRepository {
 }
 
 class SumInput extends Input {
-  @Field(description: 'First operand')
   final int a;
 
-  @Field(description: 'Second operand')
   final int b;
   
   SumInput({required this.a, required this.b});
@@ -59,7 +57,6 @@ class SumInput extends Input {
 }
 
 class SumOutput extends Output {
-  @Field(description: 'Sum result')
   final int result;
   
   SumOutput({required this.result});

--- a/dart/doc/usecase_dto_guide.md
+++ b/dart/doc/usecase_dto_guide.md
@@ -15,7 +15,9 @@ Each DTO must implement:
 2. `toJson` — method to serialize to JSON
 3. `schemaFields` — getter that returns field metadata for automatic OpenAPI schema generation
 
-The `@Field` annotation is decorative — it documents intent per field. Schema generation is driven by the `schemaFields` getter and `SchemaField` metadata.
+The `schemaFields` getter returns field metadata for automatic OpenAPI schema generation.
+
+Schema generation is driven by the `schemaFields` getter and `SchemaField` metadata.
 
 ---
 
@@ -46,13 +48,10 @@ class CasoOutput {
 import 'package:modular_api/modular_api.dart';
 
 class CasoInput extends Input {
-  @Field(description: 'Integer value')
   final int valor;
 
-  @Field(description: 'String value')
   final String valor2;
 
-  @Field(description: 'Double value')
   final double valor3;
 
   CasoInput({
@@ -93,13 +92,10 @@ class CasoInput extends Input {
 import 'package:modular_api/modular_api.dart';
 
 class CasoOutput extends Output {
-  @Field(description: 'Integer value')
   final int valor;
 
-  @Field(description: 'String value')
   final String valor2;
 
-  @Field(description: 'Double value')
   final double valor3;
 
   CasoOutput({
@@ -160,16 +156,12 @@ Use this table to map Dart types to `SchemaField` factories:
 
 ```dart
 class ProductInput extends Input {
-  @Field(description: 'Product name')
   final String name;
 
-  @Field(description: 'Product price')
   final double price;
 
-  @Field(description: 'Product description (optional)')
   final String? description;
 
-  @Field(description: 'Available stock (optional)')
   final int? stock;
 
   ProductInput({
@@ -212,10 +204,8 @@ class ProductInput extends Input {
 
 ```dart
 class UserInput extends Input {
-  @Field(description: 'User name')
   final String name;
 
-  @Field(description: 'User roles')
   final List<String> roles;
 
   UserInput({required this.name, required this.roles});
@@ -246,8 +236,7 @@ If your DTOs currently override `toSchema()` manually, you can migrate to the `s
 
 1. **Add `schemaFields` getter** — Declare each field as a `SchemaField` with the appropriate factory
 2. **Remove `toSchema()` override** — The base class `toSchema()` calls `buildSchema(schemaFields)` automatically
-3. **Add `@Field` annotations** (optional) — Document intent per field
-4. **Change `implements` to `extends`** — Use `extends Input`/`extends Output` instead of `implements`
+3. **Change `implements` to `extends`** — Use `extends Input`/`extends Output` instead of `implements`
 
 **Before (manual):**
 ```dart
@@ -271,7 +260,6 @@ class MyInput implements Input {
 **After (auto-schema):**
 ```dart
 class MyInput extends Input {
-  @Field(description: 'User name')
   final String name;
   // ... fromJson, toJson ...
 
@@ -282,7 +270,7 @@ class MyInput extends Input {
 }
 ```
 
-> **Note:** Manual `toSchema()` overrides still work in v0.4.2 — they are deprecated but not removed. When Dart macros stabilize, `@MacssSchema()` will replace the `schemaFields` getter entirely.
+> **Note:** Manual `toSchema()` overrides still work but are deprecated. Use the `schemaFields` getter instead.
 
 ---
 
@@ -295,7 +283,6 @@ When creating or updating Input/Output DTOs, ensure:
 - [ ] `fromJson` factory constructor is implemented
 - [ ] `toJson` method is implemented and overrides base class
 - [ ] `schemaFields` getter is implemented with `SchemaField` entries for each field
-- [ ] `@Field` annotation is present on each property (optional but recommended)
 - [ ] SchemaField factory matches Dart type (see Type Mapping Reference)
 - [ ] Nullable fields use `nullable: true` in their `SchemaField`
 - [ ] Optional fields use nullable Dart types (`Type?`)
@@ -314,7 +301,6 @@ Copy and adapt this template for new DTOs:
 import 'package:modular_api/modular_api.dart';
 
 class MyUseCaseInput extends Input {
-  @Field(description: 'Description here')
   final String myField;
 
   MyUseCaseInput({required this.myField});
@@ -333,7 +319,6 @@ class MyUseCaseInput extends Input {
 }
 
 class MyUseCaseOutput extends Output {
-  @Field(description: 'Description here')
   final String result;
 
   MyUseCaseOutput({required this.result});

--- a/dart/example/example.dart
+++ b/dart/example/example.dart
@@ -5,10 +5,10 @@
 ///   dart run example/example.dart
 ///
 /// Then test:
-///   curl -X POST http://localhost:8080/api/greetings/hello \
+///   curl -X POST http://localhost:8080/api/v1/greetings/hello \
 ///        -H "Content-Type: application/json" \
 ///        -d '{"name":"World"}'
-///   curl http://localhost:8080/api/time/now?tz=utc-5
+///   curl http://localhost:8080/api/v1/time/now?tz=utc-5
 ///
 /// Docs:
 ///   http://localhost:8080/docs
@@ -27,7 +27,7 @@ Future<void> main(List<String> args) async {
   final port = args.isNotEmpty ? int.parse(args.first) : 8080;
 
   final api = ModularApi(
-    basePath: '/api',
+    basePath: '/api/v1',
     title: 'Modular API',
     version: '1.0.0',
     // Opt-in Prometheus metrics at GET /metrics

--- a/dart/example/example.dart
+++ b/dart/example/example.dart
@@ -62,7 +62,6 @@ void buildGreetingsModule(ModuleBuilder m) {
 // ─── Input DTO ────────────────────────────────────────────────────────────────
 
 class HelloInput extends Input {
-  @Field(description: 'Name to greet')
   final String name;
 
   HelloInput({required this.name});
@@ -83,7 +82,6 @@ class HelloInput extends Input {
 // ─── Output DTO ───────────────────────────────────────────────────────────────
 
 class HelloOutput extends Output {
-  @Field(description: 'Greeting message')
   final String message;
 
   HelloOutput({required this.message});

--- a/dart/example/example.dart
+++ b/dart/example/example.dart
@@ -8,12 +8,17 @@
 ///   curl -X POST http://localhost:8080/api/greetings/hello \
 ///        -H "Content-Type: application/json" \
 ///        -d '{"name":"World"}'
+///   curl http://localhost:8080/api/time/now?tz=utc-5
 ///
 /// Docs:
 ///   http://localhost:8080/docs
 library;
 
 import 'package:modular_api/modular_api.dart';
+
+import 'health/always_pass_health_check.dart';
+import 'modules/greetings/greetings_builder.dart';
+import 'modules/time/now_builder.dart';
 
 // ─── Server ───────────────────────────────────────────────────────────────────
 
@@ -42,109 +47,9 @@ Future<void> main(List<String> args) async {
   );
 
   api.module('greetings', buildGreetingsModule);
+  api.module('time', buildTimeModule);
 
   await api.serve(port: port);
 }
 
-// ─── Module Builder ───────────────────────────────────────────────────────────
-// In a real project, this would live in its own file:
-//   lib/modules/greetings/greetings_builder.dart
 
-void buildGreetingsModule(ModuleBuilder m) {
-  m.usecase(
-    'hello',
-    HelloWorld.fromJson,
-    inputExample: HelloInput.example,
-    outputExample: HelloOutput.example,
-  );
-}
-
-// ─── Input DTO ────────────────────────────────────────────────────────────────
-
-class HelloInput extends Input {
-  final String name;
-
-  HelloInput({required this.name});
-
-  @override
-  Map<String, dynamic> toJson() => {'name': name};
-
-  @override
-  List<SchemaField> get schemaFields => [
-        SchemaField.string('name',
-            description: 'Name to greet', example: 'World'),
-      ];
-
-  /// Example instance for schema extraction and Swagger UI.
-  static HelloInput get example => HelloInput(name: 'World');
-}
-
-// ─── Output DTO ───────────────────────────────────────────────────────────────
-
-class HelloOutput extends Output {
-  final String message;
-
-  HelloOutput({required this.message});
-
-  @override
-  int get statusCode => 200;
-
-  @override
-  Map<String, dynamic> toJson() => {'message': message};
-
-  @override
-  List<SchemaField> get schemaFields => [
-        SchemaField.string('message',
-            description: 'Greeting message', example: 'Hello, World!'),
-      ];
-
-  /// Example instance for schema extraction and Swagger UI.
-  static HelloOutput get example => HelloOutput(message: 'Hello, World!');
-}
-
-// ─── UseCase ──────────────────────────────────────────────────────────────────
-
-class HelloWorld implements UseCase<HelloInput, HelloOutput> {
-  @override
-  final HelloInput input;
-
-  @override
-  ModularLogger? logger;
-
-  HelloWorld({required this.input});
-
-  static HelloWorld fromJson(Map<String, dynamic> json) {
-    return HelloWorld(
-      input: HelloInput(
-        name: json['name'],
-      )
-    );
-  }
-
-  @override
-  String? validate() {
-    if (input.name.isEmpty) {
-      return 'name is required';
-    }
-    return null;
-  }
-
-  @override
-  Future<HelloOutput> execute() async {
-    logger?.info('Greeting user: ${input.name}');
-    return HelloOutput(message: 'Hello, ${input.name}!');
-  }
-}
-
-// ─── Example Health Check ─────────────────────────────────────────────────────
-// In a real project you'd check a database connection, external service, etc.
-
-class AlwaysPassHealthCheck extends HealthCheck {
-  @override
-  final String name = 'example';
-
-  @override
-  Future<HealthCheckResult> check() async {
-    return HealthCheckResult(status: HealthStatus.pass);
-  }
-}

--- a/dart/example/example.dart
+++ b/dart/example/example.dart
@@ -5,10 +5,10 @@
 ///   dart run example/example.dart
 ///
 /// Then test:
-///   curl -X POST http://localhost:8080/api/v1/greetings/hello \
+///   curl -X POST http://localhost:8080/api/v1/greetings/hello-world \
 ///        -H "Content-Type: application/json" \
 ///        -d '{"name":"World"}'
-///   curl http://localhost:8080/api/v1/time/now?tz=utc-5
+///   curl http://localhost:8080/api/v1/time/current-time?tz=utc-5
 ///
 /// Docs:
 ///   http://localhost:8080/docs
@@ -18,7 +18,7 @@ import 'package:modular_api/modular_api.dart';
 
 import 'health/always_pass_health_check.dart';
 import 'modules/greetings/greetings_builder.dart';
-import 'modules/time/now_builder.dart';
+import 'modules/time/time_builder.dart';
 
 // ─── Server ───────────────────────────────────────────────────────────────────
 

--- a/dart/example/example.dart
+++ b/dart/example/example.dart
@@ -67,12 +67,6 @@ class HelloInput extends Input {
 
   HelloInput({required this.name});
 
-  /// Strict factory — no coercion, no defaults.
-  /// Pre-validation in the handler ensures data is valid before this runs.
-  factory HelloInput.fromJson(Map<String, dynamic> json) => HelloInput(
-        name: json['name'] as String,
-      );
-
   @override
   Map<String, dynamic> toJson() => {'name': name};
 
@@ -93,9 +87,6 @@ class HelloOutput extends Output {
   final String message;
 
   HelloOutput({required this.message});
-
-  factory HelloOutput.fromJson(Map<String, dynamic> json) =>
-      HelloOutput(message: json['message'] as String);
 
   @override
   int get statusCode => 200;
@@ -125,7 +116,11 @@ class HelloWorld implements UseCase<HelloInput, HelloOutput> {
   HelloWorld({required this.input});
 
   static HelloWorld fromJson(Map<String, dynamic> json) {
-    return HelloWorld(input: HelloInput.fromJson(json));
+    return HelloWorld(
+      input: HelloInput(
+        name: json['name'],
+      )
+    );
   }
 
   @override

--- a/dart/example/example.dart
+++ b/dart/example/example.dart
@@ -120,14 +120,9 @@ class HelloWorld implements UseCase<HelloInput, HelloOutput> {
   final HelloInput input;
 
   @override
-  late HelloOutput output;
-
-  @override
   ModularLogger? logger;
 
-  HelloWorld({required this.input}) {
-    output = HelloOutput(message: '');
-  }
+  HelloWorld({required this.input});
 
   static HelloWorld fromJson(Map<String, dynamic> json) {
     return HelloWorld(input: HelloInput.fromJson(json));
@@ -142,13 +137,10 @@ class HelloWorld implements UseCase<HelloInput, HelloOutput> {
   }
 
   @override
-  Future<void> execute() async {
+  Future<HelloOutput> execute() async {
     logger?.info('Greeting user: ${input.name}');
-    output = HelloOutput(message: 'Hello, ${input.name}!');
+    return HelloOutput(message: 'Hello, ${input.name}!');
   }
-
-  @override
-  Map<String, dynamic> toJson() => output.toJson();
 }
 
 // ─── Example Health Check ─────────────────────────────────────────────────────

--- a/dart/example/health/always_pass_health_check.dart
+++ b/dart/example/health/always_pass_health_check.dart
@@ -1,0 +1,14 @@
+// ─── Example Health Check ─────────────────────────────────────────────────────
+// In a real project you'd check a database connection, external service, etc.
+
+import 'package:modular_api/modular_api.dart';
+
+class AlwaysPassHealthCheck extends HealthCheck {
+  @override
+  final String name = 'example';
+
+  @override
+  Future<HealthCheckResult> check() async {
+    return HealthCheckResult(status: HealthStatus.pass);
+  }
+}

--- a/dart/example/modules/greetings/greetings_builder.dart
+++ b/dart/example/modules/greetings/greetings_builder.dart
@@ -4,9 +4,9 @@ import 'usecases/hello_world.dart';
 
 void buildGreetingsModule(ModuleBuilder m) {
   m.usecase(
-    'hello',
+    'hello-world',
     HelloWorld.fromJson,
-    inputExample: HelloInput.example,
-    outputExample: HelloOutput.example,
+    inputExample: HelloWorldInput.example,
+    outputExample: HelloWorldOutput.example,
   );
 }

--- a/dart/example/modules/greetings/greetings_builder.dart
+++ b/dart/example/modules/greetings/greetings_builder.dart
@@ -1,0 +1,12 @@
+import 'package:modular_api/modular_api.dart';
+
+import 'usecases/hello_world.dart';
+
+void buildGreetingsModule(ModuleBuilder m) {
+  m.usecase(
+    'hello',
+    HelloWorld.fromJson,
+    inputExample: HelloInput.example,
+    outputExample: HelloOutput.example,
+  );
+}

--- a/dart/example/modules/greetings/usecases/hello_world.dart
+++ b/dart/example/modules/greetings/usecases/hello_world.dart
@@ -2,10 +2,10 @@
 
 import 'package:modular_api/modular_api.dart';
 
-class HelloInput extends Input {
+class HelloWorldInput extends Input {
   final String name;
 
-  HelloInput({required this.name});
+  HelloWorldInput({required this.name});
 
   @override
   Map<String, dynamic> toJson() => {'name': name};
@@ -17,15 +17,15 @@ class HelloInput extends Input {
       ];
 
   /// Example instance for schema extraction and Swagger UI.
-  static HelloInput get example => HelloInput(name: 'World');
+  static HelloWorldInput get example => HelloWorldInput(name: 'World');
 }
 
 // ─── Output DTO ───────────────────────────────────────────────────────────────
 
-class HelloOutput extends Output {
+class HelloWorldOutput extends Output {
   final String message;
 
-  HelloOutput({required this.message});
+  HelloWorldOutput({required this.message});
 
   @override
   int get statusCode => 200;
@@ -40,14 +40,14 @@ class HelloOutput extends Output {
       ];
 
   /// Example instance for schema extraction and Swagger UI.
-  static HelloOutput get example => HelloOutput(message: 'Hello, World!');
+  static HelloWorldOutput get example => HelloWorldOutput(message: 'Hello, World!');
 }
 
 // ─── UseCase ──────────────────────────────────────────────────────────────────
 
-class HelloWorld implements UseCase<HelloInput, HelloOutput> {
+class HelloWorld implements UseCase<HelloWorldInput, HelloWorldOutput> {
   @override
-  final HelloInput input;
+  final HelloWorldInput input;
 
   @override
   ModularLogger? logger;
@@ -56,7 +56,7 @@ class HelloWorld implements UseCase<HelloInput, HelloOutput> {
 
   static HelloWorld fromJson(Map<String, dynamic> json) {
     return HelloWorld(
-      input: HelloInput(
+      input: HelloWorldInput(
         name: json['name'],
       )
     );
@@ -71,8 +71,8 @@ class HelloWorld implements UseCase<HelloInput, HelloOutput> {
   }
 
   @override
-  Future<HelloOutput> execute() async {
+  Future<HelloWorldOutput> execute() async {
     logger?.info('Greeting user: ${input.name}');
-    return HelloOutput(message: 'Hello, ${input.name}!');
+    return HelloWorldOutput(message: 'Hello, ${input.name}!');
   }
 }

--- a/dart/example/modules/greetings/usecases/hello_world.dart
+++ b/dart/example/modules/greetings/usecases/hello_world.dart
@@ -1,0 +1,78 @@
+// ─── Input DTO ────────────────────────────────────────────────────────────────
+
+import 'package:modular_api/modular_api.dart';
+
+class HelloInput extends Input {
+  final String name;
+
+  HelloInput({required this.name});
+
+  @override
+  Map<String, dynamic> toJson() => {'name': name};
+
+  @override
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('name',
+            description: 'Name to greet', example: 'World'),
+      ];
+
+  /// Example instance for schema extraction and Swagger UI.
+  static HelloInput get example => HelloInput(name: 'World');
+}
+
+// ─── Output DTO ───────────────────────────────────────────────────────────────
+
+class HelloOutput extends Output {
+  final String message;
+
+  HelloOutput({required this.message});
+
+  @override
+  int get statusCode => 200;
+
+  @override
+  Map<String, dynamic> toJson() => {'message': message};
+
+  @override
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('message',
+            description: 'Greeting message', example: 'Hello, World!'),
+      ];
+
+  /// Example instance for schema extraction and Swagger UI.
+  static HelloOutput get example => HelloOutput(message: 'Hello, World!');
+}
+
+// ─── UseCase ──────────────────────────────────────────────────────────────────
+
+class HelloWorld implements UseCase<HelloInput, HelloOutput> {
+  @override
+  final HelloInput input;
+
+  @override
+  ModularLogger? logger;
+
+  HelloWorld({required this.input});
+
+  static HelloWorld fromJson(Map<String, dynamic> json) {
+    return HelloWorld(
+      input: HelloInput(
+        name: json['name'],
+      )
+    );
+  }
+
+  @override
+  String? validate() {
+    if (input.name.isEmpty) {
+      return 'name is required';
+    }
+    return null;
+  }
+
+  @override
+  Future<HelloOutput> execute() async {
+    logger?.info('Greeting user: ${input.name}');
+    return HelloOutput(message: 'Hello, ${input.name}!');
+  }
+}

--- a/dart/example/modules/time/now_builder.dart
+++ b/dart/example/modules/time/now_builder.dart
@@ -1,0 +1,13 @@
+import 'package:modular_api/modular_api.dart';
+
+import 'usecases/now.dart';
+
+void buildTimeModule(ModuleBuilder m) {
+  m.usecase(
+    'now',
+    CurrentTime.fromJson,
+    inputExample: TimeInput.example,
+    outputExample: TimeOutput.example,
+    method: 'GET',
+  );
+}

--- a/dart/example/modules/time/time_builder.dart
+++ b/dart/example/modules/time/time_builder.dart
@@ -1,13 +1,13 @@
 import 'package:modular_api/modular_api.dart';
 
-import 'usecases/now.dart';
+import 'usecases/current_time.dart';
 
 void buildTimeModule(ModuleBuilder m) {
   m.usecase(
-    'now',
+    'current-time',
     CurrentTime.fromJson,
-    inputExample: TimeInput.example,
-    outputExample: TimeOutput.example,
+    inputExample: CurrentTimeInput.example,
+    outputExample: CurrentTimeOutput.example,
     method: 'GET',
   );
 }

--- a/dart/example/modules/time/usecases/current_time.dart
+++ b/dart/example/modules/time/usecases/current_time.dart
@@ -2,10 +2,10 @@ import 'package:modular_api/modular_api.dart';
 
 // ─── Input DTO ────────────────────────────────────────────────────────────────
 
-class TimeInput extends Input {
+class CurrentTimeInput extends Input {
   final String tz;
 
-  TimeInput({this.tz = ''});
+  CurrentTimeInput({this.tz = ''});
 
   @override
   Map<String, dynamic> toJson() => {'tz': tz};
@@ -19,16 +19,16 @@ class TimeInput extends Input {
         ),
       ];
 
-  static TimeInput get example => TimeInput(tz: 'utc-5');
+  static CurrentTimeInput get example => CurrentTimeInput(tz: 'utc-5');
 }
 
 // ─── Output DTO ───────────────────────────────────────────────────────────────
 
-class TimeOutput extends Output {
+class CurrentTimeOutput extends Output {
   final String datetime;
   final int offset;
 
-  TimeOutput({required this.datetime, required this.offset});
+  CurrentTimeOutput({required this.datetime, required this.offset});
 
   @override
   int get statusCode => 200;
@@ -45,15 +45,15 @@ class TimeOutput extends Output {
             description: 'UTC offset in hours', example: -5),
       ];
 
-  static TimeOutput get example =>
-      TimeOutput(datetime: '2026-03-14T07:00:00', offset: -5);
+  static CurrentTimeOutput get example =>
+      CurrentTimeOutput(datetime: '2026-03-14T07:00:00', offset: -5);
 }
 
 // ─── UseCase ──────────────────────────────────────────────────────────────────
 
-class CurrentTime implements UseCase<TimeInput, TimeOutput> {
+class CurrentTime implements UseCase<CurrentTimeInput, CurrentTimeOutput> {
   @override
-  final TimeInput input;
+  final CurrentTimeInput input;
 
   @override
   ModularLogger? logger;
@@ -61,7 +61,7 @@ class CurrentTime implements UseCase<TimeInput, TimeOutput> {
   CurrentTime({required this.input});
 
   static CurrentTime fromJson(Map<String, dynamic> json) {
-    return CurrentTime(input: TimeInput(tz: (json['tz'] ?? '').toString()));
+    return CurrentTime(input: CurrentTimeInput(tz: (json['tz'] ?? '').toString()));
   }
 
   @override
@@ -74,7 +74,7 @@ class CurrentTime implements UseCase<TimeInput, TimeOutput> {
   }
 
   @override
-  Future<TimeOutput> execute() async {
+  Future<CurrentTimeOutput> execute() async {
     final now = DateTime.now().toUtc();
     final offsetHours = input.tz.isEmpty
         ? DateTime.now().timeZoneOffset.inHours
@@ -83,7 +83,7 @@ class CurrentTime implements UseCase<TimeInput, TimeOutput> {
     final iso = adjusted.toIso8601String().split('.').first;
 
     logger?.info('Time requested for offset $offsetHours');
-    return TimeOutput(datetime: iso, offset: offsetHours);
+    return CurrentTimeOutput(datetime: iso, offset: offsetHours);
   }
 
   /// Parses "utc-5", "utc+3", "utc" into an integer offset. Returns null on bad format.

--- a/dart/example/modules/time/usecases/now.dart
+++ b/dart/example/modules/time/usecases/now.dart
@@ -1,0 +1,97 @@
+import 'package:modular_api/modular_api.dart';
+
+// ─── Input DTO ────────────────────────────────────────────────────────────────
+
+class TimeInput extends Input {
+  final String tz;
+
+  TimeInput({this.tz = ''});
+
+  @override
+  Map<String, dynamic> toJson() => {'tz': tz};
+
+  @override
+  List<SchemaField> get schemaFields => [
+        SchemaField.optional(
+          SchemaField.string('tz',
+              description: 'Timezone offset (e.g. utc-5, utc+3, utc)',
+              example: 'utc-5'),
+        ),
+      ];
+
+  static TimeInput get example => TimeInput(tz: 'utc-5');
+}
+
+// ─── Output DTO ───────────────────────────────────────────────────────────────
+
+class TimeOutput extends Output {
+  final String datetime;
+  final int offset;
+
+  TimeOutput({required this.datetime, required this.offset});
+
+  @override
+  int get statusCode => 200;
+
+  @override
+  Map<String, dynamic> toJson() => {'datetime': datetime, 'offset': offset};
+
+  @override
+  List<SchemaField> get schemaFields => [
+        SchemaField.string('datetime',
+            description: 'ISO 8601 datetime at the requested offset',
+            example: '2026-03-14T07:00:00'),
+        SchemaField.integer('offset',
+            description: 'UTC offset in hours', example: -5),
+      ];
+
+  static TimeOutput get example =>
+      TimeOutput(datetime: '2026-03-14T07:00:00', offset: -5);
+}
+
+// ─── UseCase ──────────────────────────────────────────────────────────────────
+
+class CurrentTime implements UseCase<TimeInput, TimeOutput> {
+  @override
+  final TimeInput input;
+
+  @override
+  ModularLogger? logger;
+
+  CurrentTime({required this.input});
+
+  static CurrentTime fromJson(Map<String, dynamic> json) {
+    return CurrentTime(input: TimeInput(tz: (json['tz'] ?? '').toString()));
+  }
+
+  @override
+  String? validate() {
+    if (input.tz.isEmpty) return null;
+    final offset = _parseOffset(input.tz);
+    if (offset == null) return 'invalid timezone format, use utc, utc-5, utc+3';
+    if (offset < -12 || offset > 14) return 'offset must be between -12 and +14';
+    return null;
+  }
+
+  @override
+  Future<TimeOutput> execute() async {
+    final now = DateTime.now().toUtc();
+    final offsetHours = input.tz.isEmpty
+        ? DateTime.now().timeZoneOffset.inHours
+        : _parseOffset(input.tz)!;
+    final adjusted = now.add(Duration(hours: offsetHours));
+    final iso = adjusted.toIso8601String().split('.').first;
+
+    logger?.info('Time requested for offset $offsetHours');
+    return TimeOutput(datetime: iso, offset: offsetHours);
+  }
+
+  /// Parses "utc-5", "utc+3", "utc" into an integer offset. Returns null on bad format.
+  static int? _parseOffset(String tz) {
+    final lower = tz.toLowerCase().trim();
+    if (lower == 'utc') return 0;
+    final match = RegExp(r'^utc([+-]\d{1,2})$').firstMatch(lower);
+    if (match == null) return null;
+    return int.tryParse(match.group(1)!);
+  }
+}

--- a/dart/lib/modular_api.dart
+++ b/dart/lib/modular_api.dart
@@ -12,7 +12,6 @@ export 'src/core/usecase/usecase.dart' show UseCase, Input, Output;
 export 'src/core/usecase/use_case_exception.dart' show UseCaseException;
 export 'src/core/schema/field.dart'
     show
-        Field,
         SchemaField,
         buildSchema,
         InputValidationException,

--- a/dart/lib/src/core/modular_api.dart
+++ b/dart/lib/src/core/modular_api.dart
@@ -213,8 +213,8 @@ class ModuleBuilder {
     String method = 'POST',
     String? summary,
     String? description,
-    Input? inputExample,
-    Output? outputExample,
+    required Input inputExample,
+    required Output outputExample,
   }) {
     Handler h = useCaseHttpHandler(usecaseFactory, inputExample: inputExample);
 
@@ -301,12 +301,11 @@ class UseCaseRegistration {
   final UseCaseDocMeta? doc;
 
   /// Example Input instance for schema extraction and Swagger UI.
-  /// When provided, the framework extracts schema from this instance
-  /// instead of calling `factory({})` — enabling strict `fromJson`.
-  final Input? inputExample;
+  /// The framework extracts schema from this instance — enabling strict `fromJson`.
+  final Input inputExample;
 
   /// Example Output instance for schema extraction and Swagger UI.
-  final Output? outputExample;
+  final Output outputExample;
 
   UseCaseRegistration({
     required this.module,
@@ -315,8 +314,8 @@ class UseCaseRegistration {
     required this.path,
     required this.factory,
     this.doc,
-    this.inputExample,
-    this.outputExample,
+    required this.inputExample,
+    required this.outputExample,
   });
 }
 

--- a/dart/lib/src/core/modular_api.dart
+++ b/dart/lib/src/core/modular_api.dart
@@ -206,9 +206,13 @@ class ModuleBuilder {
     required Router root,
   }) : _root = root;
 
-  /// POST by default
+  /// Registers a use case as an HTTP endpoint on this module.
+  ///
+  /// [command] becomes the route segment and the OpenAPI operationId root.
+  /// Convention: command, class name, and file name share the same root.
+  /// Example: command `'hello-world'` → class `HelloWorld` → file `hello_world.dart`.
   ModuleBuilder usecase(
-    String usecaseName,
+    String command,
     UseCaseFactory usecaseFactory, {
     String method = 'POST',
     String? summary,
@@ -218,15 +222,12 @@ class ModuleBuilder {
   }) {
     Handler h = useCaseHttpHandler(usecaseFactory, inputExample: inputExample);
 
-    /// Clean usecase name
-    usecaseName = usecaseName.trim();
-
-    /// if starts with '/', remove it
-    if (usecaseName.startsWith('/')) {
-      usecaseName = usecaseName.substring(1);
+    command = command.trim();
+    if (command.startsWith('/')) {
+      command = command.substring(1);
     }
 
-    final String subPath = '/$usecaseName';
+    final String subPath = '/$command';
     final String methodU = method.toUpperCase();
 
     switch (methodU) {
@@ -248,18 +249,18 @@ class ModuleBuilder {
 
     // Register metadata for Swagger
     UseCaseDocMeta doc = UseCaseDocMeta(
-      summary: summary ?? 'Use case $usecaseName in module $moduleName',
+      summary: summary ?? 'Use case $command in module $moduleName',
       description:
-          description ?? 'Auto-generated documentation for $usecaseName',
+          description ?? 'Auto-generated documentation for $command',
       tags: [moduleName],
     );
 
     apiRegistry.routes.add(
       UseCaseRegistration(
         module: moduleName,
-        name: usecaseName,
+        command: command,
         method: methodU,
-        path: '${_normalizeBase(basePath)}/$moduleName/$usecaseName',
+        path: '${_normalizeBase(basePath)}/$moduleName/$command',
         factory: usecaseFactory,
         doc: doc,
         inputExample: inputExample,
@@ -294,9 +295,9 @@ class UseCaseDocMeta {
 
 class UseCaseRegistration {
   final String module;
-  final String name;
+  final String command;
   final String method; // "POST" | "GET" | ...
-  final String path; // p.ej. "/api/ligo/example"
+  final String path; // e.g. "/api/v1/greetings/hello-world"
   final UseCaseFactory factory;
   final UseCaseDocMeta? doc;
 
@@ -309,7 +310,7 @@ class UseCaseRegistration {
 
   UseCaseRegistration({
     required this.module,
-    required this.name,
+    required this.command,
     required this.method,
     required this.path,
     required this.factory,

--- a/dart/lib/src/core/schema/field.dart
+++ b/dart/lib/src/core/schema/field.dart
@@ -6,12 +6,8 @@
 /// The base class `Input.toSchema()` / `Output.toSchema()` builds the
 /// OpenAPI 3.0.3-compatible JSON Schema automatically from this list.
 ///
-/// The `@Field` annotation is decorative — it documents the field's purpose
-/// and will be consumed by `@MacssSchema()` macro when macros stabilize.
-///
 /// ```dart
 /// class HelloInput extends Input {
-///   @Field(description: 'Name to greet')
 ///   final String name;
 ///
 ///   HelloInput({required this.name});
@@ -24,16 +20,6 @@
 /// }
 /// ```
 library;
-
-/// Decorative annotation for field metadata.
-///
-/// Used for documentation, IDE support, and future macro consumption.
-/// Does NOT affect runtime behavior in the current version.
-class Field {
-  final String? description;
-
-  const Field({this.description});
-}
 
 /// Metadata for a single schema field.
 ///

--- a/dart/lib/src/core/usecase/usecase.dart
+++ b/dart/lib/src/core/usecase/usecase.dart
@@ -42,7 +42,6 @@ abstract class UseCase<I extends Input, O extends Output> {
 ///
 /// ```dart
 /// class HelloInput implements Input {
-///   @Field(description: 'Name to greet')
 ///   final String name;
 ///
 ///   HelloInput({required this.name});

--- a/dart/lib/src/core/usecase/usecase.dart
+++ b/dart/lib/src/core/usecase/usecase.dart
@@ -9,20 +9,11 @@ import 'package:modular_api/src/core/schema/field.dart';
 /// Lifecycle (handled by the framework):
 ///   1. `fromJson(json)`    — static factory, builds the use case
 ///   2. `validate()`        — return error string or null
-///   3. `execute()`         — run business logic, set `this.output`
-///   4. `output.toJson()`   — serialize and return to HTTP client
+///   3. `execute()`         — run business logic, return Output
+///   4. handler serializes  — `output.toJson()` → HTTP response
 abstract class UseCase<I extends Input, O extends Output> {
-  /// DTO entrada
-  /// Debe ser inicializado en el constructor
-  /// si no se inicializa en el contructor no se puede inferir el esquema
-  /// para OpenApi
+  /// Input DTO — set in constructor via fromJson.
   I get input;
-
-  /// DTO salida
-  /// Debe ser inicializado en el constructor
-  /// si no se inicializa en el contructor no se puede inferir el esquema
-  /// para OpenApi
-  late O output;
 
   /// Logger scoped to the current HTTP request.
   /// Set by the framework before [execute] is called.
@@ -38,13 +29,9 @@ abstract class UseCase<I extends Input, O extends Output> {
   /// Validate the use case data
   String? validate();
 
-  /// Execute the use case logic
-  /// Bussiness logic should be implemented here
-  Future<void> execute();
-
-  /// Write to DTO
-  /// Serialize the use case data to JSON
-  Map<String, dynamic> toJson();
+  /// Execute the use case logic and return the Output.
+  /// Business logic should be implemented here.
+  Future<O> execute();
 }
 
 /// **Contract** — use `implements Input`.

--- a/dart/lib/src/core/usecase/usecase_http_handler.dart
+++ b/dart/lib/src/core/usecase/usecase_http_handler.dart
@@ -56,14 +56,13 @@ Handler useCaseHttpHandler(
       useCase.logger = req.context[loggerContextKey] as ModularLogger?;
 
       // 4. Execute the use case
-      await useCase.execute();
+      final output = await useCase.execute();
 
       // 5. Serialize the response and return with the appropriate status code
-      final statusCode = useCase.output.statusCode;
       return Response(
-        statusCode,
+        output.statusCode,
         headers: jsonHeaders,
-        body: jsonEncode(useCase.toJson()),
+        body: jsonEncode(output.toJson()),
       );
     } on UseCaseException catch (e) {
       // Handle known business logic exceptions with custom status codes

--- a/dart/lib/src/openapi/openapi.dart
+++ b/dart/lib/src/openapi/openapi.dart
@@ -197,15 +197,15 @@ class OpenApi {
       final outputSchema = _inferOutputSchema(r);
 
       // 3) Name schemas for components (reusables)
-      final inputRefName = '${r.module}_${r.name}_Input';
-      final outputRefName = '${r.module}_${r.name}_Output';
+      final inputRefName = '${r.module}_${r.command}_Input';
+      final outputRefName = '${r.module}_${r.command}_Output';
       compSchemas[inputRefName] = inputSchema;
       compSchemas[outputRefName] = outputSchema;
 
       // 4) Build operation
       final op = <String, dynamic>{
         'tags': r.doc?.tags ?? [r.module],
-        'operationId': '${r.module}_${r.name}_${r.method.toLowerCase()}',
+        'operationId': '${r.module}_${r.command}_${r.method.toLowerCase()}',
         if (r.doc?.summary != null) 'summary': r.doc!.summary,
         if (r.doc?.description != null) 'description': r.doc!.description,
         'responses': {

--- a/dart/lib/src/openapi/openapi.dart
+++ b/dart/lib/src/openapi/openapi.dart
@@ -197,15 +197,16 @@ class OpenApi {
       final outputSchema = _inferOutputSchema(r);
 
       // 3) Name schemas for components (reusables)
-      final inputRefName = '${r.module}_${r.command}_Input';
-      final outputRefName = '${r.module}_${r.command}_Output';
+      final safeCommand = r.command.replaceAll('-', '_');
+      final inputRefName = '${r.module}_${safeCommand}_Input';
+      final outputRefName = '${r.module}_${safeCommand}_Output';
       compSchemas[inputRefName] = inputSchema;
       compSchemas[outputRefName] = outputSchema;
 
       // 4) Build operation
       final op = <String, dynamic>{
         'tags': r.doc?.tags ?? [r.module],
-        'operationId': '${r.module}_${r.command}_${r.method.toLowerCase()}',
+        'operationId': '${r.module}_${safeCommand}_${r.method.toLowerCase()}',
         if (r.doc?.summary != null) 'summary': r.doc!.summary,
         if (r.doc?.description != null) 'description': r.doc!.description,
         'responses': {

--- a/dart/lib/src/openapi/openapi.dart
+++ b/dart/lib/src/openapi/openapi.dart
@@ -246,49 +246,25 @@ class OpenApi {
     return const JsonEncoder.withIndent('  ').convert(spec);
   }
 
-  /// Extracts the input schema, preferring the registered example instance.
+  /// Extracts the input schema from the required example instance.
   ///
-  /// When [inputExample] is provided, the schema is built from the example
-  /// (via schemaFields or type inference) and `schema['example']` is set to
-  /// the example's serialized JSON. No `factory({})` call needed.
-  /// Falls back to `factory({})` when no example is registered.
+  /// The schema is built from the example (via schemaFields or type inference)
+  /// and `schema['example']` is set to the example's serialized JSON.
   static Map<String, dynamic> _inferInputSchema(UseCaseRegistration r) {
-    if (r.inputExample != null) {
-      final schema = r.inputExample!.toSchema();
-      if (schema['type'] == null) schema['type'] = 'object';
-      final exampleJson = r.inputExample!.toJson();
-      if (exampleJson.isNotEmpty) schema['example'] = exampleJson;
-      return schema;
-    }
-
-    try {
-      final uc = r.factory(<String, dynamic>{});
-      final schema = uc.input.toSchema();
-      if (schema['type'] == null) schema['type'] = 'object';
-      return schema;
-    } catch (_) {
-      return {'type': 'object', 'properties': {}};
-    }
+    final schema = r.inputExample.toSchema();
+    if (schema['type'] == null) schema['type'] = 'object';
+    final exampleJson = r.inputExample.toJson();
+    if (exampleJson.isNotEmpty) schema['example'] = exampleJson;
+    return schema;
   }
 
-  /// Extracts the output schema, preferring the registered example instance.
+  /// Extracts the output schema from the required example instance.
   static Map<String, dynamic> _inferOutputSchema(UseCaseRegistration r) {
-    if (r.outputExample != null) {
-      final schema = r.outputExample!.toSchema();
-      if (schema['type'] == null) schema['type'] = 'object';
-      final exampleJson = r.outputExample!.toJson();
-      if (exampleJson.isNotEmpty) schema['example'] = exampleJson;
-      return schema;
-    }
-
-    try {
-      final uc = r.factory(<String, dynamic>{});
-      final schema = uc.output.toSchema();
-      if (schema['type'] == null) schema['type'] = 'object';
-      return schema;
-    } catch (_) {
-      return {'type': 'object', 'properties': {}};
-    }
+    final schema = r.outputExample.toSchema();
+    if (schema['type'] == null) schema['type'] = 'object';
+    final exampleJson = r.outputExample.toJson();
+    if (exampleJson.isNotEmpty) schema['example'] = exampleJson;
+    return schema;
   }
 
   /// Converts a flat schema into query parameters (top-level properties only).

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: modular_api
 description: Use-case centric API toolkit for Dart — Shelf UseCase base class, HTTP adapters, CORS middleware, and automatic OpenAPI documentation.
-version: 0.4.2
+version: 0.4.3
 
 repository: https://github.com/macss-dev/modular_api/tree/main/dart
 homepage: https://github.com/macss-dev/modular_api

--- a/dart/test/handler/handler_pre_validation_test.dart
+++ b/dart/test/handler/handler_pre_validation_test.dart
@@ -85,9 +85,6 @@ class StrictUseCase implements UseCase<StrictInput, StrictOutput> {
   final StrictInput input;
 
   @override
-  late StrictOutput output;
-
-  @override
   ModularLogger? logger;
 
   StrictUseCase({required this.input});
@@ -100,12 +97,9 @@ class StrictUseCase implements UseCase<StrictInput, StrictOutput> {
   String? validate() => null;
 
   @override
-  Future<void> execute() async {
-    output = StrictOutput(greeting: 'Hello ${input.name}');
+  Future<StrictOutput> execute() async {
+    return StrictOutput(greeting: 'Hello ${input.name}');
   }
-
-  @override
-  Map<String, dynamic> toJson() => output.toJson();
 }
 
 // ── Helpers ──

--- a/dart/test/logger/logging_integration_test.dart
+++ b/dart/test/logger/logging_integration_test.dart
@@ -49,13 +49,9 @@ class EchoUseCase implements UseCase<EchoInput, EchoOutput> {
   @override
   final EchoInput input;
   @override
-  late EchoOutput output;
-  @override
   ModularLogger? logger;
 
-  EchoUseCase({required this.input}) {
-    output = EchoOutput(echo: '');
-  }
+  EchoUseCase({required this.input});
 
   static EchoUseCase fromJson(Map<String, dynamic> json) =>
       EchoUseCase(input: EchoInput.fromJson(json));
@@ -64,13 +60,10 @@ class EchoUseCase implements UseCase<EchoInput, EchoOutput> {
   String? validate() => null;
 
   @override
-  Future<void> execute() async {
+  Future<EchoOutput> execute() async {
     logger?.info('echoing value', fields: {'value': input.value});
-    output = EchoOutput(echo: input.value);
+    return EchoOutput(echo: input.value);
   }
-
-  @override
-  Map<String, dynamic> toJson() => output.toJson();
 }
 
 /// UseCase that does NOT use the logger (regression test)
@@ -78,13 +71,9 @@ class SilentUseCase implements UseCase<EchoInput, EchoOutput> {
   @override
   final EchoInput input;
   @override
-  late EchoOutput output;
-  @override
   ModularLogger? logger;
 
-  SilentUseCase({required this.input}) {
-    output = EchoOutput(echo: '');
-  }
+  SilentUseCase({required this.input});
 
   static SilentUseCase fromJson(Map<String, dynamic> json) =>
       SilentUseCase(input: EchoInput.fromJson(json));
@@ -93,13 +82,10 @@ class SilentUseCase implements UseCase<EchoInput, EchoOutput> {
   String? validate() => null;
 
   @override
-  Future<void> execute() async {
+  Future<EchoOutput> execute() async {
     // Deliberately ignores logger
-    output = EchoOutput(echo: input.value);
+    return EchoOutput(echo: input.value);
   }
-
-  @override
-  Map<String, dynamic> toJson() => output.toJson();
 }
 
 /// UseCase that throws an unexpected error
@@ -107,13 +93,9 @@ class FailUseCase implements UseCase<EchoInput, EchoOutput> {
   @override
   final EchoInput input;
   @override
-  late EchoOutput output;
-  @override
   ModularLogger? logger;
 
-  FailUseCase({required this.input}) {
-    output = EchoOutput(echo: '');
-  }
+  FailUseCase({required this.input});
 
   static FailUseCase fromJson(Map<String, dynamic> json) =>
       FailUseCase(input: EchoInput.fromJson(json));
@@ -122,12 +104,9 @@ class FailUseCase implements UseCase<EchoInput, EchoOutput> {
   String? validate() => null;
 
   @override
-  Future<void> execute() async {
+  Future<EchoOutput> execute() async {
     throw Exception('unexpected crash');
   }
-
-  @override
-  Map<String, dynamic> toJson() => output.toJson();
 }
 
 // ─── Tests ─────────────────────────────────────────────────────────
@@ -150,9 +129,9 @@ void main() {
 
       final uc = EchoUseCase(input: EchoInput(value: 'hello'));
       uc.logger = logger;
-      await uc.execute();
+      final output = await uc.execute();
 
-      expect(uc.output.echo, 'hello');
+      expect(output.echo, 'hello');
       final lines = buf.toString().trim().split('\n');
       expect(lines.length, 1);
       final json = jsonDecode(lines[0]) as Map<String, dynamic>;
@@ -164,8 +143,8 @@ void main() {
     test('UseCase works without logger (regression)', () async {
       final uc = SilentUseCase(input: EchoInput(value: 'world'));
       // logger is null — execute should work fine
-      await uc.execute();
-      expect(uc.output.echo, 'world');
+      final output = await uc.execute();
+      expect(output.echo, 'world');
     });
   });
 
@@ -181,8 +160,8 @@ void main() {
 
       final uc = EchoUseCase(input: EchoInput(value: 'hi'));
       uc.logger = logger;
-      await uc.execute();
-      expect(uc.output.echo, 'hi');
+      final output = await uc.execute();
+      expect(output.echo, 'hi');
 
       // Verify logger was used
       final lines = buf.toString().trim().split('\n');
@@ -195,8 +174,8 @@ void main() {
 
     test('UseCase works without logger assigned (default behavior)', () async {
       final uc = SilentUseCase(input: EchoInput(value: 'hi'));
-      await uc.execute();
-      expect(uc.output.echo, 'hi');
+      final output = await uc.execute();
+      expect(output.echo, 'hi');
     });
   });
 
@@ -224,9 +203,15 @@ void main() {
       );
 
       api.module('test', (m) {
-        m.usecase('echo', EchoUseCase.fromJson);
-        m.usecase('silent', SilentUseCase.fromJson);
-        m.usecase('fail', FailUseCase.fromJson);
+        m.usecase('echo', EchoUseCase.fromJson,
+            inputExample: EchoInput(value: 'test'),
+            outputExample: EchoOutput(echo: 'test'));
+        m.usecase('silent', SilentUseCase.fromJson,
+            inputExample: EchoInput(value: 'test'),
+            outputExample: EchoOutput(echo: 'test'));
+        m.usecase('fail', FailUseCase.fromJson,
+            inputExample: EchoInput(value: 'test'),
+            outputExample: EchoOutput(echo: 'test'));
       });
 
       server = await api.serve(port: 0); // ephemeral port

--- a/dart/test/metrics/metrics_integration_test.dart
+++ b/dart/test/metrics/metrics_integration_test.dart
@@ -35,8 +35,6 @@ class _PingUseCase implements UseCase<_PingInput, _PingOutput> {
   @override
   final _PingInput input;
   @override
-  late _PingOutput output;
-  @override
   ModularLogger? logger;
 
   _PingUseCase(this.input);
@@ -47,12 +45,9 @@ class _PingUseCase implements UseCase<_PingInput, _PingOutput> {
   String? validate() => null;
 
   @override
-  Future<void> execute() async {
-    output = _PingOutput();
+  Future<_PingOutput> execute() async {
+    return _PingOutput();
   }
-
-  @override
-  Map<String, dynamic> toJson() => output.toJson();
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────
@@ -76,7 +71,8 @@ void main() {
         metricsEnabled: metricsEnabled,
       );
       api.module('test', (m) {
-        m.usecase('ping', _PingUseCase.fromJson);
+        m.usecase('ping', _PingUseCase.fromJson,
+            inputExample: _PingInput(), outputExample: _PingOutput());
       });
       server = await api.serve(port: 0);
       baseUrl = 'http://localhost:${server.port}';
@@ -161,7 +157,8 @@ void main() {
         metricsEnabled: true,
       );
       api.module('test', (m) {
-        m.usecase('ping', _PingUseCase.fromJson);
+        m.usecase('ping', _PingUseCase.fromJson,
+            inputExample: _PingInput(), outputExample: _PingOutput());
       });
 
       // Register a custom metric

--- a/dart/test/openapi/openapi_example_test.dart
+++ b/dart/test/openapi/openapi_example_test.dart
@@ -84,13 +84,9 @@ class _GreetUseCase implements UseCase<_GreetInput, _GreetOutput> {
   @override
   final _GreetInput input;
   @override
-  late _GreetOutput output;
-  @override
   ModularLogger? logger;
 
-  _GreetUseCase({required this.input}) {
-    output = _GreetOutput();
-  }
+  _GreetUseCase({required this.input});
 
   static _GreetUseCase fromJson(Map<String, dynamic> json) =>
       _GreetUseCase(input: _GreetInput.fromJson(json));
@@ -99,12 +95,9 @@ class _GreetUseCase implements UseCase<_GreetInput, _GreetOutput> {
   String? validate() => null;
 
   @override
-  Future<void> execute() async {
-    output = _GreetOutput(message: 'Hello, ${input.name}!');
+  Future<_GreetOutput> execute() async {
+    return _GreetOutput(message: 'Hello, ${input.name}!');
   }
-
-  @override
-  Map<String, dynamic> toJson() => output.toJson();
 }
 
 void main() {

--- a/dart/test/openapi/openapi_example_test.dart
+++ b/dart/test/openapi/openapi_example_test.dart
@@ -8,7 +8,6 @@ import 'package:test/test.dart';
 // ── UseCase with examples (strict fromJson — no coercion) ────────────────
 
 class _GreetInput extends Input {
-  @Field(description: 'Name to greet')
   final String name;
   final int age;
   final double score;

--- a/dart/test/openapi/openapi_spec_test.dart
+++ b/dart/test/openapi/openapi_spec_test.dart
@@ -38,8 +38,6 @@ class _PingUseCase implements UseCase<_PingInput, _PingOutput> {
   @override
   final _PingInput input;
   @override
-  late _PingOutput output;
-  @override
   ModularLogger? logger;
 
   _PingUseCase(this.input);
@@ -49,12 +47,9 @@ class _PingUseCase implements UseCase<_PingInput, _PingOutput> {
   @override
   String? validate() => null;
   @override
-  Future<void> execute() async {
-    output = _PingOutput();
+  Future<_PingOutput> execute() async {
+    return _PingOutput();
   }
-
-  @override
-  Map<String, dynamic> toJson() => output.toJson();
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────
@@ -159,7 +154,8 @@ void main() {
       );
 
       api.module('test', (m) {
-        m.usecase('ping', _PingUseCase.fromJson);
+        m.usecase('ping', _PingUseCase.fromJson,
+            inputExample: _PingInput(), outputExample: _PingOutput());
       });
 
       server = await api.serve(port: 0);
@@ -223,7 +219,8 @@ void main() {
       );
 
       api.module('test', (m) {
-        m.usecase('ping', _PingUseCase.fromJson);
+        m.usecase('ping', _PingUseCase.fromJson,
+            inputExample: _PingInput(), outputExample: _PingOutput());
       });
 
       server = await api.serve(port: 0);
@@ -287,7 +284,8 @@ void main() {
       );
 
       api.module('test', (m) {
-        m.usecase('ping', _PingUseCase.fromJson);
+        m.usecase('ping', _PingUseCase.fromJson,
+            inputExample: _PingInput(), outputExample: _PingOutput());
       });
 
       server = await api.serve(port: 0);

--- a/dart/test/schema/auto_schema_test.dart
+++ b/dart/test/schema/auto_schema_test.dart
@@ -5,7 +5,6 @@ import 'package:modular_api/src/core/usecase/usecase.dart';
 // ── Test DTOs with schemaFields ──────────────────────────────
 
 class NameInput extends Input {
-  @Field(description: 'Name to greet')
   final String name;
 
   NameInput({required this.name});
@@ -23,7 +22,6 @@ class NameInput extends Input {
 }
 
 class GreetOutput extends Output {
-  @Field(description: 'Greeting message')
   final String message;
 
   GreetOutput({this.message = ''});
@@ -41,10 +39,8 @@ class GreetOutput extends Output {
 }
 
 class OptionalInput extends Input {
-  @Field(description: 'Required name')
   final String name;
 
-  @Field(description: 'Optional nickname')
   final String? nickname;
 
   OptionalInput({required this.name, this.nickname});

--- a/dart/test/schema_conformance_test.dart
+++ b/dart/test/schema_conformance_test.dart
@@ -7,7 +7,6 @@ import 'package:modular_api/src/core/usecase/usecase.dart';
 import 'package:modular_api/src/core/schema/field.dart';
 
 class HelloInput extends Input {
-  @Field(description: 'Name to greet')
   final String name;
   HelloInput({required this.name});
 
@@ -25,7 +24,6 @@ class HelloInput extends Input {
 }
 
 class HelloOutput extends Output {
-  @Field(description: 'Greeting message')
   final String message;
   HelloOutput({this.message = ''});
 

--- a/dart/test/use_case_exception_test.dart
+++ b/dart/test/use_case_exception_test.dart
@@ -99,8 +99,8 @@ void main() {
         ThrowExceptionInput(shouldThrow: false),
       );
 
-      await useCase.execute();
-      expect(useCase.output.success, isTrue);
+      final output = await useCase.execute();
+      expect(output.success, isTrue);
     });
   });
 }
@@ -163,9 +163,6 @@ class ThrowExceptionUseCase
   final ThrowExceptionInput input;
 
   @override
-  late ThrowExceptionOutput output;
-
-  @override
   ModularLogger? logger;
 
   ThrowExceptionUseCase(this.input);
@@ -178,7 +175,7 @@ class ThrowExceptionUseCase
   String? validate() => null;
 
   @override
-  Future<void> execute() async {
+  Future<ThrowExceptionOutput> execute() async {
     if (input.shouldThrow) {
       throw UseCaseException(
         statusCode: 404,
@@ -187,9 +184,6 @@ class ThrowExceptionUseCase
       );
     }
 
-    output = ThrowExceptionOutput(success: true);
+    return ThrowExceptionOutput(success: true);
   }
-
-  @override
-  Map<String, dynamic> toJson() => output.toJson();
 }

--- a/dart/test/usecase_test.dart
+++ b/dart/test/usecase_test.dart
@@ -8,20 +8,12 @@ class SumUseCase implements UseCase<SumInput, SumOutput> {
   final SumInput input;
 
   @override
-  late SumOutput output;
-
-  @override
   ModularLogger? logger;
 
-  SumUseCase({required this.input}) {
-    // Default value for output (needed for schema inference elsewhere)
-    output = SumOutput(resultado: 0);
-  }
+  SumUseCase({required this.input});
 
   factory SumUseCase.fromJson(Map<String, dynamic> json) {
-    final uc = SumUseCase(input: SumInput.fromJson(json));
-    uc.output = SumOutput(resultado: 0);
-    return uc;
+    return SumUseCase(input: SumInput.fromJson(json));
   }
 
   @override
@@ -32,14 +24,11 @@ class SumUseCase implements UseCase<SumInput, SumOutput> {
   }
 
   @override
-  Future<void> execute() async {
+  Future<SumOutput> execute() async {
     final a = input.a ?? 0;
     final b = input.b ?? 0;
-    output = SumOutput(resultado: a + b);
+    return SumOutput(resultado: a + b);
   }
-
-  @override
-  Map<String, dynamic> toJson() => output.toJson();
 }
 
 class SumInput extends Input {
@@ -105,8 +94,8 @@ void main() {
     () async {
       final useCase = SumUseCase(input: SumInput(a: 3, b: 4));
       expect(useCase.validate(), isNull);
-      await useCase.execute();
-      expect(useCase.output.resultado, equals(7));
+      final output = await useCase.execute();
+      expect(output.resultado, equals(7));
     },
   );
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,12 +56,10 @@ with a well-defined lifecycle managed entirely by the framework.
 ```
 UseCase<I extends Input, O extends Output>
 ├── input: I                          // Read-only DTO, set at construction
-├── output: O                         // Write DTO, set during execute()
 ├── logger?: ModularLogger            // Injected by the framework
 ├── fromJson(json) → UseCase          // Static factory (construction)
 ├── validate() → string | null        // Pre-execution validation
-├── execute() → Future<void>          // Business logic
-└── toJson() → Map                    // Serialization of output
+└── execute() → Future<O>             // Business logic, returns Output
 ```
 
 **Lifecycle:**
@@ -86,7 +84,7 @@ sequenceDiagram
             UseCase-->>Framework: UseCaseException
             Framework-->>Client: exception.statusCode + structured error
         else success
-            UseCase-->>Framework: output set
+            UseCase-->>Framework: Output returned
             Framework-->>Client: output.statusCode + output.toJson()
         end
     end
@@ -99,7 +97,7 @@ sequenceDiagram
   the use case from the deserialized HTTP payload.
 - `validate()` MUST return a single error string or `null`. The framework
   returns 400 if non-null.
-- `execute()` MUST set `this.output` before returning. The framework reads
+- `execute()` MUST return an `Output` instance. The framework reads
   `output.toJson()` and `output.statusCode` to build the HTTP response.
 - `logger` is injected by the framework before `execute()` is called.
   Use cases SHOULD use `logger?.info(...)` for structured, request-scoped logging.

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.4.3] - 2026-03-13
+
+### Changed (BREAKING)
+
+- **`execute()` returns `O`** — no longer `None`; the handler reads the returned Output directly
+- **Removed `output` property** from `UseCase` — no mutable state; `execute()` returns the result
+- **Removed `to_json()`** from `UseCase` — the handler calls `output.to_json()` on the returned value
+- **Removed Strategy 2 fallback** in OpenAPI schema extraction — no `factory({}).output` path
+
 ## [0.4.2] - 2026-03-12
 
 ### Added

--- a/py/doc/naming_guide.md
+++ b/py/doc/naming_guide.md
@@ -46,7 +46,7 @@ file:     hello_world.py
 class:    HelloWorld
 input:    HelloWorldInput
 output:   HelloWorldOutput
-schema:   greetings_hello-world_Input / greetings_hello-world_Output
+schema:   greetings_hello_world_Input / greetings_hello_world_Output
 ```
 
 ---

--- a/py/doc/naming_guide.md
+++ b/py/doc/naming_guide.md
@@ -1,0 +1,63 @@
+# Naming Guide
+
+Naming conventions for commands, classes, and files in `modular-api`.
+
+---
+
+## Core Rule
+
+The **command**, the **UseCase class**, and the **file** share the same root:
+
+| Layer | Format | Example |
+|---|---|---|
+| Command (route segment) | `kebab-case` | `'hello-world'` |
+| UseCase class | `PascalCase` | `HelloWorld` |
+| File | `snake_case` | `hello_world.py` |
+
+The command string passed to `m.usecase(command, ...)` becomes the URL segment
+(`/module/command`) and the root for every related symbol.
+
+---
+
+## Input / Output DTOs
+
+Append `Input` and `Output` to the UseCase class name:
+
+```python
+class HelloWorldInput(Input):
+    ...
+
+class HelloWorldOutput(Output):
+    ...
+
+class HelloWorld(UseCase[HelloWorldInput, HelloWorldOutput]):
+    ...
+```
+
+---
+
+## Full Example
+
+```
+command:  'hello-world'
+route:    POST /api/v1/greetings/hello-world
+
+file:     hello_world.py
+class:    HelloWorld
+input:    HelloWorldInput
+output:   HelloWorldOutput
+schema:   greetings_hello-world_Input / greetings_hello-world_Output
+```
+
+---
+
+## Why "Command"?
+
+Use cases are **commands** — explicit, validated operations that change state
+(POST, PUT, PATCH, DELETE). This terminology aligns with the CQRS architecture
+planned for v0.6.0, where:
+
+- **Commands** → REST endpoints (use cases) — write operations
+- **Queries** → GraphQL plugin — read operations
+
+See [roadmap.md](../../docs/roadmap.md) for the full CQRS vision.

--- a/py/example/example.py
+++ b/py/example/example.py
@@ -8,10 +8,10 @@
 
 # Then test::
 
-#     curl -X POST http://localhost:8080/api/v1/greetings/hello \
+#     curl -X POST http://localhost:8080/api/v1/greetings/hello-world \
 #          -H "Content-Type: application/json" \
 #          -d '{"name":"World"}'
-#     curl http://localhost:8080/api/v1/time/now?tz=utc-5
+#     curl http://localhost:8080/api/v1/time/current-time?tz=utc-5
 
 # Docs::
 

--- a/py/example/example.py
+++ b/py/example/example.py
@@ -8,9 +8,10 @@
 
 # Then test::
 
-#     curl -X POST http://localhost:8080/api/greetings/hello \
+#     curl -X POST http://localhost:8080/api/v1/greetings/hello \
 #          -H "Content-Type: application/json" \
 #          -d '{"name":"World"}'
+#     curl http://localhost:8080/api/v1/time/now?tz=utc-5
 
 # Docs::
 
@@ -104,7 +105,7 @@ def main() -> None:
     port = int(sys.argv[1]) if len(sys.argv) > 1 else 8080
 
     api = ModularApi(
-        base_path="/api",
+        base_path="/api/v1",
         title="Modular API",
         version="1.0.0",
         metrics_enabled=True,

--- a/py/example/example.py
+++ b/py/example/example.py
@@ -66,19 +66,10 @@ class HelloOutput(Output):
 class HelloWorld(UseCase[HelloInput, HelloOutput]):
     def __init__(self, input_dto: HelloInput) -> None:
         self._input = input_dto
-        self._output = HelloOutput(message="")
 
     @property
     def input(self) -> HelloInput:
         return self._input
-
-    @property
-    def output(self) -> HelloOutput:
-        return self._output
-
-    @output.setter
-    def output(self, value: HelloOutput) -> None:
-        self._output = value
 
     @classmethod
     def from_json(cls, json: dict[str, object]) -> HelloWorld:
@@ -89,12 +80,9 @@ class HelloWorld(UseCase[HelloInput, HelloOutput]):
             return "name is required"
         return None
 
-    async def execute(self) -> None:
+    async def execute(self) -> HelloOutput:
         self.logger.info(f"Greeting user: {self.input.name}")
-        self.output = HelloOutput(message=f"Hello, {self.input.name}!")
-
-    def to_json(self) -> dict[str, object]:
-        return self.output.to_json()
+        return HelloOutput(message=f"Hello, {self.input.name}!")
 
 
 # ── Health check ──────────────────────────────────────────────

--- a/py/example/example.py
+++ b/py/example/example.py
@@ -21,80 +21,11 @@ from __future__ import annotations
 
 import sys
 
-from modular_api import (
-    HealthCheck,
-    HealthCheckResult,
-    HealthStatus,
-    Input,
-    LogLevel,
-    ModularApi,
-    ModuleBuilder,
-    Output,
-    UseCase,
-    Field,
-)
+from modular_api import LogLevel, ModularApi
 
-
-# ── Module builder ────────────────────────────────────────────
-
-
-def build_greetings_module(m: ModuleBuilder) -> None:
-    m.usecase("hello", HelloWorld.from_json)
-
-
-# ── Input DTO ─────────────────────────────────────────────────
-
-
-class HelloInput(Input):
-    name: str = Field(description="Name to greet", examples=["World"])
-
-
-# ── Output DTO ────────────────────────────────────────────────
-
-
-class HelloOutput(Output):
-    message: str = Field(description="Greeting message", examples=["Hello, World!"])
-
-    @property
-    def status_code(self) -> int:
-        return 200
-
-
-# ── UseCase ───────────────────────────────────────────────────
-
-
-class HelloWorld(UseCase[HelloInput, HelloOutput]):
-    def __init__(self, input_dto: HelloInput) -> None:
-        self._input = input_dto
-
-    @property
-    def input(self) -> HelloInput:
-        return self._input
-
-    @classmethod
-    def from_json(cls, json: dict[str, object]) -> HelloWorld:
-        return cls(HelloInput.from_json(json))
-
-    def validate(self) -> str | None:
-        if not self.input.name:
-            return "name is required"
-        return None
-
-    async def execute(self) -> HelloOutput:
-        self.logger.info(f"Greeting user: {self.input.name}")
-        return HelloOutput(message=f"Hello, {self.input.name}!")
-
-
-# ── Health check ──────────────────────────────────────────────
-
-
-class AlwaysPassHealthCheck(HealthCheck):
-    @property
-    def name(self) -> str:
-        return "example"
-
-    async def check(self) -> HealthCheckResult:
-        return HealthCheckResult(status=HealthStatus.PASS)
+from .health.always_pass_health_check import AlwaysPassHealthCheck
+from .modules.greetings.greetings_builder import build_greetings_module
+from .modules.time.time_builder import build_time_module
 
 
 # ── Server ────────────────────────────────────────────────────
@@ -121,6 +52,7 @@ def main() -> None:
         )
 
     api.module("greetings", build_greetings_module)
+    api.module("time", build_time_module)
 
     api.serve(port=port)
 

--- a/py/example/example.py
+++ b/py/example/example.py
@@ -1,21 +1,20 @@
-"""example/example.py — Minimal runnable example.
+# example/example.py — Minimal runnable example.
 
-Mirrors ``example/example.dart`` (Dart) and ``example/example.ts`` (TypeScript).
+# Mirrors ``example/example.dart`` (Dart) and ``example/example.ts`` (TypeScript).
 
-Run::
+# Run::
 
-    python -m example.example
+#     python -m example.example
 
-Then test::
+# Then test::
 
-    curl -X POST http://localhost:8080/api/greetings/hello \
-         -H "Content-Type: application/json" \
-         -d '{"name":"World"}'
+#     curl -X POST http://localhost:8080/api/greetings/hello \
+#          -H "Content-Type: application/json" \
+#          -d '{"name":"World"}'
 
-Docs::
+# Docs::
 
-    http://localhost:8080/docs
-"""
+#     http://localhost:8080/docs
 
 from __future__ import annotations
 

--- a/py/example/health/always_pass_health_check.py
+++ b/py/example/health/always_pass_health_check.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from modular_api import HealthCheck, HealthCheckResult, HealthStatus
+
+
+class AlwaysPassHealthCheck(HealthCheck):
+    @property
+    def name(self) -> str:
+        return "example"
+
+    async def check(self) -> HealthCheckResult:
+        return HealthCheckResult(status=HealthStatus.PASS)

--- a/py/example/modules/greetings/greetings_builder.py
+++ b/py/example/modules/greetings/greetings_builder.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from modular_api import ModuleBuilder
+
+from .usecases.hello_world import HelloWorld
+
+
+def build_greetings_module(m: ModuleBuilder) -> None:
+    m.usecase("hello", HelloWorld.from_json)

--- a/py/example/modules/greetings/greetings_builder.py
+++ b/py/example/modules/greetings/greetings_builder.py
@@ -6,4 +6,4 @@ from .usecases.hello_world import HelloWorld
 
 
 def build_greetings_module(m: ModuleBuilder) -> None:
-    m.usecase("hello", HelloWorld.from_json)
+    m.usecase("hello-world", HelloWorld.from_json)

--- a/py/example/modules/greetings/usecases/hello_world.py
+++ b/py/example/modules/greetings/usecases/hello_world.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from modular_api import Input, Output, UseCase, Field
+
+
+# ── Input DTO ─────────────────────────────────────────────────
+
+
+class HelloInput(Input):
+    name: str = Field(description="Name to greet", examples=["World"])
+
+
+# ── Output DTO ────────────────────────────────────────────────
+
+
+class HelloOutput(Output):
+    message: str = Field(description="Greeting message", examples=["Hello, World!"])
+
+    @property
+    def status_code(self) -> int:
+        return 200
+
+
+# ── UseCase ───────────────────────────────────────────────────
+
+
+class HelloWorld(UseCase[HelloInput, HelloOutput]):
+    def __init__(self, input_dto: HelloInput) -> None:
+        self._input = input_dto
+
+    @property
+    def input(self) -> HelloInput:
+        return self._input
+
+    @classmethod
+    def from_json(cls, json: dict[str, object]) -> HelloWorld:
+        return cls(HelloInput.from_json(json))
+
+    def validate(self) -> str | None:
+        if not self.input.name:
+            return "name is required"
+        return None
+
+    async def execute(self) -> HelloOutput:
+        self.logger.info(f"Greeting user: {self.input.name}")
+        return HelloOutput(message=f"Hello, {self.input.name}!")

--- a/py/example/modules/greetings/usecases/hello_world.py
+++ b/py/example/modules/greetings/usecases/hello_world.py
@@ -6,14 +6,14 @@ from modular_api import Input, Output, UseCase, Field
 # ── Input DTO ─────────────────────────────────────────────────
 
 
-class HelloInput(Input):
+class HelloWorldInput(Input):
     name: str = Field(description="Name to greet", examples=["World"])
 
 
 # ── Output DTO ────────────────────────────────────────────────
 
 
-class HelloOutput(Output):
+class HelloWorldOutput(Output):
     message: str = Field(description="Greeting message", examples=["Hello, World!"])
 
     @property
@@ -24,23 +24,23 @@ class HelloOutput(Output):
 # ── UseCase ───────────────────────────────────────────────────
 
 
-class HelloWorld(UseCase[HelloInput, HelloOutput]):
-    def __init__(self, input_dto: HelloInput) -> None:
+class HelloWorld(UseCase[HelloWorldInput, HelloWorldOutput]):
+    def __init__(self, input_dto: HelloWorldInput) -> None:
         self._input = input_dto
 
     @property
-    def input(self) -> HelloInput:
+    def input(self) -> HelloWorldInput:
         return self._input
 
     @classmethod
     def from_json(cls, json: dict[str, object]) -> HelloWorld:
-        return cls(HelloInput.from_json(json))
+        return cls(HelloWorldInput.from_json(json))
 
     def validate(self) -> str | None:
         if not self.input.name:
             return "name is required"
         return None
 
-    async def execute(self) -> HelloOutput:
+    async def execute(self) -> HelloWorldOutput:
         self.logger.info(f"Greeting user: {self.input.name}")
-        return HelloOutput(message=f"Hello, {self.input.name}!")
+        return HelloWorldOutput(message=f"Hello, {self.input.name}!")

--- a/py/example/modules/time/time_builder.py
+++ b/py/example/modules/time/time_builder.py
@@ -6,4 +6,4 @@ from .usecases.current_time import CurrentTime
 
 
 def build_time_module(m: ModuleBuilder) -> None:
-    m.usecase("now", CurrentTime.from_json, method="GET")
+    m.usecase("current-time", CurrentTime.from_json, method="GET")

--- a/py/example/modules/time/time_builder.py
+++ b/py/example/modules/time/time_builder.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from modular_api import ModuleBuilder
+
+from .usecases.current_time import CurrentTime
+
+
+def build_time_module(m: ModuleBuilder) -> None:
+    m.usecase("now", CurrentTime.from_json, method="GET")

--- a/py/example/modules/time/usecases/current_time.py
+++ b/py/example/modules/time/usecases/current_time.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import re
+
+from modular_api import Field, Input, Output, UseCase
+
+
+# ── Input DTO ─────────────────────────────────────────────────
+
+
+class TimeInput(Input):
+    tz: str | None = Field(
+        default=None,
+        description="Timezone offset (e.g. utc-5, utc+3, utc)",
+        examples=["utc-5"],
+    )
+
+
+# ── Output DTO ────────────────────────────────────────────────
+
+
+class TimeOutput(Output):
+    datetime: str = Field(
+        description="ISO 8601 datetime at the requested offset",
+        examples=["2026-03-14T07:00:00"],
+    )
+    offset: int = Field(description="UTC offset in hours", examples=[-5])
+
+    @property
+    def status_code(self) -> int:
+        return 200
+
+
+# ── UseCase ───────────────────────────────────────────────────
+
+_OFFSET_RE = re.compile(r"^utc([+-]\d{1,2})$", re.IGNORECASE)
+
+
+class CurrentTime(UseCase[TimeInput, TimeOutput]):
+    def __init__(self, input_dto: TimeInput) -> None:
+        self._input = input_dto
+
+    @property
+    def input(self) -> TimeInput:
+        return self._input
+
+    @classmethod
+    def from_json(cls, json: dict[str, object]) -> CurrentTime:
+        return cls(TimeInput.from_json(json))
+
+    def validate(self) -> str | None:
+        if not self.input.tz:
+            return None
+        offset = self._parse_offset(self.input.tz)
+        if offset is None:
+            return "invalid timezone format, use utc, utc-5, utc+3"
+        if not -12 <= offset <= 14:
+            return "offset must be between -12 and +14"
+        return None
+
+    async def execute(self) -> TimeOutput:
+        from datetime import datetime, timezone, timedelta
+
+        now_utc = datetime.now(tz=timezone.utc)
+        if self.input.tz:
+            offset_hours = self._parse_offset(self.input.tz)  # already validated
+        else:
+            # Fall back to system local offset
+            local_now = datetime.now().astimezone()
+            offset_hours = int(local_now.utcoffset().total_seconds() // 3600)  # type: ignore[union-attr]
+
+        adjusted = now_utc + timedelta(hours=offset_hours)  # type: ignore[arg-type]
+        iso = adjusted.strftime("%Y-%m-%dT%H:%M:%S")
+
+        self.logger.info(f"Time requested for offset {offset_hours}")
+        return TimeOutput(datetime=iso, offset=offset_hours)  # type: ignore[arg-type]
+
+    @staticmethod
+    def _parse_offset(tz: str) -> int | None:
+        """Parses 'utc-5', 'utc+3', 'utc' into an integer offset. Returns None on bad format."""
+        lower = tz.strip().lower()
+        if lower == "utc":
+            return 0
+        match = _OFFSET_RE.match(lower)
+        if not match:
+            return None
+        return int(match.group(1))

--- a/py/example/modules/time/usecases/current_time.py
+++ b/py/example/modules/time/usecases/current_time.py
@@ -8,7 +8,7 @@ from modular_api import Field, Input, Output, UseCase
 # ── Input DTO ─────────────────────────────────────────────────
 
 
-class TimeInput(Input):
+class CurrentTimeInput(Input):
     tz: str | None = Field(
         default=None,
         description="Timezone offset (e.g. utc-5, utc+3, utc)",
@@ -19,7 +19,7 @@ class TimeInput(Input):
 # ── Output DTO ────────────────────────────────────────────────
 
 
-class TimeOutput(Output):
+class CurrentTimeOutput(Output):
     datetime: str = Field(
         description="ISO 8601 datetime at the requested offset",
         examples=["2026-03-14T07:00:00"],
@@ -36,17 +36,17 @@ class TimeOutput(Output):
 _OFFSET_RE = re.compile(r"^utc([+-]\d{1,2})$", re.IGNORECASE)
 
 
-class CurrentTime(UseCase[TimeInput, TimeOutput]):
-    def __init__(self, input_dto: TimeInput) -> None:
+class CurrentTime(UseCase[CurrentTimeInput, CurrentTimeOutput]):
+    def __init__(self, input_dto: CurrentTimeInput) -> None:
         self._input = input_dto
 
     @property
-    def input(self) -> TimeInput:
+    def input(self) -> CurrentTimeInput:
         return self._input
 
     @classmethod
     def from_json(cls, json: dict[str, object]) -> CurrentTime:
-        return cls(TimeInput.from_json(json))
+        return cls(CurrentTimeInput.from_json(json))
 
     def validate(self) -> str | None:
         if not self.input.tz:
@@ -58,7 +58,7 @@ class CurrentTime(UseCase[TimeInput, TimeOutput]):
             return "offset must be between -12 and +14"
         return None
 
-    async def execute(self) -> TimeOutput:
+    async def execute(self) -> CurrentTimeOutput:
         from datetime import datetime, timezone, timedelta
 
         now_utc = datetime.now(tz=timezone.utc)
@@ -73,7 +73,7 @@ class CurrentTime(UseCase[TimeInput, TimeOutput]):
         iso = adjusted.strftime("%Y-%m-%dT%H:%M:%S")
 
         self.logger.info(f"Time requested for offset {offset_hours}")
-        return TimeOutput(datetime=iso, offset=offset_hours)  # type: ignore[arg-type]
+        return CurrentTimeOutput(datetime=iso, offset=offset_hours)  # type: ignore[arg-type]
 
     @staticmethod
     def _parse_offset(tz: str) -> int | None:

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "macss-modular-api"
-version = "0.4.2"
+version = "0.4.3"
 description = "Use-case-centric toolkit for building modular APIs with Starlette. Define UseCase classes (input → validate → execute → output), connect them to HTTP routes, and expose OpenAPI documentation automatically."
 readme = "README.md"
 license = "MIT"

--- a/py/src/modular_api/core/module_builder.py
+++ b/py/src/modular_api/core/module_builder.py
@@ -145,16 +145,12 @@ class ModuleBuilder:
     def _extract_schemas(factory: UseCaseFactory) -> dict[str, dict[str, Any]]:
         """Capture Input and Output schemas from a UseCase factory.
 
-        Strategy (in order of preference):
-        1. Class-level extraction via ``to_schema()`` classmethod on BaseModel DTOs.
-           Inspects the factory's type hints to find the Input/Output classes.
-        2. Fallback: instantiate via ``factory({})`` and call ``to_schema()``
-           on the resulting UseCase's input/output (legacy pattern).
+        Uses class-level extraction via ``to_schema()`` classmethod on BaseModel DTOs.
+        Inspects the factory's type hints to find the Input/Output classes.
         """
         input_schema: dict[str, Any] = {}
         output_schema: dict[str, Any] = {}
 
-        # --- Strategy 1: class-level extraction from type hints ---
         return_hint = _get_return_type_hint(factory)
 
         if return_hint is not None:
@@ -171,25 +167,6 @@ class ModuleBuilder:
                     output_schema = output_cls.to_schema()
                 except Exception:
                     pass
-
-            if input_schema or output_schema:
-                return {"input": input_schema, "output": output_schema}
-
-        # --- Strategy 2: legacy factory({}) fallback ---
-        try:
-            instance = factory({})
-        except Exception:
-            return {"input": input_schema, "output": output_schema}
-
-        try:
-            input_schema = instance.input.to_schema()
-        except Exception:
-            pass
-
-        try:
-            output_schema = instance.output.to_schema()
-        except Exception:
-            pass
 
         return {"input": input_schema, "output": output_schema}
 

--- a/py/src/modular_api/core/module_builder.py
+++ b/py/src/modular_api/core/module_builder.py
@@ -91,7 +91,7 @@ class ModuleBuilder:
 
     def usecase(
         self,
-        name: str,
+        command: str,
         factory: UseCaseFactory,
         *,
         method: str = "POST",
@@ -100,15 +100,19 @@ class ModuleBuilder:
     ) -> ModuleBuilder:
         """Register a use case as an HTTP endpoint on this module.
 
+        ``command`` becomes the route segment and the OpenAPI operationId root.
+        Convention: command, class name, and file name share the same root.
+        Example: command ``'hello-world'`` → class ``HelloWorld`` → file ``hello_world.py``.
+
         Returns ``self`` for fluent chaining.
         """
-        clean_name = name.strip().lstrip("/")
+        clean_command = command.strip().lstrip("/")
         method_upper = method.upper()
-        full_path = f"{self._normalize_base(self._base_path)}/{self._module_name}/{clean_name}"
+        full_path = f"{self._normalize_base(self._base_path)}/{self._module_name}/{clean_command}"
 
         # Mount endpoint on internal route list
         self._routes.append(
-            Route(f"/{clean_name}", endpoint=usecase_handler(factory), methods=[method_upper]),
+            Route(f"/{clean_command}", endpoint=usecase_handler(factory), methods=[method_upper]),
         )
 
         # Capture schemas via a dummy factory call (fail-safe)
@@ -116,15 +120,15 @@ class ModuleBuilder:
 
         # Register metadata for OpenAPI generation
         doc = UseCaseDocMeta(
-            summary=summary or f"Use case {clean_name} in module {self._module_name}",
-            description=description or f"Auto-generated documentation for {clean_name}",
+            summary=summary or f"Use case {clean_command} in module {self._module_name}",
+            description=description or f"Auto-generated documentation for {clean_command}",
             tags=[self._module_name],
         )
 
         api_registry.routes.append(
             UseCaseRegistration(
                 module=self._module_name,
-                name=clean_name,
+                command=clean_command,
                 method=method_upper,
                 path=full_path,
                 factory=factory,

--- a/py/src/modular_api/core/registry.py
+++ b/py/src/modular_api/core/registry.py
@@ -38,9 +38,9 @@ class UseCaseRegistration:
     """
 
     module: str
-    name: str
+    command: str  # route segment and operationId root, e.g. 'hello-world'
     method: str  # uppercase: "POST" | "GET" | "PUT" | "PATCH" | "DELETE"
-    path: str  # e.g. "/api/users/create"
+    path: str  # e.g. "/api/v1/greetings/hello-world"
     factory: UseCaseFactory
     schemas: dict[str, dict[str, Any]] = field(default_factory=dict)
     doc: UseCaseDocMeta | None = None

--- a/py/src/modular_api/core/usecase.py
+++ b/py/src/modular_api/core/usecase.py
@@ -172,8 +172,11 @@ O = TypeVar("O", bound=Output)
 class UseCase(ABC, Generic[I, O]):
     """Contract for business logic units.
 
-    Pure interface: all members must be provided by the implementor.
-    No default behavior is inherited — every UseCase is self-contained.
+    Lifecycle (handled by the framework):
+      1. ``from_json(json)``    — static factory, builds the use case
+      2. ``validate()``         — return error string or ``None``
+      3. ``execute()``          — run business logic, return Output
+      4. handler serializes     — ``output.to_json()`` → HTTP response
     """
 
     # Request-scoped logger injected by the framework before execute().
@@ -186,23 +189,12 @@ class UseCase(ABC, Generic[I, O]):
         """Input DTO — set in constructor."""
         ...
 
-    @property
-    @abstractmethod
-    def output(self) -> O:
-        """Output DTO — set in ``execute()``."""
-        ...
-
     @abstractmethod
     def validate(self) -> str | None:
         """Validate the input. Return an error message or ``None``."""
         ...
 
     @abstractmethod
-    async def execute(self) -> None:
-        """Run the business logic and set ``self.output``."""
-        ...
-
-    @abstractmethod
-    def to_json(self) -> dict[str, object]:
-        """Serialize the output for the HTTP response body."""
+    async def execute(self) -> O:
+        """Run the business logic and return the Output."""
         ...

--- a/py/src/modular_api/core/usecase_handler.py
+++ b/py/src/modular_api/core/usecase_handler.py
@@ -104,12 +104,12 @@ def usecase_handler(factory: UseCaseFactory) -> Any:
                 )
 
             # 4. Execute
-            await use_case.execute()
+            output = await use_case.execute()
 
             # 5. Respond
             return Response(
-                content=json.dumps(use_case.to_json()),
-                status_code=use_case.output.status_code,
+                content=json.dumps(output.to_json()),
+                status_code=output.status_code,
                 media_type=_JSON_CONTENT_TYPE,
             )
 

--- a/py/src/modular_api/openapi/openapi.py
+++ b/py/src/modular_api/openapi/openapi.py
@@ -89,8 +89,8 @@ def _add_route_to_spec(
     component_schemas: dict[str, Any],
 ) -> None:
     """Append a single route's path entry, schemas, and operation to the spec."""
-    input_ref_name = f"{route.module}_{route.name}_Input"
-    output_ref_name = f"{route.module}_{route.name}_Output"
+    input_ref_name = f"{route.module}_{route.command}_Input"
+    output_ref_name = f"{route.module}_{route.command}_Output"
 
     # Store schemas in components
     component_schemas[input_ref_name] = route.schemas.get("input", {"type": "object"})
@@ -102,7 +102,7 @@ def _add_route_to_spec(
     description = route.doc.description if route.doc else None
 
     operation: dict[str, Any] = {
-        "operationId": f"{route.module}_{route.name}_{method_lower}",
+        "operationId": f"{route.module}_{route.command}_{method_lower}",
         "tags": tags,
         "responses": {
             "200": {

--- a/py/src/modular_api/openapi/openapi.py
+++ b/py/src/modular_api/openapi/openapi.py
@@ -89,8 +89,9 @@ def _add_route_to_spec(
     component_schemas: dict[str, Any],
 ) -> None:
     """Append a single route's path entry, schemas, and operation to the spec."""
-    input_ref_name = f"{route.module}_{route.command}_Input"
-    output_ref_name = f"{route.module}_{route.command}_Output"
+    safe_command = route.command.replace("-", "_")
+    input_ref_name = f"{route.module}_{safe_command}_Input"
+    output_ref_name = f"{route.module}_{safe_command}_Output"
 
     # Store schemas in components
     component_schemas[input_ref_name] = route.schemas.get("input", {"type": "object"})
@@ -102,7 +103,7 @@ def _add_route_to_spec(
     description = route.doc.description if route.doc else None
 
     operation: dict[str, Any] = {
-        "operationId": f"{route.module}_{route.command}_{method_lower}",
+        "operationId": f"{route.module}_{safe_command}_{method_lower}",
         "tags": tags,
         "responses": {
             "200": {

--- a/py/tests/openapi/test_module_builder.py
+++ b/py/tests/openapi/test_module_builder.py
@@ -73,7 +73,7 @@ class TestModuleBuilderRegistration:
         assert len(api_registry.routes) == 1
         reg = api_registry.routes[0]
         assert reg.module == "users"
-        assert reg.name == "create"
+        assert reg.command == "create"
 
     def test_default_method_is_post(self) -> None:
         builder = ModuleBuilder(base_path="/api", module_name="users")
@@ -92,7 +92,7 @@ class TestModuleBuilderRegistration:
         builder.usecase("/create", _StubUseCase.from_json)
 
         reg = api_registry.routes[0]
-        assert reg.name == "create"
+        assert reg.command == "create"
         assert reg.path == "/api/users/create"
 
     def test_strips_whitespace_from_usecase_name(self) -> None:
@@ -100,7 +100,7 @@ class TestModuleBuilderRegistration:
         builder.usecase("  create  ", _StubUseCase.from_json)
 
         reg = api_registry.routes[0]
-        assert reg.name == "create"
+        assert reg.command == "create"
 
     def test_method_override_get(self) -> None:
         builder = ModuleBuilder(base_path="/api", module_name="users")

--- a/py/tests/openapi/test_module_builder.py
+++ b/py/tests/openapi/test_module_builder.py
@@ -36,24 +36,16 @@ class _StubUseCase(UseCase[_StubInput, _StubOutput]):
 
     def __init__(self, inp: _StubInput) -> None:
         self._input = inp
-        self._output = _StubOutput()
 
     @property
     def input(self) -> _StubInput:
         return self._input
 
-    @property
-    def output(self) -> _StubOutput:
-        return self._output
-
     def validate(self) -> str | None:
         return None
 
-    async def execute(self) -> None:
-        self._output = _StubOutput()
-
-    def to_json(self) -> dict:
-        return self.output.to_json()
+    async def execute(self) -> _StubOutput:
+        return _StubOutput()
 
     @staticmethod
     def from_json(json: dict) -> _StubUseCase:

--- a/py/tests/openapi/test_openapi_endpoints.py
+++ b/py/tests/openapi/test_openapi_endpoints.py
@@ -28,7 +28,7 @@ def _register_ping_usecase() -> None:
     api_registry.routes.append(
         UseCaseRegistration(
             module="test",
-            name="ping",
+            command="ping",
             method="POST",
             path="/api/test/ping",
             factory=_dummy_factory,

--- a/py/tests/openapi/test_openapi_spec.py
+++ b/py/tests/openapi/test_openapi_spec.py
@@ -23,7 +23,7 @@ def _dummy_factory(json: dict) -> object:
 def _make_registration(**overrides: object) -> UseCaseRegistration:
     defaults: dict = {
         "module": "users",
-        "name": "create",
+        "command": "create",
         "method": "POST",
         "path": "/api/users/create",
         "factory": _dummy_factory,
@@ -141,7 +141,7 @@ class TestOpenApiGetUseCase:
 
     def test_get_has_parameters(self) -> None:
         api_registry.routes.append(
-            _make_registration(name="list", method="GET", path="/api/users/list"),
+            _make_registration(command="list", method="GET", path="/api/users/list"),
         )
         spec = build_openapi_spec(title="Test", port=8000)
 
@@ -151,7 +151,7 @@ class TestOpenApiGetUseCase:
 
     def test_query_params_from_input_properties(self) -> None:
         api_registry.routes.append(
-            _make_registration(name="list", method="GET", path="/api/users/list"),
+            _make_registration(command="list", method="GET", path="/api/users/list"),
         )
         spec = build_openapi_spec(title="Test", port=8000)
 
@@ -229,10 +229,10 @@ class TestMultipleMethodsOnSamePath:
 
     def test_same_path_different_methods(self) -> None:
         api_registry.routes.append(
-            _make_registration(name="item", method="GET", path="/api/users/item"),
+            _make_registration(command="item", method="GET", path="/api/users/item"),
         )
         api_registry.routes.append(
-            _make_registration(name="item", method="PUT", path="/api/users/item"),
+            _make_registration(command="item", method="PUT", path="/api/users/item"),
         )
         spec = build_openapi_spec(title="Test", port=8000)
 

--- a/py/tests/openapi/test_registry.py
+++ b/py/tests/openapi/test_registry.py
@@ -18,7 +18,7 @@ def _make_registration(**overrides: object) -> UseCaseRegistration:
     """Builds a UseCaseRegistration with sensible defaults, overridable per field."""
     defaults: dict = {
         "module": "users",
-        "name": "create",
+        "command": "create",
         "method": "POST",
         "path": "/api/users/create",
         "factory": _dummy_factory,
@@ -37,7 +37,7 @@ class TestUseCaseRegistration:
     def test_fields_are_accessible(self) -> None:
         reg = _make_registration()
         assert reg.module == "users"
-        assert reg.name == "create"
+        assert reg.command == "create"
         assert reg.method == "POST"
         assert reg.path == "/api/users/create"
         assert reg.factory is _dummy_factory
@@ -68,20 +68,20 @@ class TestApiRegistry:
 
     def test_stores_registrations(self) -> None:
         registry = ApiRegistry()
-        reg1 = _make_registration(name="create")
-        reg2 = _make_registration(name="delete", method="DELETE", path="/api/users/delete")
+        reg1 = _make_registration(command="create")
+        reg2 = _make_registration(command="delete", method="DELETE", path="/api/users/delete")
 
         registry.routes.append(reg1)
         registry.routes.append(reg2)
 
         assert len(registry.routes) == 2
-        assert registry.routes[0].name == "create"
-        assert registry.routes[1].name == "delete"
+        assert registry.routes[0].command == "create"
+        assert registry.routes[1].command == "delete"
 
     def test_clear_empties_all_routes(self) -> None:
         registry = ApiRegistry()
         registry.routes.append(_make_registration())
-        registry.routes.append(_make_registration(name="list"))
+        registry.routes.append(_make_registration(command="list"))
         assert len(registry.routes) == 2
 
         registry.clear()

--- a/py/tests/test_fromjson_validation.py
+++ b/py/tests/test_fromjson_validation.py
@@ -41,26 +41,18 @@ class StrictUseCase(UseCase[StrictInput, StrictOutput]):
 
     def __init__(self, data: dict) -> None:
         self._input = StrictInput.from_json(data)
-        self._output = StrictOutput()
 
     @property
     def input(self) -> StrictInput:
         return self._input
-
-    @property
-    def output(self) -> StrictOutput:
-        return self._output
 
     def validate(self) -> str | None:
         if not self.input.name:
             return "name is required"
         return None
 
-    async def execute(self) -> None:
-        self._output = StrictOutput(greeting=f"Hi {self.input.name}, age {self.input.age}")
-
-    def to_json(self) -> dict:
-        return self._output.to_json()
+    async def execute(self) -> StrictOutput:
+        return StrictOutput(greeting=f"Hi {self.input.name}, age {self.input.age}")
 
 
 def _app():

--- a/py/tests/test_modular_api.py
+++ b/py/tests/test_modular_api.py
@@ -32,24 +32,16 @@ class _PingOutput(Output):
 class _PingUseCase(UseCase[_PingInput, _PingOutput]):
     def __init__(self, inp: _PingInput) -> None:
         self._input = inp
-        self._output = _PingOutput()
 
     @property
     def input(self) -> _PingInput:
         return self._input
 
-    @property
-    def output(self) -> _PingOutput:
-        return self._output
-
     def validate(self) -> str | None:
         return None
 
-    async def execute(self) -> None:
-        self._output = _PingOutput()
-
-    def to_json(self) -> dict:
-        return self.output.to_json()
+    async def execute(self) -> _PingOutput:
+        return _PingOutput()
 
     @staticmethod
     def from_json(json: dict) -> _PingUseCase:

--- a/py/tests/test_module_builder.py
+++ b/py/tests/test_module_builder.py
@@ -34,19 +34,10 @@ class StubUseCase(UseCase[StubInput, StubOutput]):
 
     def __init__(self, input_dto: StubInput) -> None:
         self._input = input_dto
-        self._output = StubOutput(message="")
 
     @property
     def input(self) -> StubInput:
         return self._input
-
-    @property
-    def output(self) -> StubOutput:
-        return self._output
-
-    @output.setter
-    def output(self, value: StubOutput) -> None:
-        self._output = value
 
     @classmethod
     def from_json(cls, json: dict) -> StubUseCase:
@@ -57,11 +48,8 @@ class StubUseCase(UseCase[StubInput, StubOutput]):
             return "name is required"
         return None
 
-    async def execute(self) -> None:
-        self.output = StubOutput(message=f"Hello, {self.input.name}!")
-
-    def to_json(self) -> dict:
-        return self.output.to_json()
+    async def execute(self) -> StubOutput:
+        return StubOutput(message=f"Hello, {self.input.name}!")
 
 
 # ── Tests ─────────────────────────────────────────────────────────────────

--- a/py/tests/test_schema_conformance.py
+++ b/py/tests/test_schema_conformance.py
@@ -10,7 +10,7 @@ import sys
 _EXAMPLE_DIR = Path(__file__).resolve().parent.parent / "example"
 sys.path.insert(0, str(_EXAMPLE_DIR))
 
-from example import HelloInput, HelloOutput  # type: ignore[import-untyped]
+from modules.greetings.usecases.hello_world import HelloInput, HelloOutput  # type: ignore[import-untyped]
 
 _FIXTURES = Path(__file__).resolve().parent.parent.parent / "tests" / "fixtures"
 

--- a/py/tests/test_schema_conformance.py
+++ b/py/tests/test_schema_conformance.py
@@ -1,4 +1,4 @@
-"""Conformance tests: HelloInput/HelloOutput schemas match shared fixtures."""
+"""Conformance tests: HelloWorldInput/HelloWorldOutput schemas match shared fixtures."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ import sys
 _EXAMPLE_DIR = Path(__file__).resolve().parent.parent / "example"
 sys.path.insert(0, str(_EXAMPLE_DIR))
 
-from modules.greetings.usecases.hello_world import HelloInput, HelloOutput  # type: ignore[import-untyped]
+from modules.greetings.usecases.hello_world import HelloWorldInput, HelloWorldOutput  # type: ignore[import-untyped]
 
 _FIXTURES = Path(__file__).resolve().parent.parent.parent / "tests" / "fixtures"
 
@@ -25,26 +25,26 @@ class TestSchemaConformance:
     def test_hello_input_schema_matches_fixture(self) -> None:
         fixture = _load_fixture("hello_input_schema.json")
         # to_schema() is now a classmethod — call on class, not instance
-        assert HelloInput.to_schema() == fixture
+        assert HelloWorldInput.to_schema() == fixture
 
     def test_hello_output_schema_matches_fixture(self) -> None:
         fixture = _load_fixture("hello_output_schema.json")
-        assert HelloOutput.to_schema() == fixture
+        assert HelloWorldOutput.to_schema() == fixture
 
     def test_hello_input_from_json(self) -> None:
         """from_json populates fields correctly."""
-        instance = HelloInput.from_json({"name": "Carlos"})
+        instance = HelloWorldInput.from_json({"name": "Carlos"})
         assert instance.name == "Carlos"
 
     def test_hello_input_to_json(self) -> None:
         """to_json serializes correctly."""
-        instance = HelloInput(name="Carlos")
+        instance = HelloWorldInput(name="Carlos")
         assert instance.to_json() == {"name": "Carlos"}
 
     def test_hello_output_from_json(self) -> None:
-        instance = HelloOutput.from_json({"message": "Hello!"})
+        instance = HelloWorldOutput.from_json({"message": "Hello!"})
         assert instance.message == "Hello!"
 
     def test_hello_output_to_json(self) -> None:
-        instance = HelloOutput(message="Hello!")
+        instance = HelloWorldOutput(message="Hello!")
         assert instance.to_json() == {"message": "Hello!"}

--- a/py/tests/test_usecase.py
+++ b/py/tests/test_usecase.py
@@ -32,15 +32,10 @@ class SumUseCase(UseCase[SumInput, SumOutput]):
 
     def __init__(self, input_dto: SumInput) -> None:
         self._input = input_dto
-        self._output = SumOutput(resultado=0)
 
     @property
     def input(self) -> SumInput:
         return self._input
-
-    @property
-    def output(self) -> SumOutput:
-        return self._output
 
     def validate(self) -> str | None:
         if self._input.a is None:
@@ -49,13 +44,10 @@ class SumUseCase(UseCase[SumInput, SumOutput]):
             return "b is required"
         return None
 
-    async def execute(self) -> None:
+    async def execute(self) -> SumOutput:
         a = self._input.a or 0
         b = self._input.b or 0
-        self._output = SumOutput(resultado=a + b)
-
-    def to_json(self) -> dict[str, object]:
-        return self._output.to_json()
+        return SumOutput(resultado=a + b)
 
 
 # ── Input tests ─────────────────────────────────────────────────────
@@ -116,16 +108,16 @@ class TestUseCase:
         uc = SumUseCase(SumInput(a=5, b=None))
         assert uc.validate() is not None
 
-    async def test_execute_sets_output(self) -> None:
+    async def test_execute_returns_output(self) -> None:
         uc = SumUseCase(SumInput(a=3, b=4))
         assert uc.validate() is None
-        await uc.execute()
-        assert uc.output.resultado == 7
+        output = await uc.execute()
+        assert output.resultado == 7
 
-    async def test_to_json_returns_output_json(self) -> None:
+    async def test_execute_output_serializes(self) -> None:
         uc = SumUseCase(SumInput(a=10, b=20))
-        await uc.execute()
-        assert uc.to_json() == {"resultado": 30}
+        output = await uc.execute()
+        assert output.to_json() == {"resultado": 30}
 
     def test_logger_defaults_to_none(self) -> None:
         uc = SumUseCase(SumInput(a=1, b=2))

--- a/py/tests/test_usecase_handler.py
+++ b/py/tests/test_usecase_handler.py
@@ -32,26 +32,18 @@ class GreetUseCase(UseCase[GreetInput, GreetOutput]):
 
     def __init__(self, data: dict) -> None:
         self._input = GreetInput.from_json(data)
-        self._output = GreetOutput()
 
     @property
     def input(self) -> GreetInput:
         return self._input
-
-    @property
-    def output(self) -> GreetOutput:
-        return self._output
 
     def validate(self) -> str | None:
         if not self._input.name:
             return "name is required"
         return None
 
-    async def execute(self) -> None:
-        self._output = GreetOutput(greeting=f"Hello, {self._input.name}!")
-
-    def to_json(self) -> dict:
-        return self._output.to_json()
+    async def execute(self) -> GreetOutput:
+        return GreetOutput(greeting=f"Hello, {self._input.name}!")
 
 
 class FailingUseCase(UseCase[GreetInput, GreetOutput]):
@@ -59,28 +51,20 @@ class FailingUseCase(UseCase[GreetInput, GreetOutput]):
 
     def __init__(self, data: dict) -> None:
         self._input = GreetInput.from_json(data)
-        self._output = GreetOutput()
 
     @property
     def input(self) -> GreetInput:
         return self._input
 
-    @property
-    def output(self) -> GreetOutput:
-        return self._output
-
     def validate(self) -> str | None:
         return None
 
-    async def execute(self) -> None:
+    async def execute(self) -> GreetOutput:
         raise UseCaseException(
             status_code=409,
             message="Already exists",
             error_code="CONFLICT",
         )
-
-    def to_json(self) -> dict:
-        return self._output.to_json()
 
 
 class CrashingUseCase(UseCase[GreetInput, GreetOutput]):
@@ -88,24 +72,16 @@ class CrashingUseCase(UseCase[GreetInput, GreetOutput]):
 
     def __init__(self, data: dict) -> None:
         self._input = GreetInput(name="x")
-        self._output = GreetOutput()
 
     @property
     def input(self) -> GreetInput:
         return self._input
 
-    @property
-    def output(self) -> GreetOutput:
-        return self._output
-
     def validate(self) -> str | None:
         return None
 
-    async def execute(self) -> None:
+    async def execute(self) -> GreetOutput:
         raise RuntimeError("disk on fire")
-
-    def to_json(self) -> dict:
-        return self._output.to_json()
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────
@@ -201,25 +177,17 @@ class TestUseCaseLifecycle:
         class SpyUseCase(UseCase[GreetInput, GreetOutput]):
             def __init__(self, data: dict) -> None:
                 self._input = GreetInput(name="x")
-                self._output = GreetOutput()
 
             @property
             def input(self) -> GreetInput:
                 return self._input
 
-            @property
-            def output(self) -> GreetOutput:
-                return self._output
-
             def validate(self) -> str | None:
                 return None
 
-            async def execute(self) -> None:
+            async def execute(self) -> GreetOutput:
                 captured_loggers.append(self.logger)
-                self._output = GreetOutput(greeting="ok")
-
-            def to_json(self) -> dict:
-                return self._output.to_json()
+                return GreetOutput(greeting="ok")
 
         # Middleware that fakes a logger in request.state
         from starlette.middleware import Middleware

--- a/tests/integration_test/parity_test.ps1
+++ b/tests/integration_test/parity_test.ps1
@@ -571,7 +571,7 @@ function Test-OpenApiJson {
         "$ImplName /openapi.json POST hello response uses `$ref to Output schema"
 
     # Schema content — Input must have properties.name with type string
-    $inputSchema = $json.components.schemas.greetings_hello-world_Input
+    $inputSchema = $json.components.schemas['greetings_hello-world_Input']
     $hasInputName = ($null -ne $inputSchema.properties) -and ($null -ne $inputSchema.properties.name)
     Assert-True $hasInputName `
         "$ImplName /openapi.json greetings_hello-world_Input has properties.name"
@@ -582,7 +582,7 @@ function Test-OpenApiJson {
     }
 
     # Schema content — Output must have properties.message with type string
-    $outputSchema = $json.components.schemas.greetings_hello-world_Output
+    $outputSchema = $json.components.schemas['greetings_hello-world_Output']
     $hasOutputMessage = ($null -ne $outputSchema.properties) -and ($null -ne $outputSchema.properties.message)
     Assert-True $hasOutputMessage `
         "$ImplName /openapi.json greetings_hello-world_Output has properties.message"
@@ -833,17 +833,17 @@ function Compare-Implementations {
     # ── Schema content parity (properties, types, required) ──────────────────
     # Dart is the reference — TS and Python must produce identical schema content.
 
-    $dartInputJson  = $Dart.OpenApiJson.components.schemas.greetings_hello-world_Input       | ConvertTo-Json -Depth 10 -Compress
-    $tsInputJson    = $TypeScript.OpenApiJson.components.schemas.greetings_hello-world_Input  | ConvertTo-Json -Depth 10 -Compress
-    $pyInputJson    = $Python.OpenApiJson.components.schemas.greetings_hello-world_Input      | ConvertTo-Json -Depth 10 -Compress
+    $dartInputJson  = $Dart.OpenApiJson.components.schemas['greetings_hello-world_Input']       | ConvertTo-Json -Depth 10 -Compress
+    $tsInputJson    = $TypeScript.OpenApiJson.components.schemas['greetings_hello-world_Input']  | ConvertTo-Json -Depth 10 -Compress
+    $pyInputJson    = $Python.OpenApiJson.components.schemas['greetings_hello-world_Input']      | ConvertTo-Json -Depth 10 -Compress
 
     Assert-True (
         ($dartInputJson -eq $tsInputJson) -and ($dartInputJson -eq $pyInputJson)
     ) 'OpenAPI greetings_hello-world_Input schema content identical across implementations'
 
-    $dartOutputJson  = $Dart.OpenApiJson.components.schemas.greetings_hello-world_Output       | ConvertTo-Json -Depth 10 -Compress
-    $tsOutputJson    = $TypeScript.OpenApiJson.components.schemas.greetings_hello-world_Output  | ConvertTo-Json -Depth 10 -Compress
-    $pyOutputJson    = $Python.OpenApiJson.components.schemas.greetings_hello-world_Output      | ConvertTo-Json -Depth 10 -Compress
+    $dartOutputJson  = $Dart.OpenApiJson.components.schemas['greetings_hello-world_Output']       | ConvertTo-Json -Depth 10 -Compress
+    $tsOutputJson    = $TypeScript.OpenApiJson.components.schemas['greetings_hello-world_Output']  | ConvertTo-Json -Depth 10 -Compress
+    $pyOutputJson    = $Python.OpenApiJson.components.schemas['greetings_hello-world_Output']      | ConvertTo-Json -Depth 10 -Compress
 
     Assert-True (
         ($dartOutputJson -eq $tsOutputJson) -and ($dartOutputJson -eq $pyOutputJson)

--- a/tests/integration_test/parity_test.ps1
+++ b/tests/integration_test/parity_test.ps1
@@ -289,7 +289,7 @@ function Test-MetricsEndpoint {
     param([string]$ImplName, [string]$BaseUrl)
 
     # Hit a use case first so metrics have at least one observation.
-    $null = Invoke-Endpoint -Uri "$BaseUrl/api/greetings/hello" `
+    $null = Invoke-Endpoint -Uri "$BaseUrl/api/v1/greetings/hello" `
         -Method POST -Body '{"name":"MetricsWarmup"}'
 
     $response = Invoke-Endpoint -Uri "$BaseUrl/metrics"
@@ -318,11 +318,11 @@ function Test-MetricsEndpoint {
 function Test-UseCaseSuccess {
     <#
     .SYNOPSIS
-        POST /api/greetings/hello with valid input → 200.
+        POST /api/v1/greetings/hello with valid input → 200.
     #>
     param([string]$ImplName, [string]$BaseUrl)
 
-    $response = Invoke-Endpoint -Uri "$BaseUrl/api/greetings/hello" `
+    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/greetings/hello" `
         -Method POST -Body '{"name":"World"}'
 
     Assert-True ($response.StatusCode -eq 200) `
@@ -344,11 +344,11 @@ function Test-UseCaseSuccess {
 function Test-UseCaseValidationFailure {
     <#
     .SYNOPSIS
-        POST /api/greetings/hello with empty name → 400.
+        POST /api/v1/greetings/hello with empty name → 400.
     #>
     param([string]$ImplName, [string]$BaseUrl)
 
-    $response = Invoke-Endpoint -Uri "$BaseUrl/api/greetings/hello" `
+    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/greetings/hello" `
         -Method POST -Body '{"name":""}'
 
     Assert-True ($response.StatusCode -eq 400) `
@@ -370,12 +370,12 @@ function Test-UseCaseValidationFailure {
 function Test-UseCaseMissingBody {
     <#
     .SYNOPSIS
-        POST /api/greetings/hello with empty object → 400.
+        POST /api/v1/greetings/hello with empty object → 400.
         fromJson validates required fields — returns "Missing required field: name".
     #>
     param([string]$ImplName, [string]$BaseUrl)
 
-    $response = Invoke-Endpoint -Uri "$BaseUrl/api/greetings/hello" `
+    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/greetings/hello" `
         -Method POST -Body '{}'
 
     Assert-True ($response.StatusCode -eq 400) `
@@ -397,12 +397,12 @@ function Test-UseCaseMissingBody {
 function Test-UseCaseWrongType {
     <#
     .SYNOPSIS
-        POST /api/greetings/hello with wrong type → 400.
+        POST /api/v1/greetings/hello with wrong type → 400.
         fromJson validates JSON types — returns "Field 'name' must be of type string".
     #>
     param([string]$ImplName, [string]$BaseUrl)
 
-    $response = Invoke-Endpoint -Uri "$BaseUrl/api/greetings/hello" `
+    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/greetings/hello" `
         -Method POST -Body '{"name":123}'
 
     Assert-True ($response.StatusCode -eq 400) `
@@ -448,13 +448,13 @@ function Test-OpenApiJson {
     Assert-True ($null -ne $json.paths) `
         "$ImplName /openapi.json has paths object"
 
-    # The example registers POST /api/greetings/hello
-    $greetingsPath = $json.paths.'/api/greetings/hello'
+    # The example registers POST /api/v1/greetings/hello
+    $greetingsPath = $json.paths.'/api/v1/greetings/hello'
     Assert-True ($null -ne $greetingsPath) `
-        "$ImplName /openapi.json paths has /api/greetings/hello"
+        "$ImplName /openapi.json paths has /api/v1/greetings/hello"
 
     Assert-True ($null -ne $greetingsPath.post) `
-        "$ImplName /openapi.json /api/greetings/hello has POST operation"
+        "$ImplName /openapi.json /api/v1/greetings/hello has POST operation"
 
     # Request body schema
     $requestBodySchema = $greetingsPath.post.requestBody.content.'application/json'.schema
@@ -535,8 +535,8 @@ function Test-OpenApiYaml {
     Assert-True ($body -match 'paths:') `
         "$ImplName /openapi.yaml contains 'paths:' key"
 
-    Assert-True ($body -match '/api/greetings/hello') `
-        "$ImplName /openapi.yaml contains /api/greetings/hello path"
+    Assert-True ($body -match '/api/v1/greetings/hello') `
+        "$ImplName /openapi.yaml contains /api/v1/greetings/hello path"
 
     Assert-True ($body -match 'components:') `
         "$ImplName /openapi.yaml contains 'components:' section"
@@ -738,7 +738,7 @@ function Compare-Implementations {
 
     # ── OpenAPI YAML parity ──────────────────────────────────────────────────
 
-    $yamlKeywords = @('openapi:', 'info:', 'paths:', '/api/greetings/hello')
+    $yamlKeywords = @('openapi:', 'info:', 'paths:', '/api/v1/greetings/hello')
     foreach ($keyword in $yamlKeywords) {
         $dartHas = $Dart.OpenApiYaml       -match [regex]::Escape($keyword)
         $tsHas   = $TypeScript.OpenApiYaml -match [regex]::Escape($keyword)

--- a/tests/integration_test/parity_test.ps1
+++ b/tests/integration_test/parity_test.ps1
@@ -289,7 +289,7 @@ function Test-MetricsEndpoint {
     param([string]$ImplName, [string]$BaseUrl)
 
     # Hit a use case first so metrics have at least one observation.
-    $null = Invoke-Endpoint -Uri "$BaseUrl/api/v1/greetings/hello" `
+    $null = Invoke-Endpoint -Uri "$BaseUrl/api/v1/greetings/hello-world" `
         -Method POST -Body '{"name":"MetricsWarmup"}'
 
     $response = Invoke-Endpoint -Uri "$BaseUrl/metrics"
@@ -318,11 +318,11 @@ function Test-MetricsEndpoint {
 function Test-UseCaseSuccess {
     <#
     .SYNOPSIS
-        POST /api/v1/greetings/hello with valid input → 200.
+        POST /api/v1/greetings/hello-world with valid input → 200.
     #>
     param([string]$ImplName, [string]$BaseUrl)
 
-    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/greetings/hello" `
+    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/greetings/hello-world" `
         -Method POST -Body '{"name":"World"}'
 
     Assert-True ($response.StatusCode -eq 200) `
@@ -344,11 +344,11 @@ function Test-UseCaseSuccess {
 function Test-UseCaseValidationFailure {
     <#
     .SYNOPSIS
-        POST /api/v1/greetings/hello with empty name → 400.
+        POST /api/v1/greetings/hello-world with empty name → 400.
     #>
     param([string]$ImplName, [string]$BaseUrl)
 
-    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/greetings/hello" `
+    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/greetings/hello-world" `
         -Method POST -Body '{"name":""}'
 
     Assert-True ($response.StatusCode -eq 400) `
@@ -370,12 +370,12 @@ function Test-UseCaseValidationFailure {
 function Test-UseCaseMissingBody {
     <#
     .SYNOPSIS
-        POST /api/v1/greetings/hello with empty object → 400.
+        POST /api/v1/greetings/hello-world with empty object → 400.
         fromJson validates required fields — returns "Missing required field: name".
     #>
     param([string]$ImplName, [string]$BaseUrl)
 
-    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/greetings/hello" `
+    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/greetings/hello-world" `
         -Method POST -Body '{}'
 
     Assert-True ($response.StatusCode -eq 400) `
@@ -397,12 +397,12 @@ function Test-UseCaseMissingBody {
 function Test-UseCaseWrongType {
     <#
     .SYNOPSIS
-        POST /api/v1/greetings/hello with wrong type → 400.
+        POST /api/v1/greetings/hello-world with wrong type → 400.
         fromJson validates JSON types — returns "Field 'name' must be of type string".
     #>
     param([string]$ImplName, [string]$BaseUrl)
 
-    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/greetings/hello" `
+    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/greetings/hello-world" `
         -Method POST -Body '{"name":123}'
 
     Assert-True ($response.StatusCode -eq 400) `
@@ -426,11 +426,11 @@ function Test-UseCaseWrongType {
 function Test-TimeNowDefault {
     <#
     .SYNOPSIS
-        GET /api/v1/time/now (no tz param) → 200 with datetime and offset.
+        GET /api/v1/time/current-time (no tz param) → 200 with datetime and offset.
     #>
     param([string]$ImplName, [string]$BaseUrl)
 
-    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/time/now"
+    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/time/current-time"
 
     Assert-True ($response.StatusCode -eq 200) `
         "$ImplName GET time/now (default) → 200"
@@ -454,11 +454,11 @@ function Test-TimeNowDefault {
 function Test-TimeNowWithOffset {
     <#
     .SYNOPSIS
-        GET /api/v1/time/now?tz=utc-5 → 200 with offset == -5.
+        GET /api/v1/time/current-time?tz=utc-5 → 200 with offset == -5.
     #>
     param([string]$ImplName, [string]$BaseUrl)
 
-    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/time/now?tz=utc-5"
+    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/time/current-time?tz=utc-5"
 
     Assert-True ($response.StatusCode -eq 200) `
         "$ImplName GET time/now?tz=utc-5 → 200"
@@ -482,11 +482,11 @@ function Test-TimeNowWithOffset {
 function Test-TimeNowInvalidTz {
     <#
     .SYNOPSIS
-        GET /api/v1/time/now?tz=invalid → 400 validation error.
+        GET /api/v1/time/current-time?tz=invalid → 400 validation error.
     #>
     param([string]$ImplName, [string]$BaseUrl)
 
-    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/time/now?tz=invalid"
+    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/time/current-time?tz=invalid"
 
     Assert-True ($response.StatusCode -eq 400) `
         "$ImplName GET time/now?tz=invalid → 400"
@@ -531,13 +531,13 @@ function Test-OpenApiJson {
     Assert-True ($null -ne $json.paths) `
         "$ImplName /openapi.json has paths object"
 
-    # The example registers POST /api/v1/greetings/hello
-    $greetingsPath = $json.paths.'/api/v1/greetings/hello'
+    # The example registers POST /api/v1/greetings/hello-world
+    $greetingsPath = $json.paths.'/api/v1/greetings/hello-world'
     Assert-True ($null -ne $greetingsPath) `
-        "$ImplName /openapi.json paths has /api/v1/greetings/hello"
+        "$ImplName /openapi.json paths has /api/v1/greetings/hello-world"
 
     Assert-True ($null -ne $greetingsPath.post) `
-        "$ImplName /openapi.json /api/v1/greetings/hello has POST operation"
+        "$ImplName /openapi.json /api/v1/greetings/hello-world has POST operation"
 
     # Request body schema
     $requestBodySchema = $greetingsPath.post.requestBody.content.'application/json'.schema
@@ -557,52 +557,52 @@ function Test-OpenApiJson {
         "$ImplName /openapi.json has components.schemas"
 
     $schemaNames = $json.components.schemas.PSObject.Properties.Name | Sort-Object
-    Assert-True ($schemaNames -contains 'greetings_hello_Input') `
-        "$ImplName /openapi.json components.schemas has greetings_hello_Input"
+    Assert-True ($schemaNames -contains 'greetings_hello-world_Input') `
+        "$ImplName /openapi.json components.schemas has greetings_hello-world_Input"
 
-    Assert-True ($schemaNames -contains 'greetings_hello_Output') `
-        "$ImplName /openapi.json components.schemas has greetings_hello_Output"
+    Assert-True ($schemaNames -contains 'greetings_hello-world_Output') `
+        "$ImplName /openapi.json components.schemas has greetings_hello-world_Output"
 
     # requestBody and response must use $ref to components.schemas
-    Assert-True ($requestBodySchema.'$ref' -match 'greetings_hello_Input') `
+    Assert-True ($requestBodySchema.'$ref' -match 'greetings_hello-world_Input') `
         "$ImplName /openapi.json POST hello requestBody uses `$ref to Input schema"
 
-    Assert-True ($responseSchema.'$ref' -match 'greetings_hello_Output') `
+    Assert-True ($responseSchema.'$ref' -match 'greetings_hello-world_Output') `
         "$ImplName /openapi.json POST hello response uses `$ref to Output schema"
 
     # Schema content — Input must have properties.name with type string
-    $inputSchema = $json.components.schemas.greetings_hello_Input
+    $inputSchema = $json.components.schemas.greetings_hello-world_Input
     $hasInputName = ($null -ne $inputSchema.properties) -and ($null -ne $inputSchema.properties.name)
     Assert-True $hasInputName `
-        "$ImplName /openapi.json greetings_hello_Input has properties.name"
+        "$ImplName /openapi.json greetings_hello-world_Input has properties.name"
 
     if ($hasInputName) {
         Assert-True ($inputSchema.properties.name.type -eq 'string') `
-            "$ImplName /openapi.json greetings_hello_Input.name type is 'string'"
+            "$ImplName /openapi.json greetings_hello-world_Input.name type is 'string'"
     }
 
     # Schema content — Output must have properties.message with type string
-    $outputSchema = $json.components.schemas.greetings_hello_Output
+    $outputSchema = $json.components.schemas.greetings_hello-world_Output
     $hasOutputMessage = ($null -ne $outputSchema.properties) -and ($null -ne $outputSchema.properties.message)
     Assert-True $hasOutputMessage `
-        "$ImplName /openapi.json greetings_hello_Output has properties.message"
+        "$ImplName /openapi.json greetings_hello-world_Output has properties.message"
 
     if ($hasOutputMessage) {
         Assert-True ($outputSchema.properties.message.type -eq 'string') `
-            "$ImplName /openapi.json greetings_hello_Output.message type is 'string'"
+            "$ImplName /openapi.json greetings_hello-world_Output.message type is 'string'"
     }
 
     # ── Time/Now endpoint in OpenAPI ─────────────────────────────────────────
 
-    $timePath = $json.paths.'/api/v1/time/now'
+    $timePath = $json.paths.'/api/v1/time/current-time'
     Assert-True ($null -ne $timePath) `
-        "$ImplName /openapi.json paths has /api/v1/time/now"
+        "$ImplName /openapi.json paths has /api/v1/time/current-time"
 
     Assert-True ($null -ne $timePath.get) `
-        "$ImplName /openapi.json /api/v1/time/now has GET operation"
+        "$ImplName /openapi.json /api/v1/time/current-time has GET operation"
 
-    Assert-True ($schemaNames -contains 'time_now_Output') `
-        "$ImplName /openapi.json components.schemas has time_now_Output"
+    Assert-True ($schemaNames -contains 'time_current-time_Output') `
+        "$ImplName /openapi.json components.schemas has time_current-time_Output"
 
     return $json
 }
@@ -630,8 +630,8 @@ function Test-OpenApiYaml {
     Assert-True ($body -match 'paths:') `
         "$ImplName /openapi.yaml contains 'paths:' key"
 
-    Assert-True ($body -match '/api/v1/greetings/hello') `
-        "$ImplName /openapi.yaml contains /api/v1/greetings/hello path"
+    Assert-True ($body -match '/api/v1/greetings/hello-world') `
+        "$ImplName /openapi.yaml contains /api/v1/greetings/hello-world path"
 
     Assert-True ($body -match 'components:') `
         "$ImplName /openapi.yaml contains 'components:' section"
@@ -833,21 +833,21 @@ function Compare-Implementations {
     # ── Schema content parity (properties, types, required) ──────────────────
     # Dart is the reference — TS and Python must produce identical schema content.
 
-    $dartInputJson  = $Dart.OpenApiJson.components.schemas.greetings_hello_Input       | ConvertTo-Json -Depth 10 -Compress
-    $tsInputJson    = $TypeScript.OpenApiJson.components.schemas.greetings_hello_Input  | ConvertTo-Json -Depth 10 -Compress
-    $pyInputJson    = $Python.OpenApiJson.components.schemas.greetings_hello_Input      | ConvertTo-Json -Depth 10 -Compress
+    $dartInputJson  = $Dart.OpenApiJson.components.schemas.greetings_hello-world_Input       | ConvertTo-Json -Depth 10 -Compress
+    $tsInputJson    = $TypeScript.OpenApiJson.components.schemas.greetings_hello-world_Input  | ConvertTo-Json -Depth 10 -Compress
+    $pyInputJson    = $Python.OpenApiJson.components.schemas.greetings_hello-world_Input      | ConvertTo-Json -Depth 10 -Compress
 
     Assert-True (
         ($dartInputJson -eq $tsInputJson) -and ($dartInputJson -eq $pyInputJson)
-    ) 'OpenAPI greetings_hello_Input schema content identical across implementations'
+    ) 'OpenAPI greetings_hello-world_Input schema content identical across implementations'
 
-    $dartOutputJson  = $Dart.OpenApiJson.components.schemas.greetings_hello_Output       | ConvertTo-Json -Depth 10 -Compress
-    $tsOutputJson    = $TypeScript.OpenApiJson.components.schemas.greetings_hello_Output  | ConvertTo-Json -Depth 10 -Compress
-    $pyOutputJson    = $Python.OpenApiJson.components.schemas.greetings_hello_Output      | ConvertTo-Json -Depth 10 -Compress
+    $dartOutputJson  = $Dart.OpenApiJson.components.schemas.greetings_hello-world_Output       | ConvertTo-Json -Depth 10 -Compress
+    $tsOutputJson    = $TypeScript.OpenApiJson.components.schemas.greetings_hello-world_Output  | ConvertTo-Json -Depth 10 -Compress
+    $pyOutputJson    = $Python.OpenApiJson.components.schemas.greetings_hello-world_Output      | ConvertTo-Json -Depth 10 -Compress
 
     Assert-True (
         ($dartOutputJson -eq $tsOutputJson) -and ($dartOutputJson -eq $pyOutputJson)
-    ) 'OpenAPI greetings_hello_Output schema content identical across implementations'
+    ) 'OpenAPI greetings_hello-world_Output schema content identical across implementations'
 
     # ── Metrics format parity ────────────────────────────────────────────────
 
@@ -862,7 +862,7 @@ function Compare-Implementations {
 
     # ── OpenAPI YAML parity ──────────────────────────────────────────────────
 
-    $yamlKeywords = @('openapi:', 'info:', 'paths:', '/api/v1/greetings/hello', '/api/v1/time/now')
+    $yamlKeywords = @('openapi:', 'info:', 'paths:', '/api/v1/greetings/hello-world', '/api/v1/time/current-time')
     foreach ($keyword in $yamlKeywords) {
         $dartHas = $Dart.OpenApiYaml       -match [regex]::Escape($keyword)
         $tsHas   = $TypeScript.OpenApiYaml -match [regex]::Escape($keyword)

--- a/tests/integration_test/parity_test.ps1
+++ b/tests/integration_test/parity_test.ps1
@@ -557,39 +557,39 @@ function Test-OpenApiJson {
         "$ImplName /openapi.json has components.schemas"
 
     $schemaNames = $json.components.schemas.PSObject.Properties.Name | Sort-Object
-    Assert-True ($schemaNames -contains 'greetings_hello-world_Input') `
-        "$ImplName /openapi.json components.schemas has greetings_hello-world_Input"
+    Assert-True ($schemaNames -contains 'greetings_hello_world_Input') `
+        "$ImplName /openapi.json components.schemas has greetings_hello_world_Input"
 
-    Assert-True ($schemaNames -contains 'greetings_hello-world_Output') `
-        "$ImplName /openapi.json components.schemas has greetings_hello-world_Output"
+    Assert-True ($schemaNames -contains 'greetings_hello_world_Output') `
+        "$ImplName /openapi.json components.schemas has greetings_hello_world_Output"
 
     # requestBody and response must use $ref to components.schemas
-    Assert-True ($requestBodySchema.'$ref' -match 'greetings_hello-world_Input') `
+    Assert-True ($requestBodySchema.'$ref' -match 'greetings_hello_world_Input') `
         "$ImplName /openapi.json POST hello requestBody uses `$ref to Input schema"
 
-    Assert-True ($responseSchema.'$ref' -match 'greetings_hello-world_Output') `
+    Assert-True ($responseSchema.'$ref' -match 'greetings_hello_world_Output') `
         "$ImplName /openapi.json POST hello response uses `$ref to Output schema"
 
     # Schema content — Input must have properties.name with type string
-    $inputSchema = $json.components.schemas['greetings_hello-world_Input']
+    $inputSchema = $json.components.schemas['greetings_hello_world_Input']
     $hasInputName = ($null -ne $inputSchema.properties) -and ($null -ne $inputSchema.properties.name)
     Assert-True $hasInputName `
-        "$ImplName /openapi.json greetings_hello-world_Input has properties.name"
+        "$ImplName /openapi.json greetings_hello_world_Input has properties.name"
 
     if ($hasInputName) {
         Assert-True ($inputSchema.properties.name.type -eq 'string') `
-            "$ImplName /openapi.json greetings_hello-world_Input.name type is 'string'"
+            "$ImplName /openapi.json greetings_hello_world_Input.name type is 'string'"
     }
 
     # Schema content — Output must have properties.message with type string
-    $outputSchema = $json.components.schemas['greetings_hello-world_Output']
+    $outputSchema = $json.components.schemas['greetings_hello_world_Output']
     $hasOutputMessage = ($null -ne $outputSchema.properties) -and ($null -ne $outputSchema.properties.message)
     Assert-True $hasOutputMessage `
-        "$ImplName /openapi.json greetings_hello-world_Output has properties.message"
+        "$ImplName /openapi.json greetings_hello_world_Output has properties.message"
 
     if ($hasOutputMessage) {
         Assert-True ($outputSchema.properties.message.type -eq 'string') `
-            "$ImplName /openapi.json greetings_hello-world_Output.message type is 'string'"
+            "$ImplName /openapi.json greetings_hello_world_Output.message type is 'string'"
     }
 
     # ── Time/Now endpoint in OpenAPI ─────────────────────────────────────────
@@ -601,8 +601,8 @@ function Test-OpenApiJson {
     Assert-True ($null -ne $timePath.get) `
         "$ImplName /openapi.json /api/v1/time/current-time has GET operation"
 
-    Assert-True ($schemaNames -contains 'time_current-time_Output') `
-        "$ImplName /openapi.json components.schemas has time_current-time_Output"
+    Assert-True ($schemaNames -contains 'time_current_time_Output') `
+        "$ImplName /openapi.json components.schemas has time_current_time_Output"
 
     return $json
 }
@@ -833,21 +833,21 @@ function Compare-Implementations {
     # ── Schema content parity (properties, types, required) ──────────────────
     # Dart is the reference — TS and Python must produce identical schema content.
 
-    $dartInputJson  = $Dart.OpenApiJson.components.schemas['greetings_hello-world_Input']       | ConvertTo-Json -Depth 10 -Compress
-    $tsInputJson    = $TypeScript.OpenApiJson.components.schemas['greetings_hello-world_Input']  | ConvertTo-Json -Depth 10 -Compress
-    $pyInputJson    = $Python.OpenApiJson.components.schemas['greetings_hello-world_Input']      | ConvertTo-Json -Depth 10 -Compress
+    $dartInputJson  = $Dart.OpenApiJson.components.schemas['greetings_hello_world_Input']       | ConvertTo-Json -Depth 10 -Compress
+    $tsInputJson    = $TypeScript.OpenApiJson.components.schemas['greetings_hello_world_Input']  | ConvertTo-Json -Depth 10 -Compress
+    $pyInputJson    = $Python.OpenApiJson.components.schemas['greetings_hello_world_Input']      | ConvertTo-Json -Depth 10 -Compress
 
     Assert-True (
         ($dartInputJson -eq $tsInputJson) -and ($dartInputJson -eq $pyInputJson)
-    ) 'OpenAPI greetings_hello-world_Input schema content identical across implementations'
+    ) 'OpenAPI greetings_hello_world_Input schema content identical across implementations'
 
-    $dartOutputJson  = $Dart.OpenApiJson.components.schemas['greetings_hello-world_Output']       | ConvertTo-Json -Depth 10 -Compress
-    $tsOutputJson    = $TypeScript.OpenApiJson.components.schemas['greetings_hello-world_Output']  | ConvertTo-Json -Depth 10 -Compress
-    $pyOutputJson    = $Python.OpenApiJson.components.schemas['greetings_hello-world_Output']      | ConvertTo-Json -Depth 10 -Compress
+    $dartOutputJson  = $Dart.OpenApiJson.components.schemas['greetings_hello_world_Output']       | ConvertTo-Json -Depth 10 -Compress
+    $tsOutputJson    = $TypeScript.OpenApiJson.components.schemas['greetings_hello_world_Output']  | ConvertTo-Json -Depth 10 -Compress
+    $pyOutputJson    = $Python.OpenApiJson.components.schemas['greetings_hello_world_Output']      | ConvertTo-Json -Depth 10 -Compress
 
     Assert-True (
         ($dartOutputJson -eq $tsOutputJson) -and ($dartOutputJson -eq $pyOutputJson)
-    ) 'OpenAPI greetings_hello-world_Output schema content identical across implementations'
+    ) 'OpenAPI greetings_hello_world_Output schema content identical across implementations'
 
     # ── Metrics format parity ────────────────────────────────────────────────
 

--- a/tests/integration_test/parity_test.ps1
+++ b/tests/integration_test/parity_test.ps1
@@ -421,6 +421,89 @@ function Test-UseCaseWrongType {
     return $json
 }
 
+# ── Time/Now UseCase tests ───────────────────────────────────────────────────
+
+function Test-TimeNowDefault {
+    <#
+    .SYNOPSIS
+        GET /api/v1/time/now (no tz param) → 200 with datetime and offset.
+    #>
+    param([string]$ImplName, [string]$BaseUrl)
+
+    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/time/now"
+
+    Assert-True ($response.StatusCode -eq 200) `
+        "$ImplName GET time/now (default) → 200"
+
+    if ($response.StatusCode -ne 200) {
+        Write-Host "    Body was: $($response.Body)" -ForegroundColor DarkGray
+        return $null
+    }
+
+    $json = $response.Body | ConvertFrom-Json
+
+    Assert-True ($null -ne $json.datetime) `
+        "$ImplName GET time/now (default) has datetime field"
+
+    Assert-True ($null -ne $json.offset) `
+        "$ImplName GET time/now (default) has offset field"
+
+    return $json
+}
+
+function Test-TimeNowWithOffset {
+    <#
+    .SYNOPSIS
+        GET /api/v1/time/now?tz=utc-5 → 200 with offset == -5.
+    #>
+    param([string]$ImplName, [string]$BaseUrl)
+
+    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/time/now?tz=utc-5"
+
+    Assert-True ($response.StatusCode -eq 200) `
+        "$ImplName GET time/now?tz=utc-5 → 200"
+
+    if ($response.StatusCode -ne 200) {
+        Write-Host "    Body was: $($response.Body)" -ForegroundColor DarkGray
+        return $null
+    }
+
+    $json = $response.Body | ConvertFrom-Json
+
+    Assert-True ($json.offset -eq -5) `
+        "$ImplName GET time/now?tz=utc-5 offset is -5"
+
+    Assert-True ($null -ne $json.datetime) `
+        "$ImplName GET time/now?tz=utc-5 has datetime field"
+
+    return $json
+}
+
+function Test-TimeNowInvalidTz {
+    <#
+    .SYNOPSIS
+        GET /api/v1/time/now?tz=invalid → 400 validation error.
+    #>
+    param([string]$ImplName, [string]$BaseUrl)
+
+    $response = Invoke-Endpoint -Uri "$BaseUrl/api/v1/time/now?tz=invalid"
+
+    Assert-True ($response.StatusCode -eq 400) `
+        "$ImplName GET time/now?tz=invalid → 400"
+
+    if ($response.StatusCode -notin @(400, 422)) {
+        Write-Host "    Body was: $($response.Body)" -ForegroundColor DarkGray
+        return $null
+    }
+
+    $json = $response.Body | ConvertFrom-Json
+
+    Assert-True ($json.error -eq 'invalid timezone format, use utc, utc-5, utc+3') `
+        "$ImplName GET time/now?tz=invalid error message is correct"
+
+    return $json
+}
+
 function Test-OpenApiJson {
     <#
     .SYNOPSIS
@@ -509,6 +592,18 @@ function Test-OpenApiJson {
             "$ImplName /openapi.json greetings_hello_Output.message type is 'string'"
     }
 
+    # ── Time/Now endpoint in OpenAPI ─────────────────────────────────────────
+
+    $timePath = $json.paths.'/api/v1/time/now'
+    Assert-True ($null -ne $timePath) `
+        "$ImplName /openapi.json paths has /api/v1/time/now"
+
+    Assert-True ($null -ne $timePath.get) `
+        "$ImplName /openapi.json /api/v1/time/now has GET operation"
+
+    Assert-True ($schemaNames -contains 'time_now_Output') `
+        "$ImplName /openapi.json components.schemas has time_now_Output"
+
     return $json
 }
 
@@ -569,6 +664,9 @@ function Test-Implementation {
         UseCaseEmptyName   = Test-UseCaseValidationFailure -ImplName $Name -BaseUrl $BaseUrl
         UseCaseMissingBody = Test-UseCaseMissingBody       -ImplName $Name -BaseUrl $BaseUrl
         UseCaseWrongType   = Test-UseCaseWrongType         -ImplName $Name -BaseUrl $BaseUrl
+        TimeNowDefault     = Test-TimeNowDefault           -ImplName $Name -BaseUrl $BaseUrl
+        TimeNowWithOffset  = Test-TimeNowWithOffset        -ImplName $Name -BaseUrl $BaseUrl
+        TimeNowInvalidTz   = Test-TimeNowInvalidTz         -ImplName $Name -BaseUrl $BaseUrl
         OpenApiJson        = Test-OpenApiJson              -ImplName $Name -BaseUrl $BaseUrl
         OpenApiYaml        = Test-OpenApiYaml              -ImplName $Name -BaseUrl $BaseUrl
     }
@@ -656,6 +754,32 @@ function Compare-Implementations {
         $script:failures += 'UseCase wrong-type error parity skipped — missing data'
     }
 
+    # ── Time/Now parity ──────────────────────────────────────────────────────
+    # Offset must be identical when a fixed tz param is used.
+    # Datetime values are NOT compared — each server's clock may differ by milliseconds.
+
+    if ($Dart.TimeNowWithOffset -and $TypeScript.TimeNowWithOffset -and $Python.TimeNowWithOffset) {
+        Assert-True (
+            ($Dart.TimeNowWithOffset.offset -eq $TypeScript.TimeNowWithOffset.offset) -and
+            ($Dart.TimeNowWithOffset.offset -eq $Python.TimeNowWithOffset.offset)
+        ) 'Time/now offset identical across implementations (utc-5)'
+    } else {
+        Write-Fail 'Time/now offset identical across implementations (skipped — missing data)'
+        $script:totalTests++; $script:failedTests++
+        $script:failures += 'Time/now offset parity skipped — missing data'
+    }
+
+    if ($Dart.TimeNowInvalidTz -and $TypeScript.TimeNowInvalidTz -and $Python.TimeNowInvalidTz) {
+        Assert-True (
+            ($Dart.TimeNowInvalidTz.error -eq $TypeScript.TimeNowInvalidTz.error) -and
+            ($Dart.TimeNowInvalidTz.error -eq $Python.TimeNowInvalidTz.error)
+        ) 'Time/now invalid tz error identical across implementations'
+    } else {
+        Write-Fail 'Time/now invalid tz error identical across implementations (skipped — missing data)'
+        $script:totalTests++; $script:failedTests++
+        $script:failures += 'Time/now invalid tz error parity skipped — missing data'
+    }
+
     # ── OpenAPI JSON structural parity ───────────────────────────────────────
 
     Assert-True (
@@ -738,7 +862,7 @@ function Compare-Implementations {
 
     # ── OpenAPI YAML parity ──────────────────────────────────────────────────
 
-    $yamlKeywords = @('openapi:', 'info:', 'paths:', '/api/v1/greetings/hello')
+    $yamlKeywords = @('openapi:', 'info:', 'paths:', '/api/v1/greetings/hello', '/api/v1/time/now')
     foreach ($keyword in $yamlKeywords) {
         $dartHas = $Dart.OpenApiYaml       -match [regex]::Escape($keyword)
         $tsHas   = $TypeScript.OpenApiYaml -match [regex]::Escape($keyword)

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -7,6 +7,16 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+## [0.4.3] - 2026-03-13
+
+### Changed (BREAKING)
+
+- **`execute()` returns `Promise<O>`** — no longer `Promise<void>`; the handler reads the returned Output directly
+- **Removed `output` field** from `UseCase` — no mutable state; `execute()` returns the result
+- **Removed `toJson()`** from `UseCase` — the handler calls `output.toJson()` on the returned value
+- **`inputClass` / `outputClass` now required** in `UseCaseOptions` — OpenAPI schema extraction uses them directly
+- **Removed Strategy 2 fallback** in OpenAPI schema extraction — no `factory({}).output` path
+
 ## [0.4.2] - 2026-03-12
 
 ### Added

--- a/ts/doc/logger_guide.md
+++ b/ts/doc/logger_guide.md
@@ -68,7 +68,7 @@ class CreateUser extends UseCase<CreateUserInput, CreateUserOutput> {
     return null;
   }
 
-  async execute(): Promise<void> {
+  async execute(): Promise<CreateUserOutput> {
     this.logger?.info(`Creating user: ${this.input.email}`);
 
     // ... business logic ...
@@ -78,11 +78,7 @@ class CreateUser extends UseCase<CreateUserInput, CreateUserOutput> {
       email: this.input.email,
     });
 
-    this.output = new CreateUserOutput(newUser.id);
-  }
-
-  toJson() {
-    return this.output.toJson();
+    return new CreateUserOutput(newUser.id);
   }
 }
 ```

--- a/ts/doc/naming_guide.md
+++ b/ts/doc/naming_guide.md
@@ -1,0 +1,58 @@
+# Naming Guide
+
+Naming conventions for commands, classes, and files in `modular-api`.
+
+---
+
+## Core Rule
+
+The **command**, the **UseCase class**, and the **file** share the same root:
+
+| Layer | Format | Example |
+|---|---|---|
+| Command (route segment) | `kebab-case` | `'hello-world'` |
+| UseCase class | `PascalCase` | `HelloWorld` |
+| File | `snake_case` | `hello_world.ts` |
+
+The command string passed to `m.usecase(command, ...)` becomes the URL segment
+(`/module/command`) and the root for every related symbol.
+
+---
+
+## Input / Output DTOs
+
+Append `Input` and `Output` to the UseCase class name:
+
+```ts
+class HelloWorldInput extends Input { ... }
+class HelloWorldOutput extends Output { ... }
+class HelloWorld implements UseCase<HelloWorldInput, HelloWorldOutput> { ... }
+```
+
+---
+
+## Full Example
+
+```
+command:  'hello-world'
+route:    POST /api/v1/greetings/hello-world
+
+file:     hello_world.ts
+class:    HelloWorld
+input:    HelloWorldInput
+output:   HelloWorldOutput
+schema:   greetings_hello-world_Input / greetings_hello-world_Output
+```
+
+---
+
+## Why "Command"?
+
+Use cases are **commands** — explicit, validated operations that change state
+(POST, PUT, PATCH, DELETE). This terminology aligns with the CQRS architecture
+planned for v0.6.0, where:
+
+- **Commands** → REST endpoints (use cases) — write operations
+- **Queries** → GraphQL plugin — read operations
+
+See [roadmap.md](../../docs/roadmap.md) for the full CQRS vision.

--- a/ts/doc/naming_guide.md
+++ b/ts/doc/naming_guide.md
@@ -41,7 +41,7 @@ file:     hello_world.ts
 class:    HelloWorld
 input:    HelloWorldInput
 output:   HelloWorldOutput
-schema:   greetings_hello-world_Input / greetings_hello-world_Output
+schema:   greetings_hello_world_Input / greetings_hello_world_Output
 ```
 
 ---

--- a/ts/example/example.ts
+++ b/ts/example/example.ts
@@ -67,12 +67,10 @@ class HelloOutput extends Output {
 
 class HelloWorld implements UseCase<HelloInput, HelloOutput> {
   readonly input: HelloInput;
-  output: HelloOutput;
   logger?: import('../src/core/logger/logger').ModularLogger;
 
   constructor(input: HelloInput) {
     this.input = input;
-    this.output = new HelloOutput();
   }
 
   static fromJson(json: Record<string, unknown>): HelloWorld {
@@ -86,15 +84,11 @@ class HelloWorld implements UseCase<HelloInput, HelloOutput> {
     return null;
   }
 
-  async execute(): Promise<void> {
+  async execute(): Promise<HelloOutput> {
     this.logger?.info(`Greeting user: ${this.input.name}`);
     const output = new HelloOutput();
     output.message = `Hello, ${this.input.name}!`;
-    this.output = output;
-  }
-
-  toJson(): Record<string, unknown> {
-    return this.output.toJson();
+    return output;
   }
 }
 

--- a/ts/example/example.ts
+++ b/ts/example/example.ts
@@ -6,10 +6,10 @@
  *   npx ts-node example/example.ts
  *
  * Then test:
- *   curl -X POST http://localhost:8080/api/v1/greetings/hello \
+ *   curl -X POST http://localhost:8080/api/v1/greetings/hello-world \
  *        -H "Content-Type: application/json" \
  *        -d '{"name":"World"}'
- *   curl http://localhost:8080/api/v1/time/now?tz=utc-5
+ *   curl http://localhost:8080/api/v1/time/current-time?tz=utc-5
  *
  * Docs:
  *   http://localhost:8080/docs

--- a/ts/example/example.ts
+++ b/ts/example/example.ts
@@ -43,13 +43,6 @@ class HelloInput extends Input {
   @Field.string({ description: 'Name to greet', example: 'World' })
   name!: string;
 
-  /// Strict factory — no coercion, no defaults.
-  /// Pre-validation in the handler ensures data is valid before this runs.
-  static fromJson(json: Record<string, unknown>): HelloInput {
-    const instance = new HelloInput();
-    instance.name = json['name'] as string;
-    return instance;
-  }
 }
 
 // ─── Output DTO ───────────────────────────────────────────────────────────────
@@ -74,7 +67,9 @@ class HelloWorld implements UseCase<HelloInput, HelloOutput> {
   }
 
   static fromJson(json: Record<string, unknown>): HelloWorld {
-    return new HelloWorld(HelloInput.fromJson(json));
+      const input = new HelloInput();
+      input.name = json['name'] as string;
+      return new HelloWorld(input);
   }
 
   validate(): string | null {

--- a/ts/example/example.ts
+++ b/ts/example/example.ts
@@ -6,97 +6,19 @@
  *   npx ts-node example/example.ts
  *
  * Then test:
- *   curl -X POST http://localhost:8080/api/greetings/hello \
+ *   curl -X POST http://localhost:8080/api/v1/greetings/hello \
  *        -H "Content-Type: application/json" \
  *        -d '{"name":"World"}'
+ *   curl http://localhost:8080/api/v1/time/now?tz=utc-5
  *
  * Docs:
  *   http://localhost:8080/docs
  */
 
-import {
-  Input,
-  Output,
-  UseCase,
-  ModularApi,
-  ModuleBuilder,
-  HealthCheck,
-  HealthCheckResult,
-  LogLevel,
-  Field,
-} from '../src/index';
-
-// ─── Module Builder ───────────────────────────────────────────────────────────
-// In a real project, this would live in its own file:
-//   src/modules/greetings/greetings_builder.ts
-
-function buildGreetingsModule(m: ModuleBuilder): void {
-  m.usecase('hello', HelloWorld.fromJson, {
-    inputClass: HelloInput,
-    outputClass: HelloOutput,
-  });
-}
-
-// ─── Input DTO ────────────────────────────────────────────────────────────────
-
-class HelloInput extends Input {
-  @Field.string({ description: 'Name to greet', example: 'World' })
-  name!: string;
-
-}
-
-// ─── Output DTO ───────────────────────────────────────────────────────────────
-
-class HelloOutput extends Output {
-  @Field.string({ description: 'Greeting message', example: 'Hello, World!' })
-  message!: string;
-
-  get statusCode() {
-    return 200;
-  }
-}
-
-// ─── UseCase ──────────────────────────────────────────────────────────────────
-
-class HelloWorld implements UseCase<HelloInput, HelloOutput> {
-  readonly input: HelloInput;
-  logger?: import('../src/core/logger/logger').ModularLogger;
-
-  constructor(input: HelloInput) {
-    this.input = input;
-  }
-
-  static fromJson(json: Record<string, unknown>): HelloWorld {
-      const input = new HelloInput();
-      input.name = json['name'] as string;
-      return new HelloWorld(input);
-  }
-
-  validate(): string | null {
-    if (!this.input.name) {
-      return 'name is required';
-    }
-    return null;
-  }
-
-  async execute(): Promise<HelloOutput> {
-    this.logger?.info(`Greeting user: ${this.input.name}`);
-    const output = new HelloOutput();
-    output.message = `Hello, ${this.input.name}!`;
-    return output;
-  }
-}
-
-// ─── Example Health Check ─────────────────────────────────────────────────────
-// In a real project you'd check a database connection, external service, etc.
-
-class AlwaysPassHealthCheck extends HealthCheck {
-  readonly name = 'example';
-
-  async check(): Promise<HealthCheckResult> {
-    return new HealthCheckResult('pass');
-  }
-}
+import { ModularApi, LogLevel } from '../src/index';
+import { AlwaysPassHealthCheck } from './health/always_pass_health_check';
+import { buildGreetingsModule } from './modules/greetings/greetings_builder';
+import { buildTimeModule } from './modules/time/time_builder';
 
 // ─── Server ───────────────────────────────────────────────────────────────────
 
@@ -104,7 +26,7 @@ class AlwaysPassHealthCheck extends HealthCheck {
 const port = Number(process.argv[2]) || 8080;
 
 const api = new ModularApi({
-  basePath: '/api',
+  basePath: '/api/v1',
   title: 'Modular API',
   version: '1.0.0',
   metricsEnabled: true,
@@ -123,5 +45,6 @@ if (api.metrics) {
 }
 
 api.module('greetings', buildGreetingsModule);
+api.module('time', buildTimeModule);
 
 api.serve({ port });

--- a/ts/example/health/always_pass_health_check.ts
+++ b/ts/example/health/always_pass_health_check.ts
@@ -1,0 +1,9 @@
+import { HealthCheck, HealthCheckResult } from '../../src/index';
+
+export class AlwaysPassHealthCheck extends HealthCheck {
+  readonly name = 'example';
+
+  async check(): Promise<HealthCheckResult> {
+    return new HealthCheckResult('pass');
+  }
+}

--- a/ts/example/modules/greetings/greetings_builder.ts
+++ b/ts/example/modules/greetings/greetings_builder.ts
@@ -1,9 +1,9 @@
 import { ModuleBuilder } from '../../../src/index';
-import { HelloInput, HelloOutput, HelloWorld } from './usecases/hello_world';
+import { HelloWorldInput, HelloWorldOutput, HelloWorld } from './usecases/hello_world';
 
 export function buildGreetingsModule(m: ModuleBuilder): void {
-  m.usecase('hello', HelloWorld.fromJson, {
-    inputClass: HelloInput,
-    outputClass: HelloOutput,
+  m.usecase('hello-world', HelloWorld.fromJson, {
+    inputClass: HelloWorldInput,
+    outputClass: HelloWorldOutput,
   });
 }

--- a/ts/example/modules/greetings/greetings_builder.ts
+++ b/ts/example/modules/greetings/greetings_builder.ts
@@ -1,0 +1,9 @@
+import { ModuleBuilder } from '../../../src/index';
+import { HelloInput, HelloOutput, HelloWorld } from './usecases/hello_world';
+
+export function buildGreetingsModule(m: ModuleBuilder): void {
+  m.usecase('hello', HelloWorld.fromJson, {
+    inputClass: HelloInput,
+    outputClass: HelloOutput,
+  });
+}

--- a/ts/example/modules/greetings/usecases/hello_world.ts
+++ b/ts/example/modules/greetings/usecases/hello_world.ts
@@ -2,14 +2,14 @@ import { Input, Output, UseCase, Field, ModularLogger } from '../../../../src/in
 
 // ─── Input DTO ────────────────────────────────────────────────────────────────
 
-export class HelloInput extends Input {
+export class HelloWorldInput extends Input {
   @Field.string({ description: 'Name to greet', example: 'World' })
   name!: string;
 }
 
 // ─── Output DTO ───────────────────────────────────────────────────────────────
 
-export class HelloOutput extends Output {
+export class HelloWorldOutput extends Output {
   @Field.string({ description: 'Greeting message', example: 'Hello, World!' })
   message!: string;
 
@@ -20,16 +20,16 @@ export class HelloOutput extends Output {
 
 // ─── UseCase ──────────────────────────────────────────────────────────────────
 
-export class HelloWorld implements UseCase<HelloInput, HelloOutput> {
-  readonly input: HelloInput;
+export class HelloWorld implements UseCase<HelloWorldInput, HelloWorldOutput> {
+  readonly input: HelloWorldInput;
   logger?: ModularLogger;
 
-  constructor(input: HelloInput) {
+  constructor(input: HelloWorldInput) {
     this.input = input;
   }
 
   static fromJson(json: Record<string, unknown>): HelloWorld {
-    const input = new HelloInput();
+    const input = new HelloWorldInput();
     input.name = json['name'] as string;
     return new HelloWorld(input);
   }
@@ -41,9 +41,9 @@ export class HelloWorld implements UseCase<HelloInput, HelloOutput> {
     return null;
   }
 
-  async execute(): Promise<HelloOutput> {
+  async execute(): Promise<HelloWorldOutput> {
     this.logger?.info(`Greeting user: ${this.input.name}`);
-    const output = new HelloOutput();
+    const output = new HelloWorldOutput();
     output.message = `Hello, ${this.input.name}!`;
     return output;
   }

--- a/ts/example/modules/greetings/usecases/hello_world.ts
+++ b/ts/example/modules/greetings/usecases/hello_world.ts
@@ -1,0 +1,50 @@
+import { Input, Output, UseCase, Field, ModularLogger } from '../../../../src/index';
+
+// ─── Input DTO ────────────────────────────────────────────────────────────────
+
+export class HelloInput extends Input {
+  @Field.string({ description: 'Name to greet', example: 'World' })
+  name!: string;
+}
+
+// ─── Output DTO ───────────────────────────────────────────────────────────────
+
+export class HelloOutput extends Output {
+  @Field.string({ description: 'Greeting message', example: 'Hello, World!' })
+  message!: string;
+
+  get statusCode() {
+    return 200;
+  }
+}
+
+// ─── UseCase ──────────────────────────────────────────────────────────────────
+
+export class HelloWorld implements UseCase<HelloInput, HelloOutput> {
+  readonly input: HelloInput;
+  logger?: ModularLogger;
+
+  constructor(input: HelloInput) {
+    this.input = input;
+  }
+
+  static fromJson(json: Record<string, unknown>): HelloWorld {
+    const input = new HelloInput();
+    input.name = json['name'] as string;
+    return new HelloWorld(input);
+  }
+
+  validate(): string | null {
+    if (!this.input.name) {
+      return 'name is required';
+    }
+    return null;
+  }
+
+  async execute(): Promise<HelloOutput> {
+    this.logger?.info(`Greeting user: ${this.input.name}`);
+    const output = new HelloOutput();
+    output.message = `Hello, ${this.input.name}!`;
+    return output;
+  }
+}

--- a/ts/example/modules/time/time_builder.ts
+++ b/ts/example/modules/time/time_builder.ts
@@ -1,10 +1,10 @@
 import { ModuleBuilder } from '../../../src/index';
-import { TimeInput, TimeOutput, CurrentTime } from './usecases/current_time';
+import { CurrentTimeInput, CurrentTimeOutput, CurrentTime } from './usecases/current_time';
 
 export function buildTimeModule(m: ModuleBuilder): void {
-  m.usecase('now', CurrentTime.fromJson, {
-    inputClass: TimeInput,
-    outputClass: TimeOutput,
+  m.usecase('current-time', CurrentTime.fromJson, {
+    inputClass: CurrentTimeInput,
+    outputClass: CurrentTimeOutput,
     method: 'GET',
   });
 }

--- a/ts/example/modules/time/time_builder.ts
+++ b/ts/example/modules/time/time_builder.ts
@@ -1,0 +1,10 @@
+import { ModuleBuilder } from '../../../src/index';
+import { TimeInput, TimeOutput, CurrentTime } from './usecases/current_time';
+
+export function buildTimeModule(m: ModuleBuilder): void {
+  m.usecase('now', CurrentTime.fromJson, {
+    inputClass: TimeInput,
+    outputClass: TimeOutput,
+    method: 'GET',
+  });
+}

--- a/ts/example/modules/time/usecases/current_time.ts
+++ b/ts/example/modules/time/usecases/current_time.ts
@@ -2,14 +2,14 @@ import { Input, Output, UseCase, Field, ModularLogger } from '../../../../src/in
 
 // ─── Input DTO ────────────────────────────────────────────────────────────────
 
-export class TimeInput extends Input {
+export class CurrentTimeInput extends Input {
   @Field.optional(Field.string({ description: 'Timezone offset (e.g. utc-5, utc+3, utc)', example: 'utc-5' }))
   tz?: string;
 }
 
 // ─── Output DTO ───────────────────────────────────────────────────────────────
 
-export class TimeOutput extends Output {
+export class CurrentTimeOutput extends Output {
   @Field.string({ description: 'ISO 8601 datetime at the requested offset', example: '2026-03-14T07:00:00' })
   datetime!: string;
 
@@ -23,16 +23,16 @@ export class TimeOutput extends Output {
 
 // ─── UseCase ──────────────────────────────────────────────────────────────────
 
-export class CurrentTime implements UseCase<TimeInput, TimeOutput> {
-  readonly input: TimeInput;
+export class CurrentTime implements UseCase<CurrentTimeInput, CurrentTimeOutput> {
+  readonly input: CurrentTimeInput;
   logger?: ModularLogger;
 
-  constructor(input: TimeInput) {
+  constructor(input: CurrentTimeInput) {
     this.input = input;
   }
 
   static fromJson(json: Record<string, unknown>): CurrentTime {
-    const input = new TimeInput();
+    const input = new CurrentTimeInput();
     input.tz = json['tz'] != null ? String(json['tz']) : undefined;
     return new CurrentTime(input);
   }
@@ -45,7 +45,7 @@ export class CurrentTime implements UseCase<TimeInput, TimeOutput> {
     return null;
   }
 
-  async execute(): Promise<TimeOutput> {
+  async execute(): Promise<CurrentTimeOutput> {
     const now = new Date();
     const offsetHours = this.input.tz
       ? CurrentTime.parseOffset(this.input.tz)!
@@ -54,7 +54,7 @@ export class CurrentTime implements UseCase<TimeInput, TimeOutput> {
     const iso = adjusted.toISOString().split('.')[0];
 
     this.logger?.info(`Time requested for offset ${offsetHours}`);
-    const output = new TimeOutput();
+    const output = new CurrentTimeOutput();
     output.datetime = iso;
     output.offset = offsetHours;
     return output;

--- a/ts/example/modules/time/usecases/current_time.ts
+++ b/ts/example/modules/time/usecases/current_time.ts
@@ -1,0 +1,71 @@
+import { Input, Output, UseCase, Field, ModularLogger } from '../../../../src/index';
+
+// ─── Input DTO ────────────────────────────────────────────────────────────────
+
+export class TimeInput extends Input {
+  @Field.optional(Field.string({ description: 'Timezone offset (e.g. utc-5, utc+3, utc)', example: 'utc-5' }))
+  tz?: string;
+}
+
+// ─── Output DTO ───────────────────────────────────────────────────────────────
+
+export class TimeOutput extends Output {
+  @Field.string({ description: 'ISO 8601 datetime at the requested offset', example: '2026-03-14T07:00:00' })
+  datetime!: string;
+
+  @Field.integer({ description: 'UTC offset in hours', example: -5 })
+  offset!: number;
+
+  get statusCode() {
+    return 200;
+  }
+}
+
+// ─── UseCase ──────────────────────────────────────────────────────────────────
+
+export class CurrentTime implements UseCase<TimeInput, TimeOutput> {
+  readonly input: TimeInput;
+  logger?: ModularLogger;
+
+  constructor(input: TimeInput) {
+    this.input = input;
+  }
+
+  static fromJson(json: Record<string, unknown>): CurrentTime {
+    const input = new TimeInput();
+    input.tz = json['tz'] != null ? String(json['tz']) : undefined;
+    return new CurrentTime(input);
+  }
+
+  validate(): string | null {
+    if (!this.input.tz) return null;
+    const offset = CurrentTime.parseOffset(this.input.tz);
+    if (offset === null) return 'invalid timezone format, use utc, utc-5, utc+3';
+    if (offset < -12 || offset > 14) return 'offset must be between -12 and +14';
+    return null;
+  }
+
+  async execute(): Promise<TimeOutput> {
+    const now = new Date();
+    const offsetHours = this.input.tz
+      ? CurrentTime.parseOffset(this.input.tz)!
+      : -(now.getTimezoneOffset() / 60);
+    const adjusted = new Date(now.getTime() + offsetHours * 3600_000);
+    const iso = adjusted.toISOString().split('.')[0];
+
+    this.logger?.info(`Time requested for offset ${offsetHours}`);
+    const output = new TimeOutput();
+    output.datetime = iso;
+    output.offset = offsetHours;
+    return output;
+  }
+
+  /** Parses "utc-5", "utc+3", "utc" into an integer offset. Returns null on bad format. */
+  private static parseOffset(tz: string): number | null {
+    const lower = tz.toLowerCase().trim();
+    if (lower === 'utc') return 0;
+    const match = lower.match(/^utc([+-]\d{1,2})$/);
+    if (!match) return null;
+    return parseInt(match[1], 10);
+  }
+}

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macss/modular-api",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Use-case-centric toolkit for building modular APIs with Express. Define UseCase classes (input → validate → execute → output), connect them to HTTP routes, and expose Swagger/OpenAPI documentation automatically.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/ts/src/core/module_builder.ts
+++ b/ts/src/core/module_builder.ts
@@ -56,20 +56,20 @@ export class ModuleBuilder {
   /**
    * Registers a use case as an HTTP endpoint.
    *
-   * @param name     Route segment, e.g. 'create' → POST /api/users/create
+   * @param command  Route segment and operationId root, e.g. 'hello-world' → POST /api/greetings/hello-world.
+   *                  Convention: command, class name, and file name share the same root.
    * @param factory  The static `fromJson` of your UseCase class
-   * @param options  Optional HTTP method, summary and description for OpenAPI
+   * @param options  HTTP method, inputClass/outputClass, and optional OpenAPI metadata
    */
   usecase<I extends Input, O extends Output>(
-    name: string,
+    command: string,
     factory: UseCaseFactory<I, O>,
     options: UseCaseOptions,
   ): this {
     const { method = 'POST', summary, description, inputSchema, outputSchema, inputClass, outputClass } = options;
 
-    // Normalize name: trim and remove leading slash
-    const cleanName = name.trim().replace(/^\//g, '');
-    const subPath = `/${cleanName}`;
+    const cleanCommand = command.trim().replace(/^\//g, '');
+    const subPath = `/${cleanCommand}`;
     const methodL = method.toLowerCase() as Lowercase<HttpMethod>;
 
     // Mount the Express handler (with optional pre-validation)
@@ -85,14 +85,14 @@ export class ModuleBuilder {
     // Register in the global registry for OpenAPI generation
     apiRegistry.routes.push({
       module: this.moduleName,
-      name: cleanName,
+      command: cleanCommand,
       method: method,
-      path: `${this._normalizeBase(this.basePath)}/${this.moduleName}/${cleanName}`,
+      path: `${this._normalizeBase(this.basePath)}/${this.moduleName}/${cleanCommand}`,
       factory: factory as UseCaseFactory<Input, Output>,
       schemas,
       doc: {
-        summary: summary ?? `Use case ${cleanName} in module ${this.moduleName}`,
-        description: description ?? `Auto-generated documentation for ${cleanName}`,
+        summary: summary ?? `Use case ${cleanCommand} in module ${this.moduleName}`,
+        description: description ?? `Auto-generated documentation for ${cleanCommand}`,
         tags: [this.moduleName],
       },
     });

--- a/ts/src/core/module_builder.ts
+++ b/ts/src/core/module_builder.ts
@@ -23,9 +23,9 @@ export interface UseCaseOptions {
   /** Override output schema for OpenAPI (if fromJson fails with empty data) */
   outputSchema?: Record<string, unknown>;
   /** Input class for pre-validation and schema extraction (enables strict fromJson). */
-  inputClass?: abstract new (...args: unknown[]) => Input;
+  inputClass: abstract new (...args: unknown[]) => Input;
   /** Output class for schema extraction. */
-  outputClass?: abstract new (...args: unknown[]) => Output;
+  outputClass: abstract new (...args: unknown[]) => Output;
 }
 
 /**
@@ -63,7 +63,7 @@ export class ModuleBuilder {
   usecase<I extends Input, O extends Output>(
     name: string,
     factory: UseCaseFactory<I, O>,
-    options: UseCaseOptions = {},
+    options: UseCaseOptions,
   ): this {
     const { method = 'POST', summary, description, inputSchema, outputSchema, inputClass, outputClass } = options;
 
@@ -75,8 +75,8 @@ export class ModuleBuilder {
     // Mount the Express handler (with optional pre-validation)
     this.router[methodL](subPath, useCaseHandler(factory, { inputClass }));
 
-    // Try to capture schemas — prefer class-level metadata, then dummy factory
-    const extracted = this._extractSchemas(factory, inputClass, outputClass);
+    // Capture schemas from @Field decorator metadata
+    const extracted = this._extractSchemas(inputClass, outputClass);
     const schemas = {
       input: inputSchema ?? extracted.input,
       output: outputSchema ?? extracted.output,
@@ -101,59 +101,25 @@ export class ModuleBuilder {
   }
 
   /**
-   * Capture Input and Output schemas from decorator metadata or a dummy factory call.
+   * Capture Input and Output schemas from decorator metadata.
    *
-   * Strategy (in order of preference):
-   * 1. Class-level: inputClass/outputClass → @Field metadata → build schema.
-   * 2. Fallback: call factory({}) and invoke toSchema() on the result (legacy).
+   * Uses @Field metadata from inputClass/outputClass to build schemas.
    */
   private _extractSchemas<I extends Input, O extends Output>(
-    factory: UseCaseFactory<I, O>,
-    inputClass?: abstract new (...args: unknown[]) => Input,
-    outputClass?: abstract new (...args: unknown[]) => Output,
+    inputClass: abstract new (...args: unknown[]) => Input,
+    outputClass: abstract new (...args: unknown[]) => Output,
   ): { input: Record<string, unknown>; output: Record<string, unknown> } {
     let input: Record<string, unknown> = {};
     let output: Record<string, unknown> = {};
 
-    // Strategy 1: class-level via @Field metadata (no instantiation needed)
-    if (inputClass) {
-      const fields = getFieldMetadata(inputClass);
-      if (fields.length > 0) {
-        input = new (inputClass as new () => Input)().toSchema();
-      }
-    }
-    if (outputClass) {
-      const fields = getFieldMetadata(outputClass);
-      if (fields.length > 0) {
-        output = new (outputClass as new () => Output)().toSchema();
-      }
+    const inputFields = getFieldMetadata(inputClass);
+    if (inputFields.length > 0) {
+      input = new (inputClass as new () => Input)().toSchema();
     }
 
-    // Strategy 2 fallback: dummy factory call
-    if (Object.keys(input).length === 0 || Object.keys(output).length === 0) {
-      let instance: UseCase<I, O> | undefined;
-      try {
-        instance = factory({});
-      } catch {
-        // Factory failed — that's fine.
-      }
-
-      if (instance) {
-        if (Object.keys(input).length === 0) {
-          try {
-            input = instance.input.toSchema();
-          } catch {
-            // toSchema() not available — keep empty.
-          }
-        }
-        if (Object.keys(output).length === 0) {
-          try {
-            output = instance.output.toSchema();
-          } catch {
-            // Output not initialised until execute() — expected for most UseCases.
-          }
-        }
-      }
+    const outputFields = getFieldMetadata(outputClass);
+    if (outputFields.length > 0) {
+      output = new (outputClass as new () => Output)().toSchema();
     }
 
     return { input, output };

--- a/ts/src/core/registry.ts
+++ b/ts/src/core/registry.ts
@@ -21,10 +21,11 @@ export interface UseCaseDocMeta {
 
 export interface UseCaseRegistration {
   module: string;
-  name: string;
+  /** Route segment and operationId root, e.g. 'hello-world' */
+  command: string;
   /** HTTP method in uppercase: "POST" | "GET" | "PUT" | "PATCH" | "DELETE" */
   method: string;
-  /** Full path e.g. "/api/users/create" */
+  /** Full path e.g. "/api/v1/greetings/hello-world" */
   path: string;
   factory: UseCaseFactory<Input, Output>;
   doc?: UseCaseDocMeta;

--- a/ts/src/core/usecase.ts
+++ b/ts/src/core/usecase.ts
@@ -265,9 +265,6 @@ export abstract class UseCase<I extends Input, O extends Output> {
   /** Input DTO — set in constructor. */
   abstract readonly input: I;
 
-  /** Output DTO — set in execute(). */
-  abstract output: O;
-
   /**
    * Request-scoped logger injected by the framework's logging middleware.
    * Available inside `execute()`. Undefined when running without middleware
@@ -283,14 +280,8 @@ export abstract class UseCase<I extends Input, O extends Output> {
   abstract validate(): string | null;
 
   /**
-   * Business logic. Must set `this.output` before returning.
+   * Business logic. Returns the Output DTO.
    * Keep this method free of HTTP concerns.
    */
-  abstract execute(): Promise<void>;
-
-  /**
-   * Serializes the output DTO to a plain object for the HTTP response.
-   * Typically implemented as `return this.output.toJson();`
-   */
-  abstract toJson(): Record<string, unknown>;
+  abstract execute(): Promise<O>;
 }

--- a/ts/src/core/usecase_handler.ts
+++ b/ts/src/core/usecase_handler.ts
@@ -83,10 +83,10 @@ export function useCaseHandler<I extends Input, O extends Output>(
       }
 
       // 4. Execute
-      await useCase.execute();
+      const output = await useCase.execute();
 
       // 5. Respond
-      res.status(useCase.output.statusCode).set(JSON_HEADERS).json(useCase.toJson());
+      res.status(output.statusCode).set(JSON_HEADERS).json(output.toJson());
     } catch (err) {
       if (err instanceof InputValidationError) {
         res.status(400).set(JSON_HEADERS).json({ error: err.message });

--- a/ts/src/openapi/openapi.ts
+++ b/ts/src/openapi/openapi.ts
@@ -44,8 +44,9 @@ export function buildOpenApiSpec(options: OpenApiOptions): Record<string, unknow
     const path = route.path;
 
     // Store named schemas in components for Swagger UI "Schemas" section
-    const inputRefName = `${route.module}_${route.command}_Input`;
-    const outputRefName = `${route.module}_${route.command}_Output`;
+    const safeCommand = route.command.replace(/-/g, '_');
+    const inputRefName = `${route.module}_${safeCommand}_Input`;
+    const outputRefName = `${route.module}_${safeCommand}_Output`;
     componentSchemas[inputRefName] = route.schemas.input;
     componentSchemas[outputRefName] = route.schemas.output;
 

--- a/ts/src/openapi/openapi.ts
+++ b/ts/src/openapi/openapi.ts
@@ -44,8 +44,8 @@ export function buildOpenApiSpec(options: OpenApiOptions): Record<string, unknow
     const path = route.path;
 
     // Store named schemas in components for Swagger UI "Schemas" section
-    const inputRefName = `${route.module}_${route.name}_Input`;
-    const outputRefName = `${route.module}_${route.name}_Output`;
+    const inputRefName = `${route.module}_${route.command}_Input`;
+    const outputRefName = `${route.module}_${route.command}_Output`;
     componentSchemas[inputRefName] = route.schemas.input;
     componentSchemas[outputRefName] = route.schemas.output;
 

--- a/ts/test/handler/handler_pre_validation.test.ts
+++ b/ts/test/handler/handler_pre_validation.test.ts
@@ -46,7 +46,6 @@ class StrictOutput extends Output {
 
 class StrictUseCase extends UseCase<StrictInput, StrictOutput> {
   readonly input: StrictInput;
-  output!: StrictOutput;
 
   constructor(input: StrictInput) {
     super();
@@ -64,11 +63,7 @@ class StrictUseCase extends UseCase<StrictInput, StrictOutput> {
   async execute() {
     const out = new StrictOutput();
     out.greeting = `Hello ${this.input.name}`;
-    this.output = out;
-  }
-
-  toJson() {
-    return this.output.toJson();
+    return out;
   }
 }
 

--- a/ts/test/logger/logging_integration.test.ts
+++ b/ts/test/logger/logging_integration.test.ts
@@ -29,7 +29,6 @@ class PingOutput implements Output {
 
 class PingUseCase extends UseCase<PingInput, PingOutput> {
   readonly input: PingInput;
-  output!: PingOutput;
 
   constructor(input: PingInput) {
     super();
@@ -45,11 +44,7 @@ class PingUseCase extends UseCase<PingInput, PingOutput> {
   }
 
   async execute() {
-    this.output = new PingOutput();
-  }
-
-  toJson() {
-    return this.output.toJson();
+    return new PingOutput();
   }
 }
 
@@ -57,7 +52,6 @@ class PingUseCase extends UseCase<PingInput, PingOutput> {
 
 class LoggingUseCase extends UseCase<PingInput, PingOutput> {
   readonly input: PingInput;
-  output!: PingOutput;
 
   constructor(input: PingInput) {
     super();
@@ -74,11 +68,7 @@ class LoggingUseCase extends UseCase<PingInput, PingOutput> {
 
   async execute() {
     this.logger?.info('executing inside use case', { custom: 'field' });
-    this.output = new PingOutput();
-  }
-
-  toJson() {
-    return this.output.toJson();
+    return new PingOutput();
   }
 }
 
@@ -125,7 +115,7 @@ describe('Logger integration (TypeScript)', () => {
       title: 'Logger Test',
       logLevel: LogLevel.debug,
     });
-    api.module('test', (m) => m.usecase('ping', PingUseCase.fromJson));
+    api.module('test', (m) => m.usecase('ping', PingUseCase.fromJson, { inputClass: PingInput, outputClass: PingOutput }));
     server = await api.serve({ port: 0 });
 
     const res = await request(server).post('/api/test/ping').send({});
@@ -140,7 +130,7 @@ describe('Logger integration (TypeScript)', () => {
       title: 'Logger Test',
       logLevel: LogLevel.debug,
     });
-    api.module('test', (m) => m.usecase('ping', PingUseCase.fromJson));
+    api.module('test', (m) => m.usecase('ping', PingUseCase.fromJson, { inputClass: PingInput, outputClass: PingOutput }));
     server = await api.serve({ port: 0 });
 
     const res = await request(server)
@@ -158,7 +148,7 @@ describe('Logger integration (TypeScript)', () => {
       title: 'Logger Test',
       logLevel: LogLevel.debug,
     });
-    api.module('test', (m) => m.usecase('log', LoggingUseCase.fromJson));
+    api.module('test', (m) => m.usecase('log', LoggingUseCase.fromJson, { inputClass: PingInput, outputClass: PingOutput }));
     server = await api.serve({ port: 0 });
 
     const res = await request(server).post('/api/test/log').send({});
@@ -174,7 +164,7 @@ describe('Logger integration (TypeScript)', () => {
       title: 'Logger Test',
       logLevel: LogLevel.debug,
     });
-    api.module('test', (m) => m.usecase('ping', PingUseCase.fromJson));
+    api.module('test', (m) => m.usecase('ping', PingUseCase.fromJson, { inputClass: PingInput, outputClass: PingOutput }));
     server = await api.serve({ port: 0 });
 
     const res = await request(server).get('/health');

--- a/ts/test/metrics/metrics_integration.test.ts
+++ b/ts/test/metrics/metrics_integration.test.ts
@@ -32,7 +32,6 @@ class PingOutput extends Output {
 
 class PingUseCase extends UseCase<PingInput, PingOutput> {
   readonly input: PingInput;
-  output!: PingOutput;
 
   constructor(input: PingInput) {
     super();
@@ -48,11 +47,7 @@ class PingUseCase extends UseCase<PingInput, PingOutput> {
   }
 
   async execute() {
-    this.output = new PingOutput();
-  }
-
-  toJson() {
-    return this.output.toJson();
+    return new PingOutput();
   }
 }
 
@@ -76,7 +71,7 @@ describe('ModularApi metrics integration', () => {
       metricsEnabled: opts.metricsEnabled ?? false,
     });
     api.module('test', (m) => {
-      m.usecase('ping', PingUseCase.fromJson);
+      m.usecase('ping', PingUseCase.fromJson, { inputClass: PingInput, outputClass: PingOutput });
     });
     server = await api.serve({ port: 0 });
     return server;
@@ -143,7 +138,7 @@ describe('ModularApi metrics integration', () => {
       metricsEnabled: true,
     });
     api.module('test', (m) => {
-      m.usecase('ping', PingUseCase.fromJson);
+      m.usecase('ping', PingUseCase.fromJson, { inputClass: PingInput, outputClass: PingOutput });
     });
 
     // Register custom metric

--- a/ts/test/module_builder.test.ts
+++ b/ts/test/module_builder.test.ts
@@ -6,8 +6,11 @@ import { Router } from 'express';
 // ── Stubs: mirrors the example HelloWorld pattern ────────────
 
 class GreetInput extends Input {
-  constructor(readonly name: string) {
+  readonly name: string;
+
+  constructor(name = '') {
     super();
+    this.name = name;
   }
 
   static fromJson(json: Record<string, unknown>): GreetInput {
@@ -30,8 +33,11 @@ class GreetInput extends Input {
 }
 
 class GreetOutput extends Output {
-  constructor(readonly message: string) {
+  readonly message: string;
+
+  constructor(message = '') {
     super();
+    this.message = message;
   }
 
   get statusCode() {
@@ -59,12 +65,10 @@ class GreetOutput extends Output {
  */
 class UninitOutputUseCase extends UseCase<GreetInput, GreetOutput> {
   readonly input: GreetInput;
-  output: GreetOutput;
 
   constructor(input: GreetInput) {
     super();
     this.input = input;
-    this.output = new GreetOutput('');
   }
 
   static fromJson(json: Record<string, unknown>): UninitOutputUseCase {
@@ -76,11 +80,7 @@ class UninitOutputUseCase extends UseCase<GreetInput, GreetOutput> {
   }
 
   async execute() {
-    this.output = new GreetOutput(`Hello, ${this.input.name}!`);
-  }
-
-  toJson() {
-    return this.output.toJson();
+    return new GreetOutput(`Hello, ${this.input.name}!`);
   }
 }
 
@@ -91,9 +91,14 @@ describe('ModuleBuilder schema extraction', () => {
     apiRegistry.clear();
   });
 
-  it('captures Input schema even when Output is uninitialized', () => {
+  it('captures Input schema from inputSchema override', () => {
     const builder = new ModuleBuilder('/api', 'greetings', Router());
-    builder.usecase('hello', UninitOutputUseCase.fromJson);
+    builder.usecase('hello', UninitOutputUseCase.fromJson, {
+      inputClass: GreetInput as any,
+      outputClass: GreetOutput as any,
+      inputSchema: new GreetInput('').toSchema(),
+      outputSchema: new GreetOutput('').toSchema(),
+    });
 
     const registration = apiRegistry.routes[0];
     expect(registration.schemas.input).toHaveProperty('properties');
@@ -102,16 +107,26 @@ describe('ModuleBuilder schema extraction', () => {
 
   it('input schema properties.name.type is string', () => {
     const builder = new ModuleBuilder('/api', 'greetings', Router());
-    builder.usecase('hello', UninitOutputUseCase.fromJson);
+    builder.usecase('hello', UninitOutputUseCase.fromJson, {
+      inputClass: GreetInput as any,
+      outputClass: GreetOutput as any,
+      inputSchema: new GreetInput('').toSchema(),
+      outputSchema: new GreetOutput('').toSchema(),
+    });
 
     const inputSchema = apiRegistry.routes[0].schemas.input as Record<string, unknown>;
     const properties = inputSchema.properties as Record<string, Record<string, unknown>>;
     expect(properties.name.type).toBe('string');
   });
 
-  it('captures Output schema even when output is uninitialized in constructor', () => {
+  it('captures Output schema from outputSchema override', () => {
     const builder = new ModuleBuilder('/api', 'greetings', Router());
-    builder.usecase('hello', UninitOutputUseCase.fromJson);
+    builder.usecase('hello', UninitOutputUseCase.fromJson, {
+      inputClass: GreetInput as any,
+      outputClass: GreetOutput as any,
+      inputSchema: new GreetInput('').toSchema(),
+      outputSchema: new GreetOutput('').toSchema(),
+    });
 
     const outputSchema = apiRegistry.routes[0].schemas.output as Record<string, unknown>;
     expect(outputSchema).toHaveProperty('properties');

--- a/ts/test/openapi/openapi_spec.test.ts
+++ b/ts/test/openapi/openapi_spec.test.ts
@@ -33,7 +33,6 @@ class PingOutput extends Output {
 
 class PingUseCase extends UseCase<PingInput, PingOutput> {
   readonly input: PingInput;
-  output!: PingOutput;
 
   constructor(input: PingInput) {
     super();
@@ -49,11 +48,7 @@ class PingUseCase extends UseCase<PingInput, PingOutput> {
   }
 
   async execute() {
-    this.output = new PingOutput();
-  }
-
-  toJson() {
-    return this.output.toJson();
+    return new PingOutput();
   }
 }
 
@@ -149,7 +144,7 @@ describe('OpenAPI spec endpoints (TypeScript)', () => {
       version: '1.0.0',
     });
     api.module('test', (m) => {
-      m.usecase('ping', PingUseCase.fromJson);
+      m.usecase('ping', PingUseCase.fromJson, { inputClass: PingInput, outputClass: PingOutput });
     });
     server = await api.serve({ port: 0 });
     return server;
@@ -230,7 +225,7 @@ describe('OpenAPI spec endpoints (TypeScript)', () => {
         version: '2.0.0',
       });
       api.module('test', (m) => {
-        m.usecase('ping', PingUseCase.fromJson);
+        m.usecase('ping', PingUseCase.fromJson, { inputClass: PingInput, outputClass: PingOutput });
       });
       server = await api.serve({ port: 0 });
 


### PR DESCRIPTION
## Summary

`UseCase.execute()` now returns `Output` directly (was `void`), plus a full naming convention applied across all 3 SDKs.

## Changes

### v0.4.3 — execute() returns Output
- `execute()` signature changed from `void` to returning `Output` type
- Removed `output` field and `toJson()` from UseCase base class
- Applied across Dart, TypeScript, and Python SDKs

### Naming Convention
- `ModuleBuilder.usecase()` parameter renamed: `usecaseName`/`name` to `command`
- Example commands: `'hello'` to `'hello-world'`, `'now'` to `'current-time'`
- DTO classes follow command root: `HelloWorldInput`, `CurrentTimeOutput`, etc.
- OpenAPI schema names normalize hyphens to underscores: `greetings_hello_world_Input`
- `naming_guide.md` added to all 3 SDK doc folders

### Examples Restructured
- Flat example files restructured into project-like folder structure (`modules/`, `health/`, `usecases/`)
- Second example module added: `time/current-time` (GET with `tz` query param)
- `basePath` updated to `/api/v1`

### Housekeeping
- Removed decorative `@Field` from Dart (R-TEC-04)
- Parity tests updated for new URLs and schema names

## Test Results

| SDK | Tests |
|-----|-------|
| Dart | 287 passed |
| TypeScript | 207 passed |
| Python | 315 passed |
| **Total** | **809 passed** |
