### PR TITLE
fix(ts): a public-API type defect, 30 uncompilable tests, and the gap that hid both

### DIFF
--- a/code/ts/modular_api/package.json
+++ b/code/ts/modular_api/package.json
@@ -23,7 +23,9 @@
     "build": "tsc --project tsconfig.build.json",
     "prepublishOnly": "npm run build",
     "dev": "ts-node src/index.ts",
-    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "test": "npm run typecheck && vitest run",
+    "test:unit": "vitest run",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },

--- a/code/ts/modular_api/src/core/module_builder.ts
+++ b/code/ts/modular_api/src/core/module_builder.ts
@@ -23,9 +23,9 @@ export interface UseCaseOptions {
   /** Override output schema for OpenAPI (if fromJson fails with empty data) */
   outputSchema?: Record<string, unknown>;
   /** Input class for pre-validation and schema extraction (enables strict fromJson). */
-  inputClass: abstract new (...args: unknown[]) => Input;
+  inputClass: abstract new (...args: never[]) => Input;
   /** Output class for schema extraction. */
-  outputClass: abstract new (...args: unknown[]) => Output;
+  outputClass: abstract new (...args: never[]) => Output;
 }
 
 /**
@@ -106,8 +106,8 @@ export class ModuleBuilder {
    * Uses @Field metadata from inputClass/outputClass to build schemas.
    */
   private _extractSchemas<I extends Input, O extends Output>(
-    inputClass: abstract new (...args: unknown[]) => Input,
-    outputClass: abstract new (...args: unknown[]) => Output,
+    inputClass: abstract new (...args: never[]) => Input,
+    outputClass: abstract new (...args: never[]) => Output,
   ): { input: Record<string, unknown>; output: Record<string, unknown> } {
     let input: Record<string, unknown> = {};
     let output: Record<string, unknown> = {};

--- a/code/ts/modular_api/src/core/schema/field.ts
+++ b/code/ts/modular_api/src/core/schema/field.ts
@@ -153,7 +153,7 @@ export const Field = {
  * Retrieves the `@Field` metadata registered on a class.
  * Returns an empty array if the class has no decorated fields.
  */
-export function getFieldMetadata(target: abstract new (...args: unknown[]) => unknown): FieldMeta[] {
+export function getFieldMetadata(target: abstract new (...args: never[]) => unknown): FieldMeta[] {
   const metadata = (target as unknown as Record<symbol, Record<symbol, FieldMeta[]>>)[Symbol.metadata];
   return metadata?.[FIELD_KEY] ?? [];
 }

--- a/code/ts/modular_api/src/core/usecase.ts
+++ b/code/ts/modular_api/src/core/usecase.ts
@@ -111,7 +111,7 @@ export abstract class Input {
   }
 
   toJson(): Record<string, unknown> {
-    const fields = getFieldMetadata(this.constructor as abstract new (...args: unknown[]) => unknown);
+    const fields = getFieldMetadata(this.constructor as abstract new (...args: never[]) => unknown);
     if (fields.length > 0) {
       return serializeFromMetadata(this as unknown as Record<string, unknown>, fields);
     }
@@ -124,7 +124,7 @@ export abstract class Input {
    * Derived automatically from `@Field` decorators when present.
    */
   toSchema(): Record<string, unknown> {
-    const fields = getFieldMetadata(this.constructor as abstract new (...args: unknown[]) => unknown);
+    const fields = getFieldMetadata(this.constructor as abstract new (...args: never[]) => unknown);
     if (fields.length > 0) {
       return buildSchemaFromMetadata(fields);
     }
@@ -144,7 +144,7 @@ export abstract class Input {
    */
   static validateJson(
     json: Record<string, unknown>,
-    targetClass: abstract new (...args: unknown[]) => unknown,
+    targetClass: abstract new (...args: never[]) => unknown,
   ): void {
     const fields = getFieldMetadata(targetClass);
     for (const field of fields) {
@@ -193,7 +193,7 @@ export abstract class Output {
   }
 
   toJson(): Record<string, unknown> {
-    const fields = getFieldMetadata(this.constructor as abstract new (...args: unknown[]) => unknown);
+    const fields = getFieldMetadata(this.constructor as abstract new (...args: never[]) => unknown);
     if (fields.length > 0) {
       return serializeFromMetadata(this as unknown as Record<string, unknown>, fields);
     }
@@ -201,7 +201,7 @@ export abstract class Output {
   }
 
   toSchema(): Record<string, unknown> {
-    const fields = getFieldMetadata(this.constructor as abstract new (...args: unknown[]) => unknown);
+    const fields = getFieldMetadata(this.constructor as abstract new (...args: never[]) => unknown);
     if (fields.length > 0) {
       return buildSchemaFromMetadata(fields);
     }

--- a/code/ts/modular_api/src/core/usecase_handler.ts
+++ b/code/ts/modular_api/src/core/usecase_handler.ts
@@ -16,7 +16,7 @@ const JSON_HEADERS = { 'Content-Type': 'application/json; charset=utf-8' };
 
 export interface UseCaseHandlerOptions {
   /** Input class for pre-validation before fromJson (enables strict factories). */
-  inputClass?: abstract new (...args: unknown[]) => Input;
+  inputClass?: abstract new (...args: never[]) => Input;
 }
 
 /**
@@ -65,7 +65,7 @@ export function useCaseHandler<I extends Input, O extends Output>(
       if (!options.inputClass) {
         Input.validateJson(
           data,
-          useCase.input.constructor as abstract new (...args: unknown[]) => unknown,
+          useCase.input.constructor as abstract new (...args: never[]) => unknown,
         );
       }
 

--- a/code/ts/modular_api/test/core/usecase_class_types.test.ts
+++ b/code/ts/modular_api/test/core/usecase_class_types.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import { Field, Input, Output } from '../../src';
+import { getFieldMetadata } from '../../src/core/schema/field';
+import { useCaseHandler } from '../../src/core/usecase_handler';
+
+/**
+ * The public API accepts a consumer's own `Input` / `Output` subclasses.
+ *
+ * **This is a type-level regression test, and the assertions that matter are the ones the compiler
+ * makes.** `inputClass` was typed `abstract new (...args: unknown[]) => Input`, which looks like "any
+ * class producing an Input" and is not: parameter contravariance requires the class's own constructor
+ * parameters to accept `unknown`, and no real class does. A consumer writing the obvious thing —
+ *
+ *     class DniInput extends Input {
+ *       constructor(public readonly dni: string) { super(); }
+ *     }
+ *
+ * — could not pass `DniInput` as `inputClass` without a cast. The framework's own tests never caught
+ * it because they only ever declared parameterless constructors, and because `vitest` does not
+ * typecheck: `tsc --noEmit` over the test directory was the only thing that could see it, and it was
+ * not being run.
+ *
+ * The fix is `never[]`, the standard idiom: `never` is assignable to every parameter type, so any
+ * constructor fits. Nothing is lost, because the framework never *constructs* through this type — it
+ * only reads decorator metadata off the constructor, which `getFieldMetadata` does below.
+ *
+ * If someone changes `never[]` back to `unknown[]`, this file stops compiling.
+ */
+
+// A constructor with a required, typed parameter — the shape that used to be rejected.
+class DniInput extends Input {
+  @Field.string({ description: 'Document number', example: '12345678' })
+  dni!: string;
+
+  constructor(dni: string) {
+    super();
+    this.dni = dni;
+  }
+}
+
+// Two parameters, one optional, to cover the arity the old signature also rejected.
+class DetalleOutput extends Output {
+  @Field.string({ description: 'Echo of the input', example: '12345678' })
+  echo!: string;
+
+  constructor(echo: string, private readonly note?: string) {
+    super();
+    this.echo = echo;
+  }
+
+  get statusCode(): number {
+    return 200;
+  }
+
+  describe(): string {
+    return this.note ?? this.echo;
+  }
+}
+
+class ParameterlessInput extends Input {
+  @Field.string({ description: 'Anything', example: 'ping' })
+  value = 'ping';
+}
+
+describe('a consumer class with a typed constructor', () => {
+  it('is accepted as inputClass', () => {
+    // The compiler is the assertion. This line failed to typecheck while `inputClass` was
+    // `abstract new (...args: unknown[]) => Input`.
+    const handler = useCaseHandler(
+      (json) => ({ input: new DniInput(String(json['dni'])) }) as never,
+      { inputClass: DniInput },
+    );
+
+    expect(typeof handler).toBe('function');
+  });
+
+  it('a parameterless class is still accepted', () => {
+    // The old signature accepted these, which is exactly why the defect stayed hidden — every test
+    // in the repo declared its inputs this way.
+    const handler = useCaseHandler(() => ({}) as never, { inputClass: ParameterlessInput });
+
+    expect(typeof handler).toBe('function');
+  });
+
+  it('field metadata is still readable, which is all the framework uses the type for', () => {
+    // The reason `never[]` costs nothing: the type is reflection-only. The framework reads decorator
+    // metadata off the constructor and never invokes it, so a signature that cannot be *called* is
+    // not a limitation.
+    expect(getFieldMetadata(DniInput).map((field) => field.name)).toContain('dni');
+    expect(getFieldMetadata(DetalleOutput).map((field) => field.name)).toContain('echo');
+  });
+
+  it('the class remains ordinarily constructible by the consumer', () => {
+    // The type governs what the framework accepts, not what the consumer can do with their own class.
+    const output = new DetalleOutput('12345678', 'a note');
+
+    expect(output.statusCode).toBe(200);
+    expect(output.describe()).toBe('a note');
+    expect(new DniInput('12345678').dni).toBe('12345678');
+  });
+});

--- a/code/ts/modular_api/test/graphql/graphql_runtime_integration.test.ts
+++ b/code/ts/modular_api/test/graphql/graphql_runtime_integration.test.ts
@@ -114,10 +114,10 @@ describe('GraphQL runtime integration', () => {
       }),
     });
 
-    await expect(api.serve({ port: 0 })).rejects.toMatchObject<Partial<PluginHostError>>({
+    await expect(api.serve({ port: 0 })).rejects.toMatchObject({
       code: 'PLUGIN_VALIDATION_FAILED',
       resourceId: 'graphql.catalog',
-    });
+    } satisfies Partial<PluginHostError>);
   });
 
   it('startup fails when executor capability is missing', async () => {
@@ -129,10 +129,10 @@ describe('GraphQL runtime integration', () => {
       }),
     });
 
-    await expect(api.serve({ port: 0 })).rejects.toMatchObject<Partial<PluginHostError>>({
+    await expect(api.serve({ port: 0 })).rejects.toMatchObject({
       code: 'PLUGIN_VALIDATION_FAILED',
       resourceId: 'missing.sql.read_executor',
-    });
+    } satisfies Partial<PluginHostError>);
   });
 
   it('startup fails when schema generation fails', async () => {
@@ -145,10 +145,10 @@ describe('GraphQL runtime integration', () => {
       }),
     });
 
-    await expect(api.serve({ port: 0 })).rejects.toMatchObject<Partial<PluginHostError>>({
+    await expect(api.serve({ port: 0 })).rejects.toMatchObject({
       code: 'PLUGIN_VALIDATION_FAILED',
       resourceId: 'graphql.schema',
-    });
+    } satisfies Partial<PluginHostError>);
   });
 
   it('startup fails when maxDepth is invalid', async () => {
@@ -161,10 +161,10 @@ describe('GraphQL runtime integration', () => {
       }),
     });
 
-    await expect(api.serve({ port: 0 })).rejects.toMatchObject<Partial<PluginHostError>>({
+    await expect(api.serve({ port: 0 })).rejects.toMatchObject({
       code: 'PLUGIN_VALIDATION_FAILED',
       resourceId: 'graphql.maxDepth',
-    });
+    } satisfies Partial<PluginHostError>);
   });
 
   it('startup fails when maxComplexity is invalid', async () => {
@@ -177,10 +177,10 @@ describe('GraphQL runtime integration', () => {
       }),
     });
 
-    await expect(api.serve({ port: 0 })).rejects.toMatchObject<Partial<PluginHostError>>({
+    await expect(api.serve({ port: 0 })).rejects.toMatchObject({
       code: 'PLUGIN_VALIDATION_FAILED',
       resourceId: 'graphql.maxComplexity',
-    });
+    } satisfies Partial<PluginHostError>);
   });
 
   it('startup fails when defaultLimit is invalid', async () => {
@@ -193,10 +193,10 @@ describe('GraphQL runtime integration', () => {
       }),
     });
 
