### PR TITLE
ci: bump GitHub Actions to Node 24 runtime versions

### DIFF
--- a/.github/workflows/publish-dart-core.yml
+++ b/.github/workflows/publish-dart-core.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/publish-dart-graphql-client.yml
+++ b/.github/workflows/publish-dart-graphql-client.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/publish-dart-postgres.yml
+++ b/.github/workflows/publish-dart-postgres.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/publish-dart-rest-client.yml
+++ b/.github/workflows/publish-dart-rest-client.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/publish-dart-sqlserver.yml
+++ b/.github/workflows/publish-dart-sqlserver.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/publish-py-core.yml
+++ b/.github/workflows/publish-py-core.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/publish-py-graphql-client.yml
+++ b/.github/workflows/publish-py-graphql-client.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/publish-py-postgres.yml
+++ b/.github/workflows/publish-py-postgres.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/publish-py-rest-client.yml
+++ b/.github/workflows/publish-py-rest-client.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/publish-py-sqlserver.yml
+++ b/.github/workflows/publish-py-sqlserver.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/publish-ts-core.yml
+++ b/.github/workflows/publish-ts-core.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/publish-ts-graphql-client.yml
+++ b/.github/workflows/publish-ts-graphql-client.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/publish-ts-postgres.yml
+++ b/.github/workflows/publish-ts-postgres.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/publish-ts-rest-client.yml
+++ b/.github/workflows/publish-ts-rest-client.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/publish-ts-sqlserver.yml
+++ b/.github/workflows/publish-ts-sqlserver.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Determine release version
         id: version
@@ -110,7 +110,7 @@ jobs:
         working-directory: code/ts/modular_api
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Skip if already published
         id: check
@@ -126,7 +126,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.check.outputs.skip != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -169,7 +169,7 @@ jobs:
         working-directory: code/ts/modular_api_rest_client
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Skip if already published
         id: check
@@ -185,7 +185,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.check.outputs.skip != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -227,7 +227,7 @@ jobs:
         working-directory: code/ts/modular_api_sqlserver
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Skip if already published
         id: check
@@ -243,7 +243,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.check.outputs.skip != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -294,7 +294,7 @@ jobs:
         working-directory: code/ts/modular_api_postgres
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Skip if already published
         id: check
@@ -310,7 +310,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.check.outputs.skip != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -358,7 +358,7 @@ jobs:
         working-directory: code/dart/modular_api
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Skip if already published
         id: check
@@ -413,7 +413,7 @@ jobs:
         working-directory: code/dart/modular_api_rest_client
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Skip if already published
         id: check
@@ -468,7 +468,7 @@ jobs:
         working-directory: code/dart/modular_api_postgres
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Skip if already published
         id: check
@@ -523,7 +523,7 @@ jobs:
         working-directory: code/py/modular_api
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Skip if already published
         id: check
@@ -539,7 +539,7 @@ jobs:
 
       - name: Setup Python
         if: steps.check.outputs.skip != 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -576,7 +576,7 @@ jobs:
         working-directory: code/py/modular_api_rest_client
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Skip if already published
         id: check
@@ -592,7 +592,7 @@ jobs:
 
       - name: Setup Python
         if: steps.check.outputs.skip != 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -633,7 +633,7 @@ jobs:
         working-directory: code/py/modular_api_graphql_client
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Skip if already published
         id: check
@@ -649,7 +649,7 @@ jobs:
 
       - name: Setup Python
         if: steps.check.outputs.skip != 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -690,7 +690,7 @@ jobs:
         working-directory: code/py/modular_api_sqlserver
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Skip if already published
         id: check
@@ -706,7 +706,7 @@ jobs:
 
       - name: Setup Python
         if: steps.check.outputs.skip != 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -747,7 +747,7 @@ jobs:
         working-directory: code/py/modular_api_postgres
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Skip if already published
         id: check
@@ -763,7 +763,7 @@ jobs:
 
       - name: Setup Python
         if: steps.check.outputs.skip != 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -810,7 +810,7 @@ jobs:
         working-directory: code/ts/modular_api_graphql_client
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Skip if already published
         id: check
@@ -842,7 +842,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.check.outputs.skip != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -892,7 +892,7 @@ jobs:
         working-directory: code/dart/modular_api_graphql_client
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Skip if already published
         id: check
@@ -963,7 +963,7 @@ jobs:
         working-directory: code/dart/modular_api_sqlserver
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Skip if already published
         id: check


### PR DESCRIPTION
## Why

The 0.6.0 release run logged Node.js 20 deprecation warnings. `actions/checkout@v4`, `actions/setup-node@v4`, and `actions/setup-python@v5` run their JS on Node 20, which GitHub **forces to Node 24 on 2026-06-16** and **removes from runners on 2026-09-16**.

## What

Across `release.yml` and the 15 `publish-*` workflows:

- `actions/checkout` v4 → **v5** (v5 runs on Node 24)
- `actions/setup-node` v4 → **v5** (v5.0.0 introduced Node 24; minimal change)
- `actions/setup-python` v5 → **v6** (v6 introduced Node 24; v5 is Node 20)
- `dart-lang/setup-dart@v1` unchanged — third-party, not in the Node-20 warning list

Verified versions against the actions' release notes (not just the changelog). No functional change to the pipeline; it validates on the next `v*` tag push. Pure CI maintenance, independent of any package release.