### PR TITLE
release: 0.6.0 — typed params + stored procedures, contracts-only ADR

### DIFF
--- a/code/dart/modular_api/CHANGELOG.md
+++ b/code/dart/modular_api/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.6.0] - 2026-06-13
+
+### Changed
+
+- version bump for coordinated ecosystem release (ADR-0002); no functional changes in this package
+
 ## [0.5.0] - 2026-06-12
 
 ### Added

--- a/code/dart/modular_api/pubspec.yaml
+++ b/code/dart/modular_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: modular_api
 description: Use-case centric API toolkit for Dart — Shelf UseCase base class, HTTP adapters, CORS middleware, and automatic OpenAPI documentation.
-version: 0.5.0
+version: 0.6.0
 
 repository: https://github.com/macss-dev/modular_api/tree/main/code/dart/modular_api
 homepage: https://github.com/macss-dev/modular_api

--- a/code/dart/modular_api_graphql_client/CHANGELOG.md
+++ b/code/dart/modular_api_graphql_client/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.0
+
+- version bump for cross-SDK parity (ADR-0002); no functional changes
+- update `modular_api_rest_client` dependency to `^0.6.0`
+
 ## 0.5.0
 
 - version bump for cross-SDK parity (ADR-0002); no functional changes

--- a/code/dart/modular_api_graphql_client/pubspec.yaml
+++ b/code/dart/modular_api_graphql_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: modular_api_graphql_client
 description: Official MACSS outbound GraphQL client for Dart.
-version: 0.5.0
+version: 0.6.0
 
 repository: https://github.com/ccisnedev/modular_api/tree/main/code/dart/modular_api_graphql_client
 homepage: https://github.com/ccisnedev/modular_api
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
-  modular_api_rest_client: ^0.5.0
+  modular_api_rest_client: ^0.6.0
 
 dev_dependencies:
   lints: ^5.0.0

--- a/code/dart/modular_api_postgres/CHANGELOG.md
+++ b/code/dart/modular_api_postgres/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.0
+
+- add typed command parameters via `DbParameter` (name, value, direction input/output/inputOutput, free-form `typeHint`) with `input`/`output`/`inputOutput` helpers
+- add `DbCommandKind.procedure` for stored-procedure execution (the adapter maps it to EXEC/CALL; rows via `query`, no-rows via `execute`)
+- add optional `DbProcedureOutcome` (returnValue, outputParameters) on `DbRowSet` and `DbExecutionSummary`
+- extend shared-fixture conformance coverage for the new contracts across the three SDKs
+- additive and non-breaking: `DbCommand` keeps its signature (parameters already accept any value)
+
 ## 0.5.0
 
 - version bump for cross-SDK parity (ADR-0002); no functional changes

--- a/code/dart/modular_api_postgres/README.md
+++ b/code/dart/modular_api_postgres/README.md
@@ -33,10 +33,12 @@ if (result.isSuccess) {
 
 See [example/example.dart](example/example.dart) for a complete in-memory wiring sample.
 
-## Current slice
+## What this package provides
 
 - normalized Postgres connection defaults and redacted summaries
 - engine-agnostic `DbClient`, `DbRepository`, and transaction contracts
 - explicit lease ownership semantics for package-owned and application-owned sessions
 - health contributor and GraphQL support bundle for higher-level integrations
-- real driver bindings intentionally remain outside this first slice
+- the application supplies the driver binding (adapter) for its chosen engine and driver
+
+This package is **contracts-only by design** and will never ship a driver binding; you choose your engine and driver and provide the adapter. See [ADR-0004](../../../docs/adr/0004-contracts-only-database-packages.md).

--- a/code/dart/modular_api_postgres/pubspec.yaml
+++ b/code/dart/modular_api_postgres/pubspec.yaml
@@ -1,6 +1,6 @@
 name: modular_api_postgres
 description: Official MACSS Postgres integration package for Dart.
-version: 0.5.0
+version: 0.6.0
 
 repository: https://github.com/ccisnedev/modular_api/tree/main/code/dart/modular_api_postgres
 homepage: https://github.com/ccisnedev/modular_api

--- a/code/dart/modular_api_rest_client/CHANGELOG.md
+++ b/code/dart/modular_api_rest_client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+- version bump for cross-SDK parity (ADR-0002); no functional changes
+
 ## 0.5.0
 
 - version bump for cross-SDK parity (ADR-0002); no functional changes

--- a/code/dart/modular_api_rest_client/pubspec.yaml
+++ b/code/dart/modular_api_rest_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: modular_api_rest_client
 description: Official MACSS outbound REST client for Dart.
-version: 0.5.0
+version: 0.6.0
 
 repository: https://github.com/ccisnedev/modular_api/tree/main/code/dart/modular_api_rest_client
 homepage: https://github.com/ccisnedev/modular_api

--- a/code/dart/modular_api_sqlserver/CHANGELOG.md
+++ b/code/dart/modular_api_sqlserver/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.0
+
+- add typed command parameters via `DbParameter` (name, value, direction input/output/inputOutput, free-form `typeHint`) with `input`/`output`/`inputOutput` helpers
+- add `DbCommandKind.procedure` for stored-procedure execution (the adapter maps it to EXEC/CALL; rows via `query`, no-rows via `execute`)
+- add optional `DbProcedureOutcome` (returnValue, outputParameters) on `DbRowSet` and `DbExecutionSummary`
+- extend shared-fixture conformance coverage for the new contracts across the three SDKs
+- additive and non-breaking: `DbCommand` keeps its signature (parameters already accept any value)
+- update `modular_api` dependency to `^0.6.0`
+
 ## 0.5.0
 
 - version bump for cross-SDK parity (ADR-0002); no functional changes

--- a/code/dart/modular_api_sqlserver/README.md
+++ b/code/dart/modular_api_sqlserver/README.md
@@ -33,10 +33,12 @@ if (result.isSuccess) {
 
 See [example/example.dart](example/example.dart) for a complete in-memory wiring sample.
 
-## Current slice
+## What this package provides
 
 - normalized SQL Server connection defaults and redacted summaries
 - engine-agnostic `DbClient`, `DbRepository`, and transaction contracts
 - explicit lease ownership semantics for package-owned and application-owned sessions
 - health contributor and GraphQL support bundle for higher-level integrations
-- real driver bindings intentionally remain outside this first slice
+- the application supplies the driver binding (adapter) for its chosen engine and driver
+
+This package is **contracts-only by design** and will never ship a driver binding; you choose your engine and driver and provide the adapter. See [ADR-0004](../../../docs/adr/0004-contracts-only-database-packages.md).

--- a/code/dart/modular_api_sqlserver/pubspec.yaml
+++ b/code/dart/modular_api_sqlserver/pubspec.yaml
@@ -1,6 +1,6 @@
 name: modular_api_sqlserver
 description: Official MACSS SQL Server integration package for Dart.
-version: 0.5.0
+version: 0.6.0
 
 repository: https://github.com/macss-dev/modular_api/tree/main/code/dart/modular_api_sqlserver
 homepage: https://github.com/macss-dev/modular_api
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   dart_odbc: ^6.2.0
-  modular_api: ^0.5.0
+  modular_api: ^0.6.0
 
 dev_dependencies:
   lints: ^5.0.0

--- a/code/py/modular_api/CHANGELOG.md
+++ b/code/py/modular_api/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.6.0] - 2026-06-13
+
+### Changed
+
+- version bump for coordinated ecosystem release (ADR-0002); no functional changes in this package
+
 ## [0.5.0] - 2026-06-12
 
 ### Added

--- a/code/py/modular_api/pyproject.toml
+++ b/code/py/modular_api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "macss-modular-api"
-version = "0.5.0"
+version = "0.6.0"
 description = "Use-case-centric toolkit for building modular APIs with Starlette. Define UseCase classes (input → validate → execute → output), connect them to HTTP routes, and expose OpenAPI documentation automatically."
 readme = "README.md"
 license = "MIT"

--- a/code/py/modular_api_graphql_client/CHANGELOG.md
+++ b/code/py/modular_api_graphql_client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+- version bump for cross-SDK parity (ADR-0002); no functional changes
+
 ## 0.5.0
 
 - version bump for cross-SDK parity (ADR-0002); no functional changes

--- a/code/py/modular_api_graphql_client/pyproject.toml
+++ b/code/py/modular_api_graphql_client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "macss-modular-api-graphql-client"
-version = "0.5.0"
+version = "0.6.0"
 description = "Official MACSS outbound GraphQL client for Python."
 readme = "README.md"
 license = "MIT"

--- a/code/py/modular_api_postgres/CHANGELOG.md
+++ b/code/py/modular_api_postgres/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.0
+
+- add typed command parameters via `DbParameter` (name, value, direction input/output/inputOutput, free-form `typeHint`) with `input`/`output`/`inputOutput` helpers
+- add `DbCommandKind.procedure` for stored-procedure execution (the adapter maps it to EXEC/CALL; rows via `query`, no-rows via `execute`)
+- add optional `DbProcedureOutcome` (returnValue, outputParameters) on `DbRowSet` and `DbExecutionSummary`
+- extend shared-fixture conformance coverage for the new contracts across the three SDKs
+- additive and non-breaking: `DbCommand` keeps its signature (parameters already accept any value)
+
 ## 0.5.0
 
 - version bump for cross-SDK parity (ADR-0002); no functional changes

--- a/code/py/modular_api_postgres/README.md
+++ b/code/py/modular_api_postgres/README.md
@@ -32,10 +32,12 @@ else:
 
 See [example/example.py](example/example.py) for a complete in-memory wiring sample.
 
-## Current slice
+## What this package provides
 
 - normalized Postgres connection defaults and redacted summaries
 - engine-agnostic `DbClient`, `DbRepository`, and transaction contracts
 - explicit lease ownership semantics for package-owned and application-owned sessions
 - health contributor and GraphQL support bundle for higher-level integrations
-- real driver bindings intentionally remain outside this first slice
+- the application supplies the driver binding (adapter) for its chosen engine and driver
+
+This package is **contracts-only by design** and will never ship a driver binding; you choose your engine and driver and provide the adapter. See [ADR-0004](../../../docs/adr/0004-contracts-only-database-packages.md).

--- a/code/py/modular_api_postgres/pyproject.toml
+++ b/code/py/modular_api_postgres/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "macss-modular-api-postgres"
-version = "0.5.0"
+version = "0.6.0"
 description = "Official MACSS Postgres integration package for Python."
 readme = "README.md"
 license = "MIT"

--- a/code/py/modular_api_rest_client/CHANGELOG.md
+++ b/code/py/modular_api_rest_client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+- version bump for cross-SDK parity (ADR-0002); no functional changes
+
 ## 0.5.0
 
 - version bump for cross-SDK parity (ADR-0002); no functional changes

--- a/code/py/modular_api_rest_client/pyproject.toml
+++ b/code/py/modular_api_rest_client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "macss-modular-api-rest-client"
-version = "0.5.0"
+version = "0.6.0"
 description = "Official MACSS outbound REST client for Python."
 readme = "README.md"
 license = "MIT"

--- a/code/py/modular_api_sqlserver/CHANGELOG.md
+++ b/code/py/modular_api_sqlserver/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.0
+
+- add typed command parameters via `DbParameter` (name, value, direction input/output/inputOutput, free-form `typeHint`) with `input`/`output`/`inputOutput` helpers
+- add `DbCommandKind.procedure` for stored-procedure execution (the adapter maps it to EXEC/CALL; rows via `query`, no-rows via `execute`)
+- add optional `DbProcedureOutcome` (returnValue, outputParameters) on `DbRowSet` and `DbExecutionSummary`
+- extend shared-fixture conformance coverage for the new contracts across the three SDKs
+- additive and non-breaking: `DbCommand` keeps its signature (parameters already accept any value)
+
 ## 0.5.0
 
 - version bump for cross-SDK parity (ADR-0002); no functional changes

--- a/code/py/modular_api_sqlserver/README.md
+++ b/code/py/modular_api_sqlserver/README.md
@@ -32,10 +32,12 @@ else:
 
 See [example/example.py](example/example.py) for a complete in-memory wiring sample.
 
-## Current slice
+## What this package provides
 
 - normalized SQL Server connection defaults and redacted summaries
 - engine-agnostic `DbClient`, `DbRepository`, and transaction contracts
 - explicit lease ownership semantics for package-owned and application-owned sessions
 - health contributor and GraphQL support bundle for higher-level integrations
-- real driver bindings intentionally remain outside this first slice
+- the application supplies the driver binding (adapter) for its chosen engine and driver
+
+This package is **contracts-only by design** and will never ship a driver binding; you choose your engine and driver and provide the adapter. See [ADR-0004](../../../docs/adr/0004-contracts-only-database-packages.md).

--- a/code/py/modular_api_sqlserver/pyproject.toml
+++ b/code/py/modular_api_sqlserver/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "macss-modular-api-sqlserver"
-version = "0.5.0"
+version = "0.6.0"
 description = "Official MACSS SQL Server integration package for Python."
 readme = "README.md"
 license = "MIT"

--- a/code/ts/modular_api/CHANGELOG.md
+++ b/code/ts/modular_api/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.6.0] - 2026-06-13
+
+### Changed
+
+- version bump for coordinated ecosystem release (ADR-0002); no functional changes in this package
+
 ## [0.5.0] - 2026-06-12
 
 ### Added

--- a/code/ts/modular_api/package.json
+++ b/code/ts/modular_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macss/modular-api",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Use-case-centric toolkit for building modular APIs with Express. Define UseCase classes (input → validate → execute → output), connect them to HTTP routes, and expose Swagger/OpenAPI documentation automatically.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/code/ts/modular_api_graphql_client/CHANGELOG.md
+++ b/code/ts/modular_api_graphql_client/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.0
+
+- version bump for cross-SDK parity (ADR-0002); no functional changes
+- update `@macss/modular-api-rest-client` dependency to `^0.6.0`
+
 ## 0.5.0
 
 - version bump for cross-SDK parity (ADR-0002); no functional changes

--- a/code/ts/modular_api_graphql_client/package.json
+++ b/code/ts/modular_api_graphql_client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macss/modular-api-graphql-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": false,
   "description": "Official MACSS outbound GraphQL client for TypeScript.",
   "main": "dist/index.js",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/ccisnedev/modular_api/tree/main/code/ts/modular_api_graphql_client#readme",
   "dependencies": {
-    "@macss/modular-api-rest-client": "^0.5.0"
+    "@macss/modular-api-rest-client": "^0.6.0"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",

--- a/code/ts/modular_api_postgres/CHANGELOG.md
+++ b/code/ts/modular_api_postgres/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.0
+
+- add typed command parameters via `DbParameter` (name, value, direction input/output/inputOutput, free-form `typeHint`) with `input`/`output`/`inputOutput` helpers
+- add `DbCommandKind.procedure` for stored-procedure execution (the adapter maps it to EXEC/CALL; rows via `query`, no-rows via `execute`)
+- add optional `DbProcedureOutcome` (returnValue, outputParameters) on `DbRowSet` and `DbExecutionSummary`
+- extend shared-fixture conformance coverage for the new contracts across the three SDKs
+- additive and non-breaking: `DbCommand` keeps its signature (parameters already accept any value)
+
 ## 0.5.0
 
 - version bump for cross-SDK parity (ADR-0002); no functional changes

--- a/code/ts/modular_api_postgres/README.md
+++ b/code/ts/modular_api_postgres/README.md
@@ -33,10 +33,12 @@ if (result.isSuccess) {
 
 See [example/example.ts](example/example.ts) for a complete in-memory wiring sample.
 
-## Current slice
+## What this package provides
 
 - normalized Postgres connection defaults and redacted summaries
 - engine-agnostic `DbClient`, `DbRepository`, and transaction contracts
 - explicit lease ownership semantics for package-owned and application-owned sessions
 - health contributor and GraphQL support bundle for higher-level integrations
-- real driver bindings intentionally remain outside this first slice
+- the application supplies the driver binding (adapter) for its chosen engine and driver
+
+This package is **contracts-only by design** and will never ship a driver binding; you choose your engine and driver and provide the adapter. See [ADR-0004](../../../docs/adr/0004-contracts-only-database-packages.md).

--- a/code/ts/modular_api_postgres/package.json
+++ b/code/ts/modular_api_postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macss/modular-api-postgres",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": false,
   "description": "Official MACSS Postgres integration package for TypeScript.",
   "main": "dist/index.js",

--- a/code/ts/modular_api_rest_client/CHANGELOG.md
+++ b/code/ts/modular_api_rest_client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+- version bump for cross-SDK parity (ADR-0002); no functional changes
+
 ## 0.5.0
 
 - version bump for cross-SDK parity (ADR-0002); no functional changes

--- a/code/ts/modular_api_rest_client/package.json
+++ b/code/ts/modular_api_rest_client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macss/modular-api-rest-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Official MACSS outbound REST client for TypeScript.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/code/ts/modular_api_sqlserver/CHANGELOG.md
+++ b/code/ts/modular_api_sqlserver/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.0
+
+- add typed command parameters via `DbParameter` (name, value, direction input/output/inputOutput, free-form `typeHint`) with `input`/`output`/`inputOutput` helpers
+- add `DbCommandKind.procedure` for stored-procedure execution (the adapter maps it to EXEC/CALL; rows via `query`, no-rows via `execute`)
+- add optional `DbProcedureOutcome` (returnValue, outputParameters) on `DbRowSet` and `DbExecutionSummary`
+- extend shared-fixture conformance coverage for the new contracts across the three SDKs
+- additive and non-breaking: `DbCommand` keeps its signature (parameters already accept any value)
+
 ## 0.5.0
 
 - version bump for cross-SDK parity (ADR-0002); no functional changes

--- a/code/ts/modular_api_sqlserver/README.md
+++ b/code/ts/modular_api_sqlserver/README.md
@@ -33,10 +33,12 @@ if (result.isSuccess) {
 
 See [example/example.ts](example/example.ts) for a complete in-memory wiring sample.
 
-## Current slice
+## What this package provides
 
 - normalized SQL Server connection defaults and redacted summaries
 - engine-agnostic `DbClient`, `DbRepository`, and transaction contracts
 - explicit lease ownership semantics for package-owned and application-owned sessions
 - health contributor and GraphQL support bundle for higher-level integrations
-- real driver bindings intentionally remain outside this first slice
+- the application supplies the driver binding (adapter) for its chosen engine and driver
+
+This package is **contracts-only by design** and will never ship a driver binding; you choose your engine and driver and provide the adapter. See [ADR-0004](../../../docs/adr/0004-contracts-only-database-packages.md).

--- a/code/ts/modular_api_sqlserver/package.json
+++ b/code/ts/modular_api_sqlserver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macss/modular-api-sqlserver",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": false,
   "description": "Official MACSS SQL Server integration package for TypeScript.",
   "main": "dist/index.js",

--- a/docs/adr/0004-contracts-only-database-packages.md
+++ b/docs/adr/0004-contracts-only-database-packages.md
@@ -1,0 +1,69 @@
+# 4. Contracts-Only Database Packages (No Driver Bindings)
+
+Date: 2026-06-13
+
+## Status
+
+Accepted
+
+## Context
+
+The database packages (`modular_api_sqlserver`, `modular_api_postgres`, in all three SDKs)
+ship engine-agnostic contracts: `DbClient`, `DbRepository`, `DbSessionProvider`,
+`DbCommandExecutor`, `DbTransactionRunner`, `DbCommand`, the `DbFailureKind` taxonomy, and the
+related value objects. They do **not** include code that talks to a real database. To use a
+`DbClient`, the application injects three collaborators (session provider, command executor,
+transaction runner) implemented over the driver of its choice — the adapter.
+
+Until now each package README described this as a "first slice", with the line *"real driver
+bindings intentionally remain outside this first slice"*. That phrasing implied official driver
+bindings were coming later. They are not.
+
+A specification experiment (X4) validated the contracts against a production SQL Server instance:
+stored-procedure calls and `VARBINARY(MAX)` round-trips through an application-supplied `mssql`
+adapter of ~150 lines. The contracts held; the experiment also surfaced two contract gaps (typed
+parameters and stored-procedure support) which are closed additively in 0.6.0 (see issue #22).
+The experiment confirmed that the right place for engine/driver specifics is the application's
+adapter, not the package.
+
+## Decision
+
+1. **The database packages are contracts-only, permanently.** The framework will never publish a
+   driver binding and the packages will never declare a runtime dependency on a database driver.
+   The application chooses its engine and driver and supplies the adapter. A reference adapter is
+   documented in [docs/guides/db-adapter.md](../guides/db-adapter.md).
+
+2. **Contract evolution is allowed; driver coupling is not.** Improvements that make the contract
+   express real-world database usage better — typed parameters (`DbParameter`), stored procedures
+   (`DbCommandKind.procedure`, `DbProcedureOutcome`) in 0.6.0 — are welcome because they keep the
+   package free of any driver import. The free-form `typeHint` on `DbParameter` is interpreted by
+   the adapter, so the package imports no driver types.
+
+3. **Direction: converge toward a single contracts package per SDK.** The `sqlserver` and
+   `postgres` contracts are identical except for `DbConnectionSettings` (`driver` vs `sslMode`).
+   The intended evolution is a unified `modular_api_sql` (and, later, `modular_api_nosql`) per
+   SDK, dropping the per-engine split. This *reduces* the package count (the six db packages
+   become three) — a refinement of what already exists, not a new capability. No target version is
+   committed; consistent with the roadmap's stance that releases up to 1.0.0 are fixes or
+   improvements of the already-implemented architecture.
+
+4. **Known debt that temporarily contradicts this stance**, to be remedied in dedicated
+   iterations (never by adding a driver binding):
+   - **#23** — the Python db contracts are synchronous while the rest of the Python SDK is
+     async/ASGI; they must move to `async`.
+   - **#24** — the Dart `modular_api_sqlserver` package hard-depends on `dart_odbc` through
+     `SqlServerMetadataReader`. The fix is to *remove* the driver from the package (the
+     driver-backed metadata reader becomes the user's responsibility or a docs example), not to
+     wrap it in a new satellite package.
+
+## Consequences
+
+- **The application owns a small adapter** (~150 lines, validated in production by the Fotos API).
+  This is the canonical usage pattern, not transitional scaffolding.
+- **Maximum freedom, minimum surface** — consumers pick any engine and driver; the framework
+  carries no driver dependency, version skew, or transitive footprint.
+- **READMEs no longer promise bindings** — the "Current slice" section is renamed and points here.
+- **Driver-backed introspection is out of scope for the packages** — a schema metadata reader that
+  needs a driver belongs to the consumer or to documentation, consistent with point 4 (#24).
+- **Parity remains coordinated** — per ADR-0002, all ecosystem packages move together; a
+  contracts-only change still ships as a synchronized version bump.

--- a/docs/guides/db-adapter.md
+++ b/docs/guides/db-adapter.md
@@ -1,0 +1,107 @@
+# Writing a database adapter
+
+The `modular_api_sqlserver` and `modular_api_postgres` packages are **contracts-only** by design
+(see [ADR-0004](../adr/0004-contracts-only-database-packages.md)): they define `DbClient` and its
+collaborators but ship no database driver. To run real queries you provide an **adapter** — a thin
+implementation of three interfaces over the driver of your choice. This guide shows a reference
+adapter for SQL Server using the `mssql` package in TypeScript. The same shape applies to Postgres
+(`pg`), to Python (`pyodbc`/`asyncpg`), and to Dart.
+
+The adapter is small (~150 lines in production) and you own it. That is the point: you choose the
+engine and driver; the framework stays out of your dependency tree.
+
+## The three collaborators
+
+`DbClient` is constructed with:
+
+- `DbSessionProvider<S>` — `acquire()` a session (a pooled connection) and `close()` the pool.
+- `DbCommandExecutor<S>` — run a `DbCommand` via `query()` (rows), `execute()` (affected count),
+  or `scalar()` (single value).
+- `DbTransactionRunner<S>` — wrap work in a transaction.
+
+`S` is whatever session type your driver exposes. Below, `S = sql.ConnectionPool`.
+
+## Binding parameters (G2) and stored procedures (G3)
+
+A `DbCommand.parameters` entry is either a raw positional value or a `DbParameter`
+(`name`, `value`, `direction`, optional free-form `typeHint`). A `DbCommand` with
+`kind: DbCommandKind.procedure` names a stored procedure in `text`; your adapter decides how to
+invoke it (`request.execute(name)` for `mssql`). Rows come back through `query()`; a procedure with
+no result set goes through `execute()`. When the driver exposes a return value or output
+parameters, populate the optional `DbProcedureOutcome` on the result.
+
+```ts
+import sql from 'mssql';
+import {
+  DbCommand,
+  DbCommandKind,
+  DbParameter,
+  DbParameterDirection,
+  DbProcedureOutcome,
+} from '@macss/modular-api-sqlserver';
+
+// Apply DbCommand.parameters to an mssql Request, honouring DbParameter metadata.
+function bindParameters(request: sql.Request, command: DbCommand): void {
+  command.parameters.forEach((parameter, index) => {
+    if (parameter instanceof DbParameter) {
+      const type = parameter.typeHint ? resolveType(parameter.typeHint) : undefined;
+      if (parameter.direction === DbParameterDirection.output) {
+        request.output(parameter.name, type ?? sql.NVarChar);
+      } else {
+        // input and inputOutput both carry a value
+        type ? request.input(parameter.name, type, parameter.value)
+             : request.input(parameter.name, parameter.value);
+      }
+    } else {
+      // raw positional value keeps working: bind as p0, p1, ...
+      request.input(`p${index}`, parameter);
+    }
+  });
+}
+
+// Map a free-form typeHint to a driver type. The package never imports sql types;
+// this lookup lives entirely in your adapter.
+function resolveType(typeHint: string): sql.ISqlType | (() => sql.ISqlType) {
+  switch (typeHint.toLowerCase()) {
+    case 'int':
+      return sql.Int;
+    case 'varbinary(max)':
+      return sql.VarBinary(sql.MAX);
+    case 'nvarchar(255)':
+      return sql.NVarChar(255);
+    default:
+      return sql.NVarChar;
+  }
+}
+
+async function runCommand(pool: sql.ConnectionPool, command: DbCommand) {
+  const request = pool.request();
+  bindParameters(request, command);
+
+  const result =
+    command.kind === DbCommandKind.procedure
+      ? await request.execute(command.text)   // EXEC the stored procedure
+      : await request.query(command.text);     // plain SQL text
+
+  const outcome = new DbProcedureOutcome({
+    returnValue: result.returnValue,
+    outputParameters: result.output,
+  });
+
+  return { rows: result.recordset ?? [], affected: result.rowsAffected[0] ?? 0, outcome };
+}
+```
+
+## Classifying failures
+
+Map the driver's error codes to the engine-agnostic `DbFailureKind` taxonomy inside the adapter —
+this also stays out of the package. For `mssql`: `ELOGIN → authentication`, `ETIMEOUT → timeout`,
+`ESOCKET → connectivity`, SQL number `2812 → notFound`, `2627/2601/547 → constraint`,
+`1205 → conflict`. Wrap the rest as `unknown`.
+
+## Why this lives in your code
+
+Driver choice, connection-pool tuning, and error-code mapping are all engine/driver specifics. The
+contract deliberately keeps them on your side so the package never pulls a driver into your build.
+See [ADR-0004](../adr/0004-contracts-only-database-packages.md) for the rationale and the longer-term
+direction toward a single `modular_api_sql` contracts package.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,9 @@
 # modular_api - Product Roadmap
 
-This roadmap is intentionally focused on the API product itself: the core runtime, the plugin ecosystem, and the next official capabilities. It excludes unrelated future initiatives that are not part of the current direction.
+This roadmap is deliberately honest about where the project actually is. The plugin
+infrastructure, the official operational plugins, the GraphQL runtime, and the complementary
+packages are already shipped. The architecture is complete. What remains, up to `1.0.0`, is
+refinement of what already exists — not new foundational capabilities.
 
 ---
 
@@ -9,133 +12,87 @@ This roadmap is intentionally focused on the API product itself: the core runtim
 Every release must be coherent on its own.
 
 - **Major** - breaking changes to the core contract or plugin contract
-- **Minor** - new capabilities, new plugins, new public APIs
+- **Minor** - new capabilities, new public APIs
 - **Patch** - bug fixes, documentation, and performance improvements
 
+**Up to `1.0.0`, every release is a fix or an improvement of the already-implemented
+architecture, not a fundamentally new capability.** The `0.x` line refines, hardens, and
+consolidates the surfaces that already shipped. `1.0.0` is the point at which the ecosystem is
+declared stable for long-term support.
+
+A consequence worth stating explicitly: some improvements *reduce* surface rather than add it.
+For example, converging the six database packages (`sqlserver` + `postgres` across the three SDKs)
+into a single `modular_api_sql` contracts package per SDK — dropping the count from 15 packages to
+12 — is an improvement of what already exists, not a new feature. We do not commit to a version
+number for that change; it lands when it is ready, under the same semver rules.
+
 ---
 
-## Current State - v0.4.7
+## Current State - 0.6.0
 
-`modular_api` currently provides:
+`modular_api` provides, verified across Dart, TypeScript, and Python:
 
-- Official SDKs in Dart, TypeScript, and Python
 - A modular REST API model based on modules, DTOs, and use cases
-- A public plugin host in all three SDKs
-- Deterministic plugin lifecycle orchestration: setup, validation, freeze, and shutdown
-- Request-scoped structured logging
-- Three public middleware slots with deterministic runtime ordering: `preRouting`, `preHandler`, and `postHandler`
-- Host-owned plugin-pipeline guardrails: attributable middleware short-circuits in request logs and structured JSON `500` responses for uncaught plugin-pipeline failures
-- Official `HealthPlugin`, `OpenApiPlugin`, and `DocsPlugin` mounted under the shared `basePath`
-- Plugin-hosted health checks and Prometheus metrics endpoints under the shared `basePath`
-- Cross-language parity tests across the three SDKs
-
-The main remaining gaps for the v0.5.0 milestone are broader startup-validation
-coverage, the public metrics capability surface, and the final reference-plugin
-and migration docs.
-
----
-
-## v0.5.0 - Plugin Infrastructure
-
-> The immediate goal is to formalize the plugin ecosystem and reduce the core to its essential responsibilities.
-
-### Core Scope After the Refactor
-
-The core should know only about:
-
-- Modules
-- Use cases and DTO contracts
-- Common request lifecycle
-- HTTP middleware pipeline
-- Request-scoped logger context
-- Plugin host
-
-### Deliverables
-
-- [x] Add a public `.plugin()` API to `ModularApi`
-- [x] Define a public plugin contract in all three SDKs
-- [x] Define startup validation for plugin names, route collisions, and capability dependencies
-- [x] Define middleware slots that plugins can target with deterministic ordering
-- [x] Tighten middleware guardrails so plugins cannot bypass the approved core pipeline unintentionally
-- [x] Define a module-extension mechanism so plugins can attach module-scoped metadata without polluting the core API
-- [x] Define a capability registry so plugins can expose and consume shared services
-- [x] Document how to build custom plugins for Dart, TypeScript, and Python
-- [ ] Provide a minimal reference plugin built only on the public contract
-
-### Official Plugins in This Stage
-
-- [x] `HealthPlugin` - owns `/{basePath}/health` and health-check registration
-- [ ] `MetricsPlugin` - owns `/{basePath}/metrics`, the HTTP metrics middleware, and the public metrics registrar
-- [x] `OpenApiPlugin` - owns `/{basePath}/openapi.json` and `/{basePath}/openapi.yaml`
-- [x] `DocsPlugin` - owns `/{basePath}/docs` and consumes the OpenAPI capability instead of rebuilding the spec itself
-
-### Endpoint Policy
-
-- Every public endpoint resolves under the shared `basePath`.
-- `/{basePath}/docs` remains the canonical human-facing documentation endpoint.
-- `/{basePath}/openapi.json` and `/{basePath}/openapi.yaml` remain the raw machine-facing contract endpoints.
-- `/{basePath}/health` and `/{basePath}/metrics` remain the canonical operational endpoints.
-
-### Exit Criterion
-
-A developer outside the project can build and mount a custom plugin using the same public contract used by the official plugins.
+- A public plugin host with deterministic lifecycle orchestration (setup, validation, freeze,
+  shutdown) and three ordered middleware slots (`preRouting`, `preHandler`, `postHandler`)
+- Host-owned plugin-pipeline guardrails: attributable middleware short-circuits in request logs
+  and structured JSON `500` responses for uncaught plugin-pipeline failures
+- Official `HealthPlugin`, `MetricsPlugin`, `OpenApiPlugin`, and `DocsPlugin` under the shared
+  `basePath`, plus plugin routes that are first-class in OpenAPI and metrics (ADR-0003)
+- An official GraphQL runtime plugin mounted at `/{basePath}/graphql`, with catalog, metadata,
+  SDL, artifact, and SQL Server read-compiler surfaces
+- Fifteen ecosystem packages: core SDK, REST client, GraphQL client, SQL Server, and Postgres —
+  one of each per SDK — released under a single coordinated version (ADR-0002)
+- Contracts-only database packages (ADR-0004): engine-agnostic `DbClient`, repository, and
+  transaction contracts, with typed command parameters (`DbParameter`) and stored-procedure
+  support (`DbCommandKind.procedure`, `DbProcedureOutcome`) as of 0.6.0
+- Request-scoped structured logging and cross-language parity tests across the three SDKs
 
 ---
 
-## v0.6.0 - Optional GraphQL Plugin
+## History-Based Timeline
 
-> GraphQL is future work. It matters now only as a design constraint for the plugin system.
-
-### Goals
-
-- [ ] Implement an official GraphQL plugin for queries
-- [ ] Keep commands as REST use cases provided by the core module system
-- [ ] Make CQRS an optional architecture profile activated by the GraphQL plugin
-- [ ] Preserve REST-only APIs as a first-class supported mode
-- [ ] Reuse the same logging context, middleware pipeline, and plugin host introduced in v0.5.0
-
-### Exit Criterion
-
-An API can run in either of these modes without changing the core model:
-
-- REST-only
-- REST commands + GraphQL queries through the official plugin
+```
+0.4.5  Schema/OpenAPI/CORS/logging parity hardening across Dart, TypeScript, and Python
+0.4.6  Synchronized SDK versioning policy and package-layout cleanup
+0.4.7  Plugin host guardrails, official runtime plugins, GraphQL runtime, and complementary packages
+0.4.8  Flutter web compatibility (rest_client rewritten to package:http); first full end-to-end
+       verification (PostgreSQL + Dart + Flutter web + 41/41 Playwright tests)
+0.5.0  Ecosystem-wide coordinated bump of all packages; docs/contracts aligned with shipped state;
+       semver enforced from this version forward (ADR-0002)
+0.6.0  Database contract hardening: typed parameters and stored-procedure support, contracts-only
+       stance formalized (ADR-0004)
+```
 
 ---
 
-## v0.7.0 - Foundation Hardening
+## The Road to 1.0.0
 
-> After the plugin host exists, the focus shifts to stability, docs, and maintainability.
+These are improvements of the existing architecture, not new foundations. They land under semver
+when ready; no version numbers are pre-assigned.
 
-- [ ] Migrate the generated spec to OpenAPI 3.1 when compatibility work is ready
-- [ ] Strengthen CI/CD for all three SDKs
-- [ ] Add plugin compatibility tests across languages
-- [ ] Write contribution guides and style guides per language
-- [ ] Document migration guidance for users moving from core-managed global endpoints to plugins
-
-### Exit Criterion
-
-A new contributor can read the docs, create a module, enable the official plugins they want, and run the same conceptual API in Dart, TypeScript, and Python.
+- **Converge the database packages** toward a single `modular_api_sql` contracts package per SDK
+  (and, later, `modular_api_nosql`), since the per-engine contracts differ only in
+  `DbConnectionSettings`. Reduces 15 packages to 12. (ADR-0004)
+- **Align the Python database contracts to async**, matching the ASGI core (issue #23).
+- **Remove the `dart_odbc` dependency** from the Dart `modular_api_sqlserver` package so it stays
+  contracts-only; driver-backed schema introspection becomes the consumer's responsibility or a
+  docs example (issue #24).
+- **Migrate the generated spec to OpenAPI 3.1** when the compatibility work is ready.
+- **Strengthen CI/CD and contributor experience**: per-language style and contribution guides,
+  broader cross-language plugin and GraphQL compatibility tests.
+- **Document the optional CQRS profile** (REST commands + GraphQL queries) and keep REST-only APIs
+  a first-class supported mode in examples and docs.
 
 ---
 
 ## Invariants
 
-These points do not change across milestones:
+These do not change across releases:
 
 1. The core stays minimal.
-2. Official plugins must use the same public contract as third-party plugins.
+2. Official plugins use the same public contract as third-party plugins.
 3. REST-only APIs remain valid with or without optional plugins.
 4. `/{basePath}/docs` stays the canonical interactive documentation endpoint.
-5. CQRS is optional and only becomes active when the future GraphQL plugin is enabled.
-
----
-
-## Summary Timeline
-
-```
-v0.4.7  Current state: core + directly mounted global capabilities
-v0.5.0  Plugin infrastructure + official global plugins
-v0.6.0  Optional GraphQL plugin and optional CQRS profile
-v0.7.0  Foundation hardening and contributor experience
-```
+5. CQRS is optional and only active when the GraphQL plugin is enabled.
+6. Database packages are contracts-only; the framework ships no driver binding (ADR-0004).


### PR DESCRIPTION
## Summary

Prepares the coordinated **0.6.0** release of the 15 ecosystem packages. Builds on #25 (the additive db contracts) and completes everything needed before tagging `v0.6.0`.

Resolves #22.

## What changed

- **Version bump to 0.6.0** across the 15 packages and their 3 internal dependencies (ADR-0002 coordinated release).
- **CHANGELOGs `[0.6.0]`** in all 15: the 6 db packages document typed parameters + stored procedures; the other 9 are parity bumps.
- **ADR-0004 — Contracts-only database packages**: the framework will never ship a driver binding; the application supplies the adapter. Records the direction toward a unified `modular_api_sql` (15 → 12 packages) and the known debt (#23, #24).
- **`docs/guides/db-adapter.md`** — reference `mssql` adapter showing how to bind `DbParameter`, invoke `DbCommandKind.procedure`, populate `DbProcedureOutcome`, and classify failures.
- **README cleanup** — the 6 db packages drop the "first slice" wording (which implied future bindings) and point to ADR-0004.
- **Roadmap rewrite** — honest state through 0.6.0; explicit principle that releases up to 1.0.0 are fixes or improvements of the already-implemented architecture (e.g. converging packages 15 → 12 is an improvement, not a new feature).

## Verification

- 6 db suites green: TS 25+25, Python 25+25, Dart 29+25 (shared-fixture conformance covers the new contracts in all three SDKs).
- TS `tsc --noEmit` clean; `dart analyze` no issues.
- Internal-dependency resolution at `^0.6.0` validated for Dart sqlserver against the local core via a temporary override (the release pipeline resolves it for real, core-first per ADR-0002).

## Next step

Merge → tag `v0.6.0` → coordinated `release.yml` publishes the 15 packages (core first, then satellites) → `verify` job confirms npm/pub.dev/PyPI.

## Out of scope (dedicated iterations)

#23 (Python db sync → async) and #24 (Dart `dart_odbc` removal).