-    await expect(api.serve({ port: 0 })).rejects.toMatchObject<Partial<PluginHostError>>({
+    await expect(api.serve({ port: 0 })).rejects.toMatchObject({
       code: 'PLUGIN_VALIDATION_FAILED',
       resourceId: 'graphql.defaultLimit',
-    });
+    } satisfies Partial<PluginHostError>);
   });
 
   it('startup fails when maxLimit is invalid', async () => {
@@ -209,10 +209,10 @@ describe('GraphQL runtime integration', () => {
       }),
     });
 
-    await expect(api.serve({ port: 0 })).rejects.toMatchObject<Partial<PluginHostError>>({
+    await expect(api.serve({ port: 0 })).rejects.toMatchObject({
       code: 'PLUGIN_VALIDATION_FAILED',
       resourceId: 'graphql.maxLimit',
-    });
+    } satisfies Partial<PluginHostError>);
   });
 
   it('startup fails when defaultLimit exceeds maxLimit', async () => {
@@ -226,10 +226,10 @@ describe('GraphQL runtime integration', () => {
       }),
     });
 
-    await expect(api.serve({ port: 0 })).rejects.toMatchObject<Partial<PluginHostError>>({
+    await expect(api.serve({ port: 0 })).rejects.toMatchObject({
       code: 'PLUGIN_VALIDATION_FAILED',
       resourceId: 'graphql.defaultLimit',
-    });
+    } satisfies Partial<PluginHostError>);
   });
 
   it('direct executor and capability id are mutually exclusive', () => {

--- a/code/ts/modular_api/test/graphql/graphql_schema_sdl_generator.test.ts
+++ b/code/ts/modular_api/test/graphql/graphql_schema_sdl_generator.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   GraphqlCatalogBuildMode,
+  GraphqlCatalogFieldVisibility,
   GraphqlCatalogIdentityMode,
   GraphqlCatalogOrigin,
   GraphqlCatalogPaginationMode,
@@ -9,6 +10,7 @@ import {
   GraphqlSchemaSdlGenerator,
   PhysicalObjectKind,
   type GraphqlCatalog,
+  type GraphqlCatalogField,
 } from '../../src';
 
 describe('GraphqlSchemaSdlGenerator', () => {
@@ -391,7 +393,7 @@ function catalogFixture(): GraphqlCatalog {
           field('Sku', 'sku', 'String', false),
           field('Quantity', 'quantity', 'Int', false),
           field('CustomerId', 'customerId', 'Int', false, {
-            visibility: 'hidden',
+            visibility: GraphqlCatalogFieldVisibility.Hidden,
             filterable: false,
             sortable: false,
           }),
@@ -429,17 +431,20 @@ function field(
   type: string,
   nullable: boolean,
   overrides?: {
-    visibility?: 'public' | 'hidden';
+    visibility?: GraphqlCatalogFieldVisibility;
     filterable?: boolean;
     sortable?: boolean;
   },
-) {
+): GraphqlCatalogField {
   return {
     column,
     publicName,
     type,
     nullable,
-    visibility: overrides?.visibility ?? 'public',
+    // The enum, not the raw string. A TypeScript string enum is not assignable from its own literal
+    // value, so `'public'` here silently produced a helper whose result was not a
+    // `GraphqlCatalogField` at all — the return type annotation above is what keeps that honest.
+    visibility: overrides?.visibility ?? GraphqlCatalogFieldVisibility.Public,
     filterable: overrides?.filterable ?? true,
     sortable: overrides?.sortable ?? true,
     sensitive: false,

--- a/code/ts/modular_api/test/graphql/sqlserver.smoke.test.ts
+++ b/code/ts/modular_api/test/graphql/sqlserver.smoke.test.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import { join } from 'node:path';
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
@@ -15,7 +16,10 @@ type SqlModuleLike = {
   connect(config: object): Promise<SqlConnectionPoolLike>;
 };
 
-const require = createRequire(import.meta.url);
+// Resolved from the working directory rather than `import.meta.url`: this package compiles with
+// `module: commonjs`, where `import.meta` is a hard compile error (TS1343). vitest never typechecks,
+// so nothing surfaced it until `tsc --noEmit` became part of `npm test`.
+const require = createRequire(join(process.cwd(), 'package.json'));
 const hasSqlDriver = (() => {
   try {
     require.resolve('mssql');

--- a/code/ts/modular_api/test/graphql/sqlserver_metadata_reader.smoke.test.ts
+++ b/code/ts/modular_api/test/graphql/sqlserver_metadata_reader.smoke.test.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
@@ -10,7 +11,10 @@ import {
   type PhysicalObject,
 } from '../../src';
 
-const require = createRequire(import.meta.url);
+// Resolved from the working directory rather than `import.meta.url`: this package compiles with
+// `module: commonjs`, where `import.meta` is a hard compile error (TS1343). vitest never typechecks,
+// so nothing surfaced it until `tsc --noEmit` became part of `npm test`.
+const require = createRequire(join(process.cwd(), 'package.json'));
 const hasSqlDriver = (() => {
   try {
     require.resolve('mssql');

--- a/code/ts/modular_api/test/plugin_host/plugin_host.lifecycle.test.ts
+++ b/code/ts/modular_api/test/plugin_host/plugin_host.lifecycle.test.ts
@@ -129,7 +129,7 @@ class RecordingPlugin implements Plugin {
 
   readonly manifest: PluginManifest;
 
-  constructor(id: string, private readonly events?: string[]) {
+  constructor(id: string, protected readonly events?: string[]) {
     this.manifest = {
       id,
       displayName: 'Recording Plugin',

--- a/code/ts/modular_api_graphql_client/package.json
+++ b/code/ts/modular_api_graphql_client/package.json
@@ -12,7 +12,9 @@
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "prepublishOnly": "npm run build",
-    "test": "vitest run"
+    "typecheck": "tsc --noEmit",
+    "test": "npm run typecheck && vitest run",
+    "test:unit": "vitest run"
   },
   "keywords": [
     "macss",

--- a/code/ts/modular_api_postgres/package.json
+++ b/code/ts/modular_api_postgres/package.json
@@ -12,7 +12,9 @@
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "prepublishOnly": "npm run build",
-    "test": "vitest run"
+    "typecheck": "tsc --noEmit",
+    "test": "npm run typecheck && vitest run",
+    "test:unit": "vitest run"
   },
   "keywords": [
     "macss",

--- a/code/ts/modular_api_rest_client/package.json
+++ b/code/ts/modular_api_rest_client/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "prepublishOnly": "npm run build",
-    "test": "vitest run"
+    "typecheck": "tsc --noEmit",
+    "test": "npm run typecheck && vitest run",
+    "test:unit": "vitest run"
   },
   "keywords": [
     "macss",

--- a/code/ts/modular_api_sqlserver/package.json
+++ b/code/ts/modular_api_sqlserver/package.json
@@ -12,7 +12,9 @@
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "prepublishOnly": "npm run build",
-    "test": "vitest run"
+    "typecheck": "tsc --noEmit",
+    "test": "npm run typecheck && vitest run",
+    "test:unit": "vitest run"
   },
   "keywords": [
     "macss",


### PR DESCRIPTION
`tsc --noEmit` reported **30 errors** across the TypeScript core's test directory. None of them failed
`npm test`, because `npm test` ran `vitest run` and vitest transpiles without typechecking. `npm run
build` could not see them either — `tsconfig.build.json` excludes the test directory. **No command in
the repo compiled the tests**, so the errors accumulated silently.

Found while verifying the tracing PR (#29), which is where the practice of running `tsc --noEmit` over
the whole project came from. This branch is off `main` and independent of it.

## One of the 30 was a real defect in the public API

```ts
inputClass: abstract new (...args: unknown[]) => Input
```

reads as "any class producing an `Input`" and is not. Parameter contravariance requires the class's own
constructor parameters to accept `unknown`, and no real class does. A consumer writing the obvious
thing —

```ts
class DniInput extends Input {
  constructor(public readonly dni: string) { super(); }
}
```

— **could not pass `DniInput` as `inputClass` without a cast.** The framework's own tests never caught
it because every one of them declared parameterless constructors, which *are* assignable. Confirmed
with a throwaway consumer-shaped probe before changing anything.

Fixed with `never[]`, the standard idiom: `never` is assignable to every parameter type, so any
constructor fits. Nothing is lost — the framework never constructs through this type, it only reads
decorator metadata off the constructor. 12 occurrences across `module_builder`, `usecase`,
`usecase_handler` and `schema/field`.

`test/core/usecase_class_types.test.ts` pins it, and the assertions that matter there are the
compiler's: reverting `never[]` to `unknown[]` makes the file stop compiling, which I verified rather
than assumed.

## The other 29

| Count | Error | Cause |
|---|---|---|
| 16 | TS2322 | The SDL generator test's `field()` helper built `visibility` as a raw string where `GraphqlCatalogField` wants the `GraphqlCatalogFieldVisibility` enum. A TypeScript string enum is not assignable from its own literal value, so the helper's result was not a `GraphqlCatalogField` at all. The production type was correct and stricter throughout. |
| 8 | TS2558 | `.rejects.toMatchObject<Partial<PluginHostError>>(...)`. vitest 4's `Promisify` maps each matcher through `(...args: infer A) => Promise<R>`, and `infer A` erases type parameters — so `toMatchObject` is non-generic on the `.rejects` path. Replaced with `satisfies` on the literal, which checks *more*: the object is validated where it is written rather than against a parameter the matcher had already widened. |
| 2 | TS1343 | `import.meta.url` in the two SQL Server smoke tests, under `module: commonjs`. |
| 1 | TS2341 | A subclass reading `RecordingPlugin`'s `private readonly events`. Now `protected`. |

## The structural fix matters more than the 30

`typecheck: tsc --noEmit` is now a script in **all five** TypeScript packages, and `test` is
`npm run typecheck && vitest run`. `test:unit` remains for the inner loop. Without that, the count goes
back up.

## Verified

0 errors in all five packages, whole project **and** build config.

| Package | Tests | tsc errors |
|---|---|---|
| modular_api | 296 (+5 skipped) | 0 |
| modular_api_rest_client | 7 | 0 |
| modular_api_postgres | 25 | 0 |
| modular_api_graphql_client | 7 | 0 |
| modular_api_sqlserver | 25 | 0 |

## Two adjacent findings, deliberately not acted on here

- **Dart is clean.** `dart analyze` covers `test/` and reports no issues in all five packages, which is
  why this class of drift never happened there.
- **Python has the same structural hole and a much larger surface.** All five packages declare
  `[tool.pyright] typeCheckingMode = "strict"`, but pyright is not a dev dependency anywhere and has
  never run. Installing it reports **737 errors across 125 files** in the core alone, roughly 60% of
  them `reportUnknown*` — strict mode's no-implicit-Any rule against a codebase never checked. That is
  its own piece of work, not a footnote to this one.