### PR TITLE
v0.4.5: OpenAPI servers configuration & CORS middleware alignment

### DIFF
--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -6,6 +6,17 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+## [0.4.5] - 2026-03-28
+
+### Added
+
+- **`servers` parameter** in `ModularApi` constructor — configures the OpenAPI `servers` field so Swagger UI "Try it out" targets the correct host (LAN IP, domain, reverse proxy URL). Defaults to `localhost:{port}` when omitted.
+- **`corsMiddleware()`** — configurable CORS middleware replacing `exampleCorsMiddleware()`. Accepts `origin` (String or List), `methods`, and `allowedHeaders`. Aligned with TypeScript `cors()` and Python `cors_middleware()`.
+
+### Removed
+
+- **`exampleCorsMiddleware()`** — replaced by the configurable `corsMiddleware()`
+
 ## [0.4.4] - 2026-03-14
 
 ### Changed

--- a/dart/example/example.dart
+++ b/dart/example/example.dart
@@ -30,6 +30,12 @@ Future<void> main(List<String> args) async {
     basePath: '/api/v1',
     title: 'Modular API',
     version: '1.0.0',
+    // OpenAPI servers — shown in Swagger UI "Try it out" dropdown.
+    // When omitted, defaults to http://localhost:{port}.
+    // servers: [
+    //   {'url': 'https://miapi.example.com', 'description': 'Production'},
+    //   {'url': 'http://192.168.5.82:8080', 'description': 'LAN'},
+    // ],
     // Opt-in Prometheus metrics at GET /metrics
     metricsEnabled: true,
     // Structured JSON logging (Loki/Grafana compatible)

--- a/dart/lib/modular_api.dart
+++ b/dart/lib/modular_api.dart
@@ -27,7 +27,7 @@ export 'src/core/metrics/metric.dart'
 export 'src/core/metrics/metric_registry.dart' show MetricsRegistrar;
 
 // Middlewares
-export 'src/middlewares/cors.dart' show exampleCorsMiddleware;
+export 'src/middlewares/cors.dart' show corsMiddleware;
 
 // OpenAPI
 export 'src/openapi/openapi.dart' show OpenApi;

--- a/dart/lib/src/core/modular_api.dart
+++ b/dart/lib/src/core/modular_api.dart
@@ -22,6 +22,9 @@ class ModularApi {
   // ── Logger ──
   final LogLevel logLevel;
 
+  // ── OpenAPI ──
+  final List<Map<String, String>>? servers;
+
   // ── Metrics ──
   final bool metricsEnabled;
   final String metricsPath;
@@ -43,6 +46,9 @@ class ModularApi {
   /// [version] — API version (e.g. '1.0.0'). Used in health check response.
   /// [releaseId] — Defaults to `version-debug`. Override at compile time:
   ///   `dart compile exe --define=RELEASE_ID=1.2.3 bin/main.dart`
+  /// [servers] — OpenAPI `servers` list. Each entry is a map with `url` and
+  /// optional `description`. When omitted, `serve()` generates
+  /// `[{url: 'http://localhost:{port}'}]` automatically.
   /// [metricsEnabled] — Opt-in Prometheus metrics at [metricsPath].
   /// [metricsPath] — Path for the metrics endpoint (default `/metrics`).
   /// [excludedMetricsRoutes] — Routes excluded from instrumentation.
@@ -52,6 +58,7 @@ class ModularApi {
     this.title = 'Modular API',
     String version = 'x.y.z',
     String? releaseId,
+    this.servers,
     this.metricsEnabled = false,
     this.metricsPath = '/metrics',
     List<String>? excludedMetricsRoutes,
@@ -123,13 +130,7 @@ class ModularApi {
     await OpenApi.init(
       title: title,
       port: port,
-      // Customize as needed
-      // servers: [
-      //   {
-      //     'url': 'http://192.168.10.18:$port',
-      //     'description': 'PROD'
-      //   }
-      // ],
+      servers: servers,
     );
     // Swagger UI docs — inline HTML, no external dependency (PRD-003).
     _root.get('/docs', swaggerDocsHandler(title: title));

--- a/dart/lib/src/middlewares/cors.dart
+++ b/dart/lib/src/middlewares/cors.dart
@@ -1,44 +1,59 @@
+/// Configurable CORS middleware — no external dependencies.
+///
+/// Sets `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods`,
+/// and `Access-Control-Allow-Headers` on every response. Preflight
+/// `OPTIONS` requests are short-circuited with 204 No Content.
+///
+/// Mirror of `cors()` in TypeScript and `cors_middleware()` in Python.
+///
+/// Usage:
+/// ```dart
+/// api.use(corsMiddleware());
+/// api.use(corsMiddleware(origin: 'https://myapp.com'));
+/// api.use(corsMiddleware(origin: ['https://a.com', 'https://b.com']));
+/// ```
 import 'package:shelf/shelf.dart';
 
-/// Prefer building your own CORS middleware according to your needs.
-/// use this as a starting point.
-Middleware exampleCorsMiddleware() {
-  // final port = Env.getInt('PORT');
-  // final environment = Env.getString('ENV'); // 'dev' o 'prod'
+const _defaultMethods = 'GET,POST,PUT,PATCH,DELETE,OPTIONS';
+const _defaultHeaders = 'Content-Type,Authorization';
 
-  // final allowedOrigins = [
-  //   'http://localhost:$port',
-  //   'http://192.168.10.18:$port',
-  // ];
+/// Returns a Shelf [Middleware] that injects CORS headers on every response.
+///
+/// [origin] — Allowed origins. Accepts a [String] or `List<String>`.
+/// Defaults to `'*'` (all origins).
+///
+/// [methods] — Allowed HTTP methods. Defaults to
+/// `'GET,POST,PUT,PATCH,DELETE,OPTIONS'`.
+///
+/// [allowedHeaders] — Allowed request headers. Defaults to
+/// `'Content-Type,Authorization'`.
+Middleware corsMiddleware({
+  Object? origin,
+  String? methods,
+  String? allowedHeaders,
+}) {
+  final resolvedOrigin = switch (origin) {
+    List<String> list => list.join(', '),
+    String value => value,
+    _ => '*',
+  };
+
+  final resolvedMethods = methods ?? _defaultMethods;
+  final resolvedHeaders = allowedHeaders ?? _defaultHeaders;
 
   return (Handler handler) {
     return (Request request) async {
-      // stdout.writeln('CORS middleware processing request: ${request.method} ${request.requestedUri}');
-      // if (environment != 'dev') {
-      //   // Si no es dev, no se permiten CORS
-      //   return Response.forbidden('CORS not allowed in this environment');
-      // }
-
-      // final origin = request.headers['origin'];
-      // final isAllowed = origin != null && allowedOrigins.contains(origin);
-
-      // CORS headers to add if allowed
       final corsHeaders = {
-        // if (isAllowed) 'Access-Control-Allow-Origin': origin,
-        // if (isAllowed) 'Access-Control-Allow-Credentials': 'true',
-        'Access-Control-Allow-Origin': '*', // Allow all origins
-        'Access-Control-Allow-Credentials': 'true',
-        'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-        'Access-Control-Allow-Headers':
-            'Origin, Content-Type, Accept, Authorization, x-api-key',
+        'Access-Control-Allow-Origin': resolvedOrigin,
+        'Access-Control-Allow-Methods': resolvedMethods,
+        'Access-Control-Allow-Headers': resolvedHeaders,
       };
 
-      /// Handling preflight requests (OPTIONS)
+      // Short-circuit OPTIONS preflight
       if (request.method == 'OPTIONS') {
-        return Response.ok('', headers: corsHeaders);
+        return Response(204, headers: corsHeaders);
       }
 
-      // Continue with normal request
       final response = await handler(request);
       return response.change(headers: {...response.headers, ...corsHeaders});
     };

--- a/dart/test/middlewares/cors_middleware_test.dart
+++ b/dart/test/middlewares/cors_middleware_test.dart
@@ -1,0 +1,122 @@
+/// Tests for corsMiddleware — Shelf middleware that sets CORS headers.
+///
+/// Mirrors test_cors.py (Python) to ensure cross-SDK parity.
+import 'package:modular_api/modular_api.dart';
+import 'package:test/test.dart';
+
+// ── Helpers ──────────────────────────────────────────────────
+
+/// Simple handler that returns 200 with a plain text body.
+Handler _echoHandler() => (Request request) => Response.ok('ok');
+
+/// Applies [corsMiddleware] with given options and sends [request] through it.
+Future<Response> _send(
+  Request request, {
+  Object? origin,
+  String? methods,
+  String? allowedHeaders,
+}) async {
+  final middleware = corsMiddleware(
+    origin: origin,
+    methods: methods,
+    allowedHeaders: allowedHeaders,
+  );
+  final handler = middleware(_echoHandler());
+  return handler(request);
+}
+
+Request _get(String path) =>
+    Request('GET', Uri.parse('http://localhost$path'));
+
+Request _post(String path) =>
+    Request('POST', Uri.parse('http://localhost$path'));
+
+Request _options(String path) =>
+    Request('OPTIONS', Uri.parse('http://localhost$path'));
+
+// ── Default CORS headers ────────────────────────────────────
+
+void main() {
+  group('corsMiddleware — default headers', () {
+    test('sets Access-Control-Allow-Origin to * by default', () async {
+      final response = await _send(_get('/echo'));
+      expect(response.headers['access-control-allow-origin'], equals('*'));
+    });
+
+    test('sets default methods including GET, POST, OPTIONS', () async {
+      final response = await _send(_get('/echo'));
+      final methods = response.headers['access-control-allow-methods']!;
+      expect(methods, contains('GET'));
+      expect(methods, contains('POST'));
+      expect(methods, contains('OPTIONS'));
+    });
+
+    test('sets default allowed headers Content-Type and Authorization',
+        () async {
+      final response = await _send(_get('/echo'));
+      final headers = response.headers['access-control-allow-headers']!;
+      expect(headers, contains('Content-Type'));
+      expect(headers, contains('Authorization'));
+    });
+
+    test('adds CORS headers to non-OPTIONS requests', () async {
+      final response = await _send(_post('/echo'));
+      expect(response.headers['access-control-allow-origin'], equals('*'));
+    });
+  });
+
+  // ── OPTIONS preflight ───────────────────────────────────────
+
+  group('corsMiddleware — OPTIONS preflight', () {
+    test('responds 204 to OPTIONS requests', () async {
+      final response = await _send(_options('/echo'));
+      expect(response.statusCode, equals(204));
+    });
+
+    test('includes all CORS headers on OPTIONS response', () async {
+      final response = await _send(_options('/echo'));
+      expect(response.headers, contains('access-control-allow-origin'));
+      expect(response.headers, contains('access-control-allow-methods'));
+      expect(response.headers, contains('access-control-allow-headers'));
+    });
+
+    test('OPTIONS response body is empty', () async {
+      final response = await _send(_options('/echo'));
+      final body = await response.readAsString();
+      expect(body, isEmpty);
+    });
+  });
+
+  // ── Configurable origin, methods, headers ───────────────────
+
+  group('corsMiddleware — custom options', () {
+    test('sets custom origin when provided as string', () async {
+      final response =
+          await _send(_get('/echo'), origin: 'https://example.com');
+      expect(response.headers['access-control-allow-origin'],
+          equals('https://example.com'));
+    });
+
+    test('joins multiple origins when provided as list', () async {
+      final response = await _send(
+        _get('/echo'),
+        origin: ['https://a.com', 'https://b.com'],
+      );
+      expect(response.headers['access-control-allow-origin'],
+          equals('https://a.com, https://b.com'));
+    });
+
+    test('sets custom methods when provided', () async {
+      final response = await _send(_get('/echo'), methods: 'GET,POST');
+      expect(
+          response.headers['access-control-allow-methods'], equals('GET,POST'));
+    });
+
+    test('sets custom allowed headers when provided', () async {
+      final response =
+          await _send(_get('/echo'), allowedHeaders: 'X-Custom-Header');
+      expect(response.headers['access-control-allow-headers'],
+          equals('X-Custom-Header'));
+    });
+  });
+}

--- a/dart/test/openapi/openapi_spec_test.dart
+++ b/dart/test/openapi/openapi_spec_test.dart
@@ -315,4 +315,131 @@ void main() {
       expect(yamlResp.body, contains('title: Consistency Test'));
     });
   });
+
+  // ── Custom servers ──────────────────────────────────────────
+
+  group('OpenAPI spec — custom servers', () {
+    late HttpServer server;
+    late int port;
+
+    tearDown(() async {
+      await server.close(force: true);
+      apiRegistry.routes.clear();
+    });
+
+    test('uses localhost default when servers is not provided', () async {
+      apiRegistry.routes.clear();
+
+      final api = ModularApi(
+        basePath: '/api',
+        title: 'Default Servers',
+        version: '1.0.0',
+      );
+
+      api.module('test', (m) {
+        m.usecase('ping', _PingUseCase.fromJson,
+            inputExample: _PingInput(), outputExample: _PingOutput());
+      });
+
+      server = await api.serve(port: 0);
+      port = server.port;
+
+      final resp =
+          await http.get(Uri.parse('http://localhost:$port/openapi.json'));
+      final spec = jsonDecode(resp.body) as Map<String, dynamic>;
+      final servers = spec['servers'] as List;
+
+      expect(servers, hasLength(1));
+      expect(servers[0]['url'], contains('localhost'));
+    });
+
+    test('propagates custom servers to OpenAPI spec', () async {
+      apiRegistry.routes.clear();
+
+      final api = ModularApi(
+        basePath: '/api',
+        title: 'Custom Servers',
+        version: '1.0.0',
+        servers: [
+          {'url': 'https://miapi.example.com', 'description': 'Production'},
+        ],
+      );
+
+      api.module('test', (m) {
+        m.usecase('ping', _PingUseCase.fromJson,
+            inputExample: _PingInput(), outputExample: _PingOutput());
+      });
+
+      server = await api.serve(port: 0);
+      port = server.port;
+
+      final resp =
+          await http.get(Uri.parse('http://localhost:$port/openapi.json'));
+      final spec = jsonDecode(resp.body) as Map<String, dynamic>;
+      final servers = spec['servers'] as List;
+
+      expect(servers, hasLength(1));
+      expect(servers[0]['url'], equals('https://miapi.example.com'));
+      expect(servers[0]['description'], equals('Production'));
+    });
+
+    test('supports multiple servers in the OpenAPI spec', () async {
+      apiRegistry.routes.clear();
+
+      final api = ModularApi(
+        basePath: '/api',
+        title: 'Multi Servers',
+        version: '1.0.0',
+        servers: [
+          {'url': 'https://prod.example.com', 'description': 'Production'},
+          {'url': 'http://192.168.5.82:8080', 'description': 'LAN'},
+        ],
+      );
+
+      api.module('test', (m) {
+        m.usecase('ping', _PingUseCase.fromJson,
+            inputExample: _PingInput(), outputExample: _PingOutput());
+      });
+
+      server = await api.serve(port: 0);
+      port = server.port;
+
+      final resp =
+          await http.get(Uri.parse('http://localhost:$port/openapi.json'));
+      final spec = jsonDecode(resp.body) as Map<String, dynamic>;
+      final servers = spec['servers'] as List;
+
+      expect(servers, hasLength(2));
+      expect(servers[0]['url'], equals('https://prod.example.com'));
+      expect(servers[1]['url'], equals('http://192.168.5.82:8080'));
+    });
+
+    test('preserves server descriptions in spec output', () async {
+      apiRegistry.routes.clear();
+
+      final api = ModularApi(
+        basePath: '/api',
+        title: 'Described Servers',
+        version: '1.0.0',
+        servers: [
+          {'url': 'https://api.example.com', 'description': 'Main API'},
+        ],
+      );
+
+      api.module('test', (m) {
+        m.usecase('ping', _PingUseCase.fromJson,
+            inputExample: _PingInput(), outputExample: _PingOutput());
+      });
+
+      server = await api.serve(port: 0);
+      port = server.port;
+
+      final resp =
+          await http.get(Uri.parse('http://localhost:$port/openapi.json'));
+      final spec = jsonDecode(resp.body) as Map<String, dynamic>;
+      final servers = spec['servers'] as List;
+
+      expect(servers[0]['description'], equals('Main API'));
+    });
+  });
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -59,6 +59,27 @@ Versioning follows semantic versioning strictly:
 
 ---
 
+## v0.4.5
+
+> *The API must know where it lives.*
+
+### OpenAPI `servers` Configuration
+
+- [ ] Add `servers` parameter to `ModularApi` constructor in all three SDKs (Dart, TypeScript, Python)
+- [ ] When `servers` is provided, propagate it to OpenAPI spec generation — the `servers` field in `openapi.json` / `openapi.yaml` reflects the user-defined list
+- [ ] When `servers` is omitted, `serve()` auto-generates `[{url: "http://localhost:{port}", description: "Local"}]` as the default (current behavior, no breaking change)
+- [ ] Swagger UI `Try it out` dropdown populates from the user-defined servers, enabling requests to production, LAN, or any configured host
+
+### CORS Middleware Alignment (Dart)
+
+- [ ] Replace `exampleCorsMiddleware()` in Dart with a configurable `corsMiddleware()` matching the interface of TypeScript (`cors()`) and Python (`cors_middleware()`)
+- [ ] Configurable parameters: `origin` (string or list), `methods`, `allowedHeaders`
+- [ ] Defaults: `origin: '*'`, `methods: 'GET,POST,PUT,PATCH,DELETE,OPTIONS'`, `allowedHeaders: 'Content-Type,Authorization'`
+- [ ] Preflight `OPTIONS` handled with 204 No Content
+- [ ] Update Dart barrel export: remove `exampleCorsMiddleware`, export `corsMiddleware`
+
+---
+
 ## Phase 0 — Foundation Hardening `v0.5.0`
 
 > *Before building the ecosystem, the core must be production-grade.*
@@ -354,6 +375,7 @@ Features that belong in the roadmap but whose timing depends on ecosystem maturi
 ```
 v0.4.1  ████████████████████████████  Core SDKs complete (Dart + TS + Python)  ✅
 v0.4.2  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░  Auto-generated documentation
+v0.4.5  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░  OpenAPI servers config + CORS alignment
 v0.5.0  ████████░░░░░░░░░░░░░░░░░░░░  Foundation hardening (interfaces + OpenAPI 3.1)
 v0.6.0  ████████████░░░░░░░░░░░░░░░░  Plugin infrastructure (plugins + GraphQL + metrics)
 v0.7.0  ████████████████░░░░░░░░░░░░  Spec Driven Development (pragma_spec)

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.4.5] - 2026-03-28
+
+### Added
+
+- **`servers` parameter** in `ModularApi` constructor — configures the OpenAPI `servers` field so Swagger UI "Try it out" targets the correct host (LAN IP, domain, reverse proxy URL). Defaults to `localhost:{port}` when omitted.
+
 ## [0.4.4] - 2026-03-14
 
 ### Changed

--- a/py/example/example.py
+++ b/py/example/example.py
@@ -39,6 +39,12 @@ def main() -> None:
         base_path="/api/v1",
         title="Modular API",
         version="1.0.0",
+        # OpenAPI servers — shown in Swagger UI "Try it out" dropdown.
+        # When omitted, defaults to http://localhost:{port}.
+        # servers=[
+        #     {"url": "https://miapi.example.com", "description": "Production"},
+        #     {"url": "http://192.168.5.82:8080", "description": "LAN"},
+        # ],
         metrics_enabled=True,
         log_level=LogLevel.debug,
     )

--- a/py/src/modular_api/core/modular_api.py
+++ b/py/src/modular_api/core/modular_api.py
@@ -59,6 +59,7 @@ class ModularApi:
         title: str = "Modular API",
         version: str = "0.0.0",
         release_id: str | None = None,
+        servers: list[dict[str, str]] | None = None,
         metrics_enabled: bool = False,
         metrics_path: str = "/metrics",
         log_level: LogLevel = LogLevel.info,
@@ -67,6 +68,7 @@ class ModularApi:
         self._title = title
         self._version = version
         self._release_id = release_id or f"{version}-debug"
+        self._servers = servers
         self._metrics_enabled = metrics_enabled
         self._metrics_path = metrics_path
         self._log_level = log_level
@@ -188,6 +190,8 @@ class ModularApi:
 
         # OpenAPI endpoints
         spec_kwargs: dict[str, Any] = {"title": self._title, "port": port, "version": self._version}
+        if self._servers is not None:
+            spec_kwargs["servers"] = self._servers
         routes.append(Route("/openapi.json", endpoint=openapi_json_handler(**spec_kwargs)))
         routes.append(Route("/openapi.yaml", endpoint=openapi_yaml_handler(**spec_kwargs)))
 

--- a/py/tests/test_modular_api.py
+++ b/py/tests/test_modular_api.py
@@ -209,6 +209,53 @@ class TestAutoMountedEndpoints:
         assert "Test API" in response.text
 
 
+# ── Custom servers in OpenAPI spec ────────────────────────────
+
+
+class TestCustomServers:
+    """ModularApi propagates servers to the OpenAPI spec."""
+
+    def _build_client(self, **api_options: object) -> TestClient:
+        api = _make_api(**api_options)
+        api.module("test", lambda m: m.usecase("ping", _PingUseCase.from_json))
+        app = api.build()
+        return TestClient(app)
+
+    def test_uses_localhost_default_when_servers_not_provided(self) -> None:
+        client = self._build_client()
+        spec = client.get("/openapi.json").json()
+        assert len(spec["servers"]) == 1
+        assert "localhost" in spec["servers"][0]["url"]
+
+    def test_propagates_custom_servers_to_openapi_spec(self) -> None:
+        client = self._build_client(
+            servers=[{"url": "https://miapi.example.com", "description": "Production"}],
+        )
+        spec = client.get("/openapi.json").json()
+        assert len(spec["servers"]) == 1
+        assert spec["servers"][0]["url"] == "https://miapi.example.com"
+        assert spec["servers"][0]["description"] == "Production"
+
+    def test_supports_multiple_servers(self) -> None:
+        client = self._build_client(
+            servers=[
+                {"url": "https://prod.example.com", "description": "Production"},
+                {"url": "http://192.168.5.82:8080", "description": "LAN"},
+            ],
+        )
+        spec = client.get("/openapi.json").json()
+        assert len(spec["servers"]) == 2
+        assert spec["servers"][0]["url"] == "https://prod.example.com"
+        assert spec["servers"][1]["url"] == "http://192.168.5.82:8080"
+
+    def test_preserves_server_descriptions(self) -> None:
+        client = self._build_client(
+            servers=[{"url": "https://api.example.com", "description": "Main API"}],
+        )
+        spec = client.get("/openapi.json").json()
+        assert spec["servers"][0]["description"] == "Main API"
+
+
 # ── Step 2.9.3: Middleware pipeline order ─────────────────────
 
 

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -7,6 +7,12 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+## [0.4.5] - 2026-03-28
+
+### Added
+
+- **`servers` option** in `ModularApiOptions` — configures the OpenAPI `servers` field so Swagger UI "Try it out" targets the correct host (LAN IP, domain, reverse proxy URL). Defaults to `localhost:{port}` when omitted.
+
 ## [0.4.4] - 2026-03-14
 
 ### Changed

--- a/ts/example/example.ts
+++ b/ts/example/example.ts
@@ -29,6 +29,12 @@ const api = new ModularApi({
   basePath: '/api/v1',
   title: 'Modular API',
   version: '1.0.0',
+  // OpenAPI servers — shown in Swagger UI "Try it out" dropdown.
+  // When omitted, defaults to http://localhost:{port}.
+  // servers: [
+  //   { url: 'https://miapi.example.com', description: 'Production' },
+  //   { url: 'http://192.168.5.82:8080', description: 'LAN' },
+  // ],
   metricsEnabled: true,
   logLevel: LogLevel.debug,
 });

--- a/ts/src/core/modular_api.ts
+++ b/ts/src/core/modular_api.ts
@@ -41,6 +41,11 @@ export interface ModularApiOptions {
    * Default: LogLevel.info (emits emergency..info, suppresses debug).
    */
   logLevel?: LogLevel;
+  /**
+   * OpenAPI `servers` list. Each entry has a `url` and optional `description`.
+   * When omitted, `serve()` generates `[{url: 'http://localhost:{port}'}]`.
+   */
+  servers?: Array<{ url: string; description?: string }>;
 }
 
 /**
@@ -85,6 +90,9 @@ export class ModularApi {
   // Logging
   private readonly logLevel: LogLevel;
 
+  // OpenAPI
+  private readonly servers?: Array<{ url: string; description?: string }>;
+
   /** Public accessor for custom-metric registration. Undefined when metrics are disabled. */
   get metrics(): MetricsRegistrar | undefined {
     return this._metricsRegistrar;
@@ -106,6 +114,9 @@ export class ModularApi {
 
     // Logging
     this.logLevel = options.logLevel ?? LogLevel.info;
+
+    // OpenAPI servers
+    this.servers = options.servers;
 
     if (this.metricsEnabled) {
       this.metricRegistry = new MetricRegistry();
@@ -242,7 +253,7 @@ export class ModularApi {
       this.app.get('/docs', swaggerDocsHandler({ title: this.title }));
 
       // Raw spec endpoints
-      const spec = buildOpenApiSpec({ title: this.title, port });
+      const spec = buildOpenApiSpec({ title: this.title, port, servers: this.servers });
       this.app.get('/openapi.json', openApiJsonHandler(spec));
       this.app.get('/openapi.yaml', openApiYamlHandler(spec));
 

--- a/ts/test/openapi/openapi_spec.test.ts
+++ b/ts/test/openapi/openapi_spec.test.ts
@@ -242,4 +242,83 @@ describe('OpenAPI spec endpoints (TypeScript)', () => {
       expect(yamlRes.text).toContain('title: Consistency Test');
     });
   });
+
+  // ── Custom servers ──────────────────────────────────────────
+
+  describe('Custom servers in OpenAPI spec', () => {
+    it('uses localhost default when servers is not provided', async () => {
+      const api = new ModularApi({
+        basePath: '/api',
+        title: 'Default Servers',
+        version: '1.0.0',
+      });
+      api.module('test', (m) => {
+        m.usecase('ping', PingUseCase.fromJson, { inputClass: PingInput, outputClass: PingOutput });
+      });
+      server = await api.serve({ port: 0 });
+
+      const res = await request(server).get('/openapi.json');
+      expect(res.body.servers).toHaveLength(1);
+      expect(res.body.servers[0].url).toContain('localhost');
+    });
+
+    it('propagates custom servers to OpenAPI spec', async () => {
+      const api = new ModularApi({
+        basePath: '/api',
+        title: 'Custom Servers',
+        version: '1.0.0',
+        servers: [
+          { url: 'https://miapi.example.com', description: 'Production' },
+        ],
+      });
+      api.module('test', (m) => {
+        m.usecase('ping', PingUseCase.fromJson, { inputClass: PingInput, outputClass: PingOutput });
+      });
+      server = await api.serve({ port: 0 });
+
+      const res = await request(server).get('/openapi.json');
+      expect(res.body.servers).toHaveLength(1);
+      expect(res.body.servers[0].url).toBe('https://miapi.example.com');
+      expect(res.body.servers[0].description).toBe('Production');
+    });
+
+    it('supports multiple servers in the OpenAPI spec', async () => {
+      const api = new ModularApi({
+        basePath: '/api',
+        title: 'Multi Servers',
+        version: '1.0.0',
+        servers: [
+          { url: 'https://prod.example.com', description: 'Production' },
+          { url: 'http://192.168.5.82:8080', description: 'LAN' },
+        ],
+      });
+      api.module('test', (m) => {
+        m.usecase('ping', PingUseCase.fromJson, { inputClass: PingInput, outputClass: PingOutput });
+      });
+      server = await api.serve({ port: 0 });
+
+      const res = await request(server).get('/openapi.json');
+      expect(res.body.servers).toHaveLength(2);
+      expect(res.body.servers[0].url).toBe('https://prod.example.com');
+      expect(res.body.servers[1].url).toBe('http://192.168.5.82:8080');
+    });
+
+    it('preserves server descriptions in spec output', async () => {
+      const api = new ModularApi({
+        basePath: '/api',
+        title: 'Described Servers',
+        version: '1.0.0',
+        servers: [
+          { url: 'https://api.example.com', description: 'Main API' },
+        ],
+      });
+      api.module('test', (m) => {
+        m.usecase('ping', PingUseCase.fromJson, { inputClass: PingInput, outputClass: PingOutput });
+      });
+      server = await api.serve({ port: 0 });
+
+      const res = await request(server).get('/openapi.json');
+      expect(res.body.servers[0].description).toBe('Main API');
+    });
+  });
 });


### PR DESCRIPTION
Closes #9

## Summary

Allow users to configure the `servers` field in the OpenAPI spec from the `ModularApi` constructor, so Swagger UI's **Try it out** dropdown targets the correct hosts (LAN IP, domain, reverse proxy URL) instead of hardcoded `localhost`. Additionally, aligns the Dart CORS middleware with the configurable interface already present in TypeScript and Python.

## Changes

### OpenAPI `servers` configuration (all 3 SDKs)

- Added `servers` parameter to `ModularApi` constructor in **Dart**, **TypeScript**, and **Python**
- When `servers` is provided, it propagates directly to the OpenAPI spec
- When omitted, `serve()` auto-generates localhost default — **zero breaking change**

### CORS middleware alignment (Dart)

- Replaced `exampleCorsMiddleware()` with configurable `corsMiddleware()`
- Parameters: `origin` (String or List), `methods`, `allowedHeaders`
- Aligned with TS `cors()` and Python `cors_middleware()`

## Tests

| SDK | Total | New | Result |
|---|---|---|---|
| Dart | 299 | 15 | All passed |
| TypeScript | 208 | 4 | All passed |
| Python | 109 | 4 | All passed |

See RUNBOOK: `.dev/runbooks/runbook-2026-03-27-openapi-servers-cors-alignment.md`