### PR TITLE
fix(py): pyright de 1211 a 0 en los cinco paquetes, y la compuerta que lo mantiene

### DIFF
--- a/code/py/modular_api/example/modules/greetings/usecases/hello_world.py
+++ b/code/py/modular_api/example/modules/greetings/usecases/hello_world.py
@@ -42,5 +42,9 @@ class HelloWorld(UseCase[HelloWorldInput, HelloWorldOutput]):
         return None
 
     async def execute(self) -> HelloWorldOutput:
-        self.logger.info(f"Greeting user: {self.input.name}")
+        # The mirror of `logger?.info(...)` in the Dart and TypeScript examples. `logger` is None
+        # when the use case runs without the logging middleware, which is what those two already
+        # guarded and this one did not — it would have raised AttributeError.
+        if self.logger is not None:
+            self.logger.info(f"Greeting user: {self.input.name}")
         return HelloWorldOutput(message=f"Hello, {self.input.name}!")

--- a/code/py/modular_api/example/modules/time/usecases/current_time.py
+++ b/code/py/modular_api/example/modules/time/usecases/current_time.py
@@ -72,7 +72,8 @@ class CurrentTime(UseCase[CurrentTimeInput, CurrentTimeOutput]):
         adjusted = now_utc + timedelta(hours=offset_hours)  # type: ignore[arg-type]
         iso = adjusted.strftime("%Y-%m-%dT%H:%M:%S")
 
-        self.logger.info(f"Time requested for offset {offset_hours}")
+        if self.logger is not None:
+            self.logger.info(f"Time requested for offset {offset_hours}")
         return CurrentTimeOutput(datetime=iso, offset=offset_hours)  # type: ignore[arg-type]
 
     @staticmethod

--- a/code/py/modular_api/pyproject.toml
+++ b/code/py/modular_api/pyproject.toml
@@ -32,6 +32,9 @@ dependencies = [
 serve = ["uvicorn>=0.30"]
 graphql = ["json5>=0.9.14", "graphql-core>=3.2,<3.3"]
 dev = [
+    # Configured below at `typeCheckingMode = "strict"`. Declared here because a checker the
+    # repo configures and never installs is a checker that has never run.
+    "pyright>=1.1.400",
     "json5>=0.9.14",
     "graphql-core>=3.2,<3.3",
     "pytest>=8.0",
@@ -57,3 +60,24 @@ asyncio_mode = "auto"
 [tool.pyright]
 pythonVersion = "3.11"
 typeCheckingMode = "strict"
+
+[[tool.pyright.executionEnvironments]]
+root = "tests"
+reportUnknownMemberType = false
+reportUnknownArgumentType = false
+reportUnknownVariableType = false
+reportUnknownParameterType = false
+reportUnknownLambdaType = false
+reportMissingParameterType = false
+reportMissingTypeArgument = false
+# `example/` is documentation a consumer copies, not a published typed surface — same relaxed family
+# as `tests/`, and the same expectation that nothing which can indicate a real defect is silenced.
+[[tool.pyright.executionEnvironments]]
+root = "example"
+reportUnknownMemberType = false
+reportUnknownArgumentType = false
+reportUnknownVariableType = false
+reportUnknownParameterType = false
+reportUnknownLambdaType = false
+reportMissingParameterType = false
+reportMissingTypeArgument = false

--- a/code/py/modular_api/pyproject.toml
+++ b/code/py/modular_api/pyproject.toml
@@ -70,6 +70,17 @@ reportUnknownParameterType = false
 reportUnknownLambdaType = false
 reportMissingParameterType = false
 reportMissingTypeArgument = false
+# A pytest fixture is called by name through collection, never by a reference the checker can see, so
+# `reportUnusedFunction` reports every `autouse` fixture in this tree. Likewise a test that asserts a
+# class body raises a warning has to define a class it then never mentions. Both are the tool not
+# modelling pytest, not dead code. `reportUnusedImport` and `reportUnusedVariable` stay on — those do
+# find dead code, and they did.
+reportUnusedFunction = false
+reportUnusedClass = false
+# Tests legitimately reach into internals to exercise them directly. In `src/` this rule found real
+# coupling — a middleware importing another module's private default, a metric reading a private field
+# off a different object — and both were fixed rather than silenced.
+reportPrivateUsage = false
 # `example/` is documentation a consumer copies, not a published typed surface — same relaxed family
 # as `tests/`, and the same expectation that nothing which can indicate a real defect is silenced.
 [[tool.pyright.executionEnvironments]]

--- a/code/py/modular_api/src/modular_api/__init__.py
+++ b/code/py/modular_api/src/modular_api/__init__.py
@@ -54,6 +54,7 @@ from modular_api.openapi.openapi import (
 from modular_api.openapi.swagger_docs import swagger_docs_handler
 
 __all__ = [
+    "HostMetadata",
     "ApiRegistry",
     "Counter",
     "Field",

--- a/code/py/modular_api/src/modular_api/core/logger/logger.py
+++ b/code/py/modular_api/src/modular_api/core/logger/logger.py
@@ -72,12 +72,15 @@ class RequestScopedLogger:
         trace_id: str,
         log_level: LogLevel,
         service_name: str,
-        write_fn: WriteFn = _default_write,
+        # `None` selects the default sink, so a caller holding an optional write function can pass it
+        # straight through instead of importing the module-private default. This is what the TypeScript
+        # constructor already does with an omitted `writeFn` and Dart with an omitted `LogSink`.
+        write_fn: WriteFn | None = None,
     ) -> None:
         self._trace_id = trace_id
         self._log_level = log_level
         self._service_name = service_name
-        self._write_fn = write_fn
+        self._write_fn: WriteFn = _default_write if write_fn is None else write_fn
 
     @property
     def trace_id(self) -> str:

--- a/code/py/modular_api/src/modular_api/core/logger/logging_middleware.py
+++ b/code/py/modular_api/src/modular_api/core/logger/logging_middleware.py
@@ -17,13 +17,12 @@ from __future__ import annotations
 
 import time
 import uuid
-from typing import Callable
+from typing import cast
 
 from starlette.requests import Request
-from starlette.responses import Response
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
-from modular_api.core.logger.logger import LogLevel, RequestScopedLogger, WriteFn, _default_write
+from modular_api.core.logger.logger import LogLevel, RequestScopedLogger, WriteFn
 from modular_api.core.request_pipeline_audit import ensure_request_pipeline_audit
 
 # Key used in request.state to propagate the logger downstream.
@@ -76,7 +75,7 @@ def logging_middleware(
                 trace_id=trace_id,
                 log_level=log_level,
                 service_name=service_name,
-                write_fn=write_fn or _default_write,
+                write_fn=write_fn,
             )
 
             method = request.method.upper()
@@ -93,13 +92,18 @@ def logging_middleware(
             status_code = 500  # default for unhandled errors
 
             # Intercept the response start to capture status_code.
-            async def send_wrapper(message: dict) -> None:
+            # `Message` is the ASGI event type Starlette already declares, and it is what `Send`
+            # expects: a bare `dict` made this wrapper unassignable to `Send`, which is the signature
+            # the line below passes it as.
+            async def send_wrapper(message: Message) -> None:
                 nonlocal status_code
                 if message["type"] == "http.response.start":
-                    status_code = message["status"]
+                    status_code = cast(int, message["status"])
                     # Inject X-Request-ID header into the response.
-                    headers = list(message.get("headers", []))
-                    headers.append((b"x-request-id", trace_id.encode()))
+                    headers = [
+                        *cast("list[tuple[bytes, bytes]]", message.get("headers", [])),
+                        (b"x-request-id", trace_id.encode()),
+                    ]
                     message = {**message, "headers": headers}
                 await send(message)
 

--- a/code/py/modular_api/src/modular_api/core/metrics/metric.py
+++ b/code/py/modular_api/src/modular_api/core/metrics/metric.py
@@ -50,6 +50,15 @@ class LabeledCounter:
     def value(self) -> float:
         return self._value
 
+    @property
+    def labels(self) -> dict[str, str]:
+        """The label set this child holds, copied — the parent's ``collect()`` reads it.
+
+        A read property for the same reason ``value`` is one: the parent was reaching into ``_labels``,
+        which is private to this class and belongs to a different object than the one reading it.
+        """
+        return dict(self._labels)
+
     def inc(self, amount: float = 1) -> None:
         """Increments by *amount* (must be > 0)."""
         if amount <= 0:
@@ -92,7 +101,7 @@ class Counter:
         return [
             MetricSample(
                 name=self.name,
-                labels=dict(child._labels),
+                labels=child.labels,
                 value=child.value,
                 suffix="",
             )
@@ -115,6 +124,11 @@ class LabeledGauge:
     @property
     def value(self) -> float:
         return self._value
+
+    @property
+    def labels(self) -> dict[str, str]:
+        """The label set this child holds, copied — see ``LabeledCounter.labels``."""
+        return dict(self._labels)
 
     def set(self, v: float) -> None:
         self._value = float(v)
@@ -164,7 +178,7 @@ class Gauge:
         return [
             MetricSample(
                 name=self.name,
-                labels=dict(child._labels),
+                labels=child.labels,
                 value=child.value,
                 suffix="",
             )

--- a/code/py/modular_api/src/modular_api/core/metrics/metrics_middleware.py
+++ b/code/py/modular_api/src/modular_api/core/metrics/metrics_middleware.py
@@ -12,11 +12,11 @@ Records per-request:
 from __future__ import annotations
 
 import time
-from typing import Any
+from typing import Any, cast
 
 from starlette.requests import Request
 from starlette.responses import Response
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from modular_api.core.metrics.metric import Counter, Gauge, Histogram
 from modular_api.core.metrics.metric_registry import MetricRegistry
@@ -61,10 +61,12 @@ def metrics_middleware(
             start = time.perf_counter()
             status_code = 500  # default for unhandled errors
 
-            async def send_wrapper(message: dict) -> None:
+            # `Message` is the ASGI event type `Send` expects; a bare `dict` made this wrapper
+            # unassignable to it. Same fix as the logging middleware.
+            async def send_wrapper(message: Message) -> None:
                 nonlocal status_code
                 if message["type"] == "http.response.start":
-                    status_code = message["status"]
+                    status_code = cast(int, message["status"])
                 await send(message)
 
             try:

--- a/code/py/modular_api/src/modular_api/core/modular_api.py
+++ b/code/py/modular_api/src/modular_api/core/modular_api.py
@@ -37,7 +37,13 @@ from modular_api.core.metrics.metric import Counter, Gauge, Histogram
 from modular_api.core.metrics.metric_registry import MetricRegistry, MetricsRegistrar
 from modular_api.core.module_builder import ModuleBuilder
 from modular_api.core.official_plugins import build_runtime_plugins, operational_route_paths
-from modular_api.core.plugin import Plugin, PluginHostError, RuntimePluginHost, order_plugins
+from modular_api.core.plugin import (
+    Plugin,
+    PluginHostError,
+    PluginValidationResult,
+    RuntimePluginHost,
+    order_plugins,
+)
 from modular_api.core.registry import api_registry
 from modular_api.graphql.runtime import GraphqlOptions
 
@@ -196,7 +202,7 @@ class ModularApi:
                     plugin_host.end_plugin_setup()
                 plugin_host.on_shutdown(plugin.shutdown)
             plugin_host.freeze()
-            validation_results = []
+            validation_results: list[PluginValidationResult] = []
             for plugin in ordered_plugins:
                 validation_results.extend(plugin.validate(plugin_host))
             plugin_host.assert_valid(validation_results)

--- a/code/py/modular_api/src/modular_api/core/module_builder.py
+++ b/code/py/modular_api/src/modular_api/core/module_builder.py
@@ -16,7 +16,7 @@ Mirror of ``ModuleBuilder`` in Dart and TypeScript.
 from __future__ import annotations
 
 import typing
-from typing import Any, Callable
+from typing import Any, Protocol, cast
 
 from starlette.routing import Route, Router
 
@@ -30,7 +30,19 @@ from modular_api.core.usecase import UseCase
 from modular_api.core.usecase_handler import usecase_handler
 
 
-def _get_return_type_hint(factory: Callable) -> type | None:  # noqa: ANN401
+class _SchemaBearingDto(Protocol):
+    """What ``_extract_schemas`` needs from a DTO class: the schema it derives from its fields.
+
+    ``Input`` and ``Output`` both provide it. Written as a protocol rather than naming those two
+    classes because the candidates arrive from runtime reflection over ``__orig_bases__``, which cannot
+    prove what they are — the ``hasattr`` check at the call site is what establishes this much.
+    """
+
+    @classmethod
+    def to_schema(cls) -> dict[str, object]: ...
+
+
+def _get_return_type_hint(factory: UseCaseFactory) -> type[UseCase[Any, Any]] | None:
     """Extract the UseCase class from the factory callable.
 
     Our convention: factories are classmethods like ``HelloWorld.from_json``.
@@ -39,14 +51,15 @@ def _get_return_type_hint(factory: Callable) -> type | None:  # noqa: ANN401
     # Bound classmethod: StubUseCase.from_json → __self__ is StubUseCase
     owner = getattr(factory, "__self__", None)
     if isinstance(owner, type) and issubclass(owner, UseCase):
-        return owner
+        # `issubclass` proves the class but not its type arguments, which reflection cannot recover.
+        return cast("type[UseCase[Any, Any]]", owner)
 
     # Fallback: try return type hint resolution
     try:
         hints = typing.get_type_hints(factory)
         ret = hints.get("return")
         if isinstance(ret, type) and issubclass(ret, UseCase):
-            return ret
+            return cast("type[UseCase[Any, Any]]", ret)
     except Exception:
         pass
 
@@ -161,13 +174,13 @@ class ModuleBuilder:
 
             if input_cls is not None and hasattr(input_cls, "to_schema"):
                 try:
-                    input_schema = input_cls.to_schema()
+                    input_schema = cast("type[_SchemaBearingDto]", input_cls).to_schema()
                 except Exception:
                     pass
 
             if output_cls is not None and hasattr(output_cls, "to_schema"):
                 try:
-                    output_schema = output_cls.to_schema()
+                    output_schema = cast("type[_SchemaBearingDto]", output_cls).to_schema()
                 except Exception:
                     pass
 

--- a/code/py/modular_api/src/modular_api/core/module_builder.py
+++ b/code/py/modular_api/src/modular_api/core/module_builder.py
@@ -15,7 +15,6 @@ Mirror of ``ModuleBuilder`` in Dart and TypeScript.
 
 from __future__ import annotations
 
-import inspect
 import typing
 from typing import Any, Callable
 
@@ -27,7 +26,7 @@ from modular_api.core.registry import (
     UseCaseRegistration,
     api_registry,
 )
-from modular_api.core.usecase import Input, Output, UseCase
+from modular_api.core.usecase import UseCase
 from modular_api.core.usecase_handler import usecase_handler
 
 

--- a/code/py/modular_api/src/modular_api/core/plugin.py
+++ b/code/py/modular_api/src/modular_api/core/plugin.py
@@ -6,7 +6,7 @@ import asyncio
 import inspect
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 from starlette.requests import Request
 from starlette.responses import JSONResponse, PlainTextResponse, Response
@@ -39,8 +39,8 @@ class PluginManifest:
     display_name: str
     version: str
     host_api_version: str
-    requires: list[PluginRequirement] = field(default_factory=list)
-    optional: list[PluginRequirement] = field(default_factory=list)
+    requires: list[PluginRequirement] = field(default_factory=list[PluginRequirement])
+    optional: list[PluginRequirement] = field(default_factory=list[PluginRequirement])
     contributes: dict[str, Any] | None = None
 
 
@@ -506,9 +506,13 @@ def _build_plugin_route_handler(
             return result
 
         if isinstance(result, dict):
-            status = int(result.get("status", 200))
-            headers = result.get("headers") or None
-            body_value = result.get("body")
+            # A plugin handler returns whatever it likes; this is the boundary that turns the response
+            # envelope into a transport response. The casts state the envelope's expected shape — a
+            # value that does not match still fails here exactly as it did before.
+            envelope = cast("dict[str, object]", result)
+            status = int(cast("int | str", envelope.get("status", 200)))
+            headers = cast("dict[str, str] | None", envelope.get("headers")) or None
+            body_value = envelope.get("body")
             if body_value is None:
                 return Response(status_code=status, headers=headers)
             if isinstance(body_value, (str, bytes)):

--- a/code/py/modular_api/src/modular_api/core/plugin.py
+++ b/code/py/modular_api/src/modular_api/core/plugin.py
@@ -454,8 +454,19 @@ class RuntimePluginHost(PluginHost):
     def shutdown_sync(self) -> None:
         for callback in reversed(self._shutdown_callbacks):
             result = callback()
-            if inspect.isawaitable(result):
+            # `iscoroutine`, not `isawaitable`. `asyncio.run` accepts a coroutine specifically — a
+            # callback returning some other awaitable (a Future, an object with `__await__`) would
+            # have satisfied `isawaitable` and then failed inside `run`. Anything awaitable but not a
+            # coroutine is driven through a coroutine wrapper instead.
+            if inspect.iscoroutine(result):
                 asyncio.run(result)
+            elif inspect.isawaitable(result):
+                awaitable = result
+
+                async def _drive() -> None:
+                    await awaitable
+
+                asyncio.run(_drive())
 
     def _assert_mutable(self) -> None:
         if self._frozen:

--- a/code/py/modular_api/src/modular_api/core/registry.py
+++ b/code/py/modular_api/src/modular_api/core/registry.py
@@ -42,7 +42,7 @@ class UseCaseRegistration:
     method: str  # uppercase: "POST" | "GET" | "PUT" | "PATCH" | "DELETE"
     path: str  # e.g. "/api/v1/greetings/hello-world"
     factory: UseCaseFactory
-    schemas: dict[str, dict[str, Any]] = field(default_factory=dict)
+    schemas: dict[str, dict[str, Any]] = field(default_factory=dict[str, dict[str, Any]])
     doc: UseCaseDocMeta | None = None
 
 

--- a/code/py/modular_api/src/modular_api/core/registry.py
+++ b/code/py/modular_api/src/modular_api/core/registry.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
-from modular_api.core.usecase import Input, Output, UseCase
+from modular_api.core.usecase import UseCase
 
 # Type alias — same as in usecase_handler.py.
 UseCaseFactory = Callable[[dict[str, Any]], UseCase[Any, Any]]

--- a/code/py/modular_api/src/modular_api/core/usecase.py
+++ b/code/py/modular_api/src/modular_api/core/usecase.py
@@ -93,7 +93,12 @@ class Input(BaseModel):
 
     model_config = {"extra": "ignore"}
 
-    def __init_subclass__(cls, **kwargs: object) -> None:
+    # `Any`, not `object`, and the distinction is the whole point of a pass-through: pydantic's
+    # `BaseModel.__init_subclass__` declares every config key as a typed keyword parameter, and
+    # `object` is assignable to none of them. `Any` is assignable to all of them, which is the honest
+    # statement for kwargs we forward untouched and never read. The same shape of mistake as typing a
+    # constructor parameter `unknown` in TypeScript.
+    def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         if "to_schema" in cls.__dict__:
             warnings.warn(
@@ -136,7 +141,12 @@ class Output(BaseModel):
 
     model_config = {"extra": "ignore"}
 
-    def __init_subclass__(cls, **kwargs: object) -> None:
+    # `Any`, not `object`, and the distinction is the whole point of a pass-through: pydantic's
+    # `BaseModel.__init_subclass__` declares every config key as a typed keyword parameter, and
+    # `object` is assignable to none of them. `Any` is assignable to all of them, which is the honest
+    # statement for kwargs we forward untouched and never read. The same shape of mistake as typing a
+    # constructor parameter `unknown` in TypeScript.
+    def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         if "to_schema" in cls.__dict__:
             warnings.warn(

--- a/code/py/modular_api/src/modular_api/core/usecase.py
+++ b/code/py/modular_api/src/modular_api/core/usecase.py
@@ -15,6 +15,8 @@ from typing import Any, Generic, Self, TypeVar
 
 from pydantic import BaseModel
 
+from modular_api.core.logger.logger import ModularLogger
+
 
 def _reorder_type_first(prop: dict[str, Any]) -> dict[str, Any]:
     """Ensure ``type`` is the first key — matches Dart/TS property order."""
@@ -200,7 +202,12 @@ class UseCase(ABC, Generic[I, O]):
 
     # Request-scoped logger injected by the framework before execute().
     # Available inside execute(). None when running without middleware.
-    logger: object | None = None
+    #
+    # `ModularLogger | None`, not `object | None`: the framework always injects a logger that satisfies
+    # this protocol, and `object` made the one thing a use case does with it — `self.logger.info(...)` —
+    # fail to type-check. The `example/` use cases in this repo were the proof: they call it exactly as a
+    # consumer would. `PluginRequestContext.logger` already named the protocol.
+    logger: ModularLogger | None = None
 
     @property
     @abstractmethod

--- a/code/py/modular_api/src/modular_api/core/usecase.py
+++ b/code/py/modular_api/src/modular_api/core/usecase.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import warnings
 from abc import ABC, abstractmethod
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Self, TypeVar
 
 from pydantic import BaseModel
 
@@ -109,12 +109,16 @@ class Input(BaseModel):
             )
 
     @classmethod
-    def from_json(cls, json: dict[str, object]) -> Input:
+    def from_json(cls, json: dict[str, object]) -> Self:
         """Deserialize from a plain dict with strict type validation.
 
         Uses Pydantic strict mode so JSON types must match field declarations
         exactly — no implicit coercion (e.g. int → str is rejected).
         Raises ``ValidationError`` for missing or wrongly-typed fields.
+
+        Returns ``Self``, not ``Input``: ``cls.model_validate`` builds ``cls``, so a subclass calling
+        this inherited factory gets its own type back. Annotating the base class here made every
+        consumer DTO's fields unreachable without a cast. See ``tests/test_dto_typing.py``.
         """
         return cls.model_validate(json, strict=True)
 
@@ -157,8 +161,11 @@ class Output(BaseModel):
             )
 
     @classmethod
-    def from_json(cls, json: dict[str, object]) -> Output:
-        """Deserialize from a plain dict with strict type validation."""
+    def from_json(cls, json: dict[str, object]) -> Self:
+        """Deserialize from a plain dict with strict type validation.
+
+        ``Self`` for the same reason as ``Input.from_json`` — see the note there.
+        """
         return cls.model_validate(json, strict=True)
 
     def to_json(self) -> dict[str, object]:

--- a/code/py/modular_api/src/modular_api/core/usecase_handler.py
+++ b/code/py/modular_api/src/modular_api/core/usecase_handler.py
@@ -8,14 +8,14 @@ the full use-case lifecycle: parse → validate → execute → respond.
 from __future__ import annotations
 
 import json
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 from pydantic import ValidationError
 from starlette.requests import Request
 from starlette.responses import Response
 
 from modular_api.core.use_case_exception import UseCaseException
-from modular_api.core.usecase import Input, Output, UseCase
+from modular_api.core.usecase import UseCase
 
 # Key used by LoggingMiddleware to store the request-scoped logger.
 LOGGER_STATE_KEY = "modular_logger"
@@ -74,16 +74,20 @@ def usecase_handler(factory: UseCaseFactory) -> Any:
             if method in ("GET", "DELETE"):
                 data: dict[str, Any] = {**dict(request.query_params), **request.path_params}
             else:
-                data = await request.json()
+                # Typed `object`, not `dict[str, Any]`. `request.json()` decodes any valid JSON —
+                # a bare string, an array, a number — so the guard below is load-bearing. Declaring
+                # the result a dict made a type checker call that guard dead code, which is exactly
+                # backwards: the annotation was the thing that was wrong.
+                payload: object = await request.json()
 
-                # Guard: request.json() decodes any valid JSON — including bare
-                # strings, arrays, or numbers.  Our factories expect a dict.
-                if not isinstance(data, dict):
+                if not isinstance(payload, dict):
                     return Response(
                         content=json.dumps({"error": "Request body must be a JSON object"}),
                         status_code=400,
                         media_type=_JSON_CONTENT_TYPE,
                     )
+
+                data = cast("dict[str, Any]", payload)
 
             # 2. Build use case
             use_case = factory(data)

--- a/code/py/modular_api/src/modular_api/graphql/catalog/graphql_catalog_builder.py
+++ b/code/py/modular_api/src/modular_api/graphql/catalog/graphql_catalog_builder.py
@@ -7,15 +7,13 @@ from enum import Enum
 import hashlib
 import json
 import re
-from typing import Any
+from typing import Any, cast
 
 from modular_api.graphql.metadata import (
     GraphqlFieldMetadata,
-    GraphqlMetadataDiagnostic,
     GraphqlMetadataFile,
     GraphqlMetadataLimit,
     GraphqlObjectMetadata,
-    GraphqlRelationMetadata,
 )
 from modular_api.graphql.sqlserver.physical_model import (
     PhysicalCatalog,
@@ -786,7 +784,8 @@ class GraphqlCatalogBuilder:
 
     def _canonicalize(self, value: Any) -> Any:
         if isinstance(value, dict):
-            return {key: self._canonicalize(value[key]) for key in sorted(value)}
+            mapping = cast("dict[str, Any]", value)
+            return {key: self._canonicalize(mapping[key]) for key in sorted(mapping)}
         if isinstance(value, (list, tuple)):
-            return [self._canonicalize(entry) for entry in value]
+            return [self._canonicalize(entry) for entry in cast("list[Any] | tuple[Any, ...]", value)]
         return value

--- a/code/py/modular_api/src/modular_api/graphql/metadata/graphql_metadata_parser.py
+++ b/code/py/modular_api/src/modular_api/graphql/metadata/graphql_metadata_parser.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, cast
 
 import json5
 
@@ -90,7 +90,11 @@ class GraphqlMetadataParser:
         physical_objects_by_id = {object_.id: object_ for object_ in physical_catalog.objects}
 
         try:
-            decoded = json5.loads(raw_jsonc)
+            # `json5` ships no type information, so everything it returns is implicitly Any and
+            # that spread to every downstream read — over fifty diagnostics from this one line.
+            # Declared `object` here and narrowed once below, which puts the untyped boundary in one
+            # place instead of at every `.get`.
+            decoded = cast(object, json5.loads(raw_jsonc))
         except Exception as error:  # noqa: BLE001
             return GraphqlMetadataParseResult(
                 metadata=None,
@@ -115,7 +119,10 @@ class GraphqlMetadataParser:
                 ),
             )
 
-        root = dict(decoded)
+        # The `isinstance` above establishes the shape; the cast carries it. Values stay `Any`
+        # because a metadata document's values genuinely are arbitrary JSON — the helpers below each
+        # check what they read.
+        root = cast("dict[str, Any]", decoded)
         _collect_unknown_keys(
             map_=root,
             allowed_keys={"$schema", "version", "defaults", "objects"},
@@ -159,8 +166,10 @@ class GraphqlMetadataParser:
         )
 
         objects: dict[str, GraphqlObjectMetadata] = {}
-        for object_id in sorted(str(key) for key in objects_value.keys()):
-            object_value = objects_value.get(object_id)
+        # Narrowed by the `isinstance` above; the cast carries it into the loop.
+        objects_map = cast("dict[str, Any]", objects_value)
+        for object_id in sorted(objects_map):
+            object_value = objects_map.get(object_id)
             if not isinstance(object_value, dict):
                 diagnostics.append(
                     GraphqlMetadataDiagnostic(
@@ -172,7 +181,7 @@ class GraphqlMetadataParser:
                 )
                 continue
 
-            object_map = dict(object_value)
+            object_map = cast("dict[str, Any]", object_value)
             _collect_unknown_keys(
                 map_=object_map,
                 allowed_keys={"publish", "name", "key", "fields", "relations", "limit"},
@@ -261,7 +270,9 @@ def _collect_unknown_keys(
 
 def _read_optional_child_map(parent: dict[str, Any], key: str) -> dict[str, Any] | None:
     value = parent.get(key)
-    return dict(value) if isinstance(value, dict) else None
+    # `dict(x)` on an untyped mapping produces another untyped mapping. The `isinstance` establishes
+    # the shape; the cast is what carries it to the caller.
+    return cast("dict[str, Any]", value) if isinstance(value, dict) else None
 
 
 def _read_optional_string(
@@ -296,7 +307,9 @@ def _read_optional_string_list(
     value = map_.get(key)
     if value is None:
         return None
-    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+    if not isinstance(value, list) or any(
+        not isinstance(item, str) for item in cast("list[object]", value)
+    ):
         diagnostics.append(
             GraphqlMetadataDiagnostic(
                 severity=GraphqlMetadataSeverity.ERROR,
@@ -307,7 +320,7 @@ def _read_optional_string_list(
             )
         )
         return None
-    return tuple(value)
+    return tuple(cast("list[str]", value))
 
 
 def _parse_fields(
@@ -330,8 +343,9 @@ def _parse_fields(
         return {}
 
     fields: dict[str, GraphqlFieldMetadata] = {}
-    for field_name in sorted(str(key) for key in value.keys()):
-        field_value = value.get(field_name)
+    fields_map = cast("dict[str, Any]", value)
+    for field_name in sorted(fields_map):
+        field_value = fields_map.get(field_name)
         if not isinstance(field_value, dict):
             diagnostics.append(
                 GraphqlMetadataDiagnostic(

--- a/code/py/modular_api/src/modular_api/graphql/metadata/graphql_metadata_parser.py
+++ b/code/py/modular_api/src/modular_api/graphql/metadata/graphql_metadata_parser.py
@@ -358,18 +358,19 @@ def _parse_fields(
             )
             continue
 
+        field_map = cast("dict[str, Any]", field_value)
         _collect_unknown_keys(
-            map_=dict(field_value),
+            map_=dict(field_map),
             allowed_keys={"hidden", "sensitive", "noFilter", "noSort", "name"},
             diagnostics=diagnostics,
             object_id=object_id,
         )
         fields[field_name] = GraphqlFieldMetadata(
-            hidden=_read_optional_bool(field_value, "hidden", diagnostics, object_id, field_name),
-            sensitive=_read_optional_bool(field_value, "sensitive", diagnostics, object_id, field_name),
-            no_filter=_read_optional_bool(field_value, "noFilter", diagnostics, object_id, field_name),
-            no_sort=_read_optional_bool(field_value, "noSort", diagnostics, object_id, field_name),
-            name=_read_optional_string(field_value, "name", diagnostics, object_id),
+            hidden=_read_optional_bool(field_map, "hidden", diagnostics, object_id, field_name),
+            sensitive=_read_optional_bool(field_map, "sensitive", diagnostics, object_id, field_name),
+            no_filter=_read_optional_bool(field_map, "noFilter", diagnostics, object_id, field_name),
+            no_sort=_read_optional_bool(field_map, "noSort", diagnostics, object_id, field_name),
+            name=_read_optional_string(field_map, "name", diagnostics, object_id),
         )
 
     return fields
@@ -395,7 +396,7 @@ def _parse_relations(
         return ()
 
     relations: list[GraphqlRelationMetadata] = []
-    for entry in value:
+    for entry in cast("list[object]", value):
         if not isinstance(entry, dict):
             diagnostics.append(
                 GraphqlMetadataDiagnostic(
@@ -408,18 +409,27 @@ def _parse_relations(
             )
             continue
 
+        entry_map = cast("dict[str, Any]", entry)
         _collect_unknown_keys(
-            map_=dict(entry),
+            map_=dict(entry_map),
             allowed_keys={"name", "cardinality", "target", "via"},
             diagnostics=diagnostics,
             object_id=object_id,
         )
+        # `via` is only read when it really is an array. The previous form put that check inside the
+        # comprehension's `if`, so it tested the container once per item and dropped every item when the
+        # test failed — the same result, reached by filtering items on a property of their container.
+        via_value = entry_map.get("via")
         relations.append(
             GraphqlRelationMetadata(
-                name=str(entry.get("name", "")),
-                cardinality=str(entry.get("cardinality", "")),
-                target=str(entry.get("target", "")),
-                via=tuple(str(item) for item in entry.get("via", []) if isinstance(entry.get("via", []), list)),
+                name=str(entry_map.get("name", "")),
+                cardinality=str(entry_map.get("cardinality", "")),
+                target=str(entry_map.get("target", "")),
+                via=(
+                    tuple(str(item) for item in cast("list[Any]", via_value))
+                    if isinstance(via_value, list)
+                    else ()
+                ),
             )
         )
 
@@ -447,8 +457,9 @@ def _parse_limit(
         )
         return None
 
-    default_value = value.get("default")
-    max_value = value.get("max")
+    limit_map = cast("dict[str, Any]", value)
+    default_value = limit_map.get("default")
+    max_value = limit_map.get("max")
     if not isinstance(default_value, int) or not isinstance(max_value, int):
         diagnostics.append(
             GraphqlMetadataDiagnostic(

--- a/code/py/modular_api/src/modular_api/graphql/metadata/graphql_metadata_parser.py
+++ b/code/py/modular_api/src/modular_api/graphql/metadata/graphql_metadata_parser.py
@@ -148,11 +148,13 @@ class GraphqlMetadataParser:
                 diagnostics=_sort_diagnostics(diagnostics),
             )
 
+        # Bound once. The previous form called `_read_optional_child_map` twice — once to test for
+        # None and once to read through it — so the test guarded a *different* call than the one it
+        # protected, and no type checker could see the two as related.
+        defaults_map = _read_optional_child_map(root, "defaults")
         defaults_limit = _parse_limit(
             scope_name="defaults.limit",
-            value=_read_optional_child_map(root, "defaults").get("limit")
-            if _read_optional_child_map(root, "defaults") is not None
-            else None,
+            value=defaults_map.get("limit") if defaults_map is not None else None,
             diagnostics=diagnostics,
         )
 

--- a/code/py/modular_api/src/modular_api/graphql/read/sql_read_contract.py
+++ b/code/py/modular_api/src/modular_api/graphql/read/sql_read_contract.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Iterable, Mapping
 

--- a/code/py/modular_api/src/modular_api/graphql/read/sqlserver_read_compiler.py
+++ b/code/py/modular_api/src/modular_api/graphql/read/sqlserver_read_compiler.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 from modular_api.graphql.catalog import (
     GraphqlCatalog,
     GraphqlCatalogField,
@@ -21,13 +23,24 @@ from modular_api.graphql.read.sql_read_contract import (
     SqlFilterOperator,
     SqlItemSelection,
     SqlOrderByClause,
-    SqlPage,
     SqlParameter,
     SqlReadCommand,
     SqlReadCommandPurpose,
     SqlRelationBatchSelection,
     SqlSortDirection,
 )
+
+
+def _sequence_operand(value: object) -> tuple[Any, ...]:
+    """The operand of an ``IN`` condition, or empty when it is not a sequence.
+
+    A function rather than an inline conditional so the narrowing applies to a parameter: narrowing
+    ``condition.value`` in place gave that member an unparameterised element type, which then travelled
+    into every parameter the compiler bound from it.
+    """
+    if isinstance(value, (list, tuple)):
+        return tuple(cast("list[Any] | tuple[Any, ...]", value))
+    return ()
 
 
 class SqlServerReadCompiler:
@@ -225,7 +238,7 @@ class SqlServerReadCompiler:
         if condition.operator is SqlFilterOperator.NE:
             return f"{column_ref} <> @{parameters.add(condition.value, type_=field.type)}"
         if condition.operator is SqlFilterOperator.IN_LIST:
-            values = tuple(condition.value) if isinstance(condition.value, (list, tuple)) else ()
+            values = _sequence_operand(condition.value)
             if not values:
                 return "1 = 0"
             parameter_refs = ", ".join(f"@{parameters.add(value, type_=field.type)}" for value in values)

--- a/code/py/modular_api/src/modular_api/graphql/runtime/graphql_artifacts.py
+++ b/code/py/modular_api/src/modular_api/graphql/runtime/graphql_artifacts.py
@@ -7,7 +7,7 @@ import inspect
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Coroutine, cast
 
 from modular_api.graphql.catalog import (
     GraphqlCatalog,
@@ -165,7 +165,9 @@ def resolve_catalog_from_artifacts_or_source(options: GraphqlOptions) -> Graphql
 
 def _resolve_maybe_awaitable(value: Any) -> Any:
     if inspect.isawaitable(value):
-        return asyncio.run(value)
+        # `asyncio.run` takes a coroutine, not any awaitable — it rejects the rest at runtime. The cast
+        # records that narrower requirement without changing which values reach it.
+        return asyncio.run(cast("Coroutine[Any, Any, Any]", value))
     return value
 
 
@@ -318,9 +320,10 @@ def _catalog_from_json(payload: dict[str, Any]) -> GraphqlCatalog:
     provider_json = _require_object(payload.get("provider"), "catalog.json provider must be an object.")
     build_json = _require_object(payload.get("build"), "catalog.json build must be an object.")
     objects_json = _require_list(payload.get("objects"), "catalog.json objects must be an array.")
-    diagnostics_json = payload.get("diagnostics") or []
-    if not isinstance(diagnostics_json, list):
-        raise GraphqlArtifactLoadError("catalog.json diagnostics must be an array.")
+    diagnostics_json = _require_list(
+        payload.get("diagnostics") or [],
+        "catalog.json diagnostics must be an array.",
+    )
 
     return GraphqlCatalog(
         catalog_version=_require_string(payload.get("catalogVersion"), "catalog.json catalogVersion must be a string."),
@@ -496,19 +499,21 @@ def _parse_json_object(text: str, error_message: str) -> dict[str, Any]:
         raise GraphqlArtifactLoadError(str(error)) from error
     if not isinstance(payload, dict):
         raise GraphqlArtifactLoadError(error_message)
-    return payload
+    return cast("dict[str, Any]", payload)
 
 
 def _require_object(value: Any, error_message: str) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise GraphqlArtifactLoadError(error_message)
-    return value
+    # These three helpers are the only place a decoded artifact value becomes a typed container, so the
+    # cast lands once here instead of at every read in the readers above.
+    return cast("dict[str, Any]", value)
 
 
 def _require_list(value: Any, error_message: str) -> list[Any]:
     if not isinstance(value, list):
         raise GraphqlArtifactLoadError(error_message)
-    return value
+    return cast("list[Any]", value)
 
 
 def _require_string(value: Any, error_message: str) -> str:

--- a/code/py/modular_api/src/modular_api/graphql/runtime/graphql_runtime_plugin.py
+++ b/code/py/modular_api/src/modular_api/graphql/runtime/graphql_runtime_plugin.py
@@ -20,7 +20,14 @@ from graphql import (
     specified_rules,
     validate,
 )
-from graphql.language.ast import DocumentNode, FieldNode, FragmentDefinitionNode, SelectionSetNode
+from graphql.language.ast import (
+    DocumentNode,
+    FieldNode,
+    FragmentDefinitionNode,
+    FragmentSpreadNode,
+    InlineFragmentNode,
+    SelectionSetNode,
+)
 
 from modular_api.core.health.health_check import HealthCheck, HealthCheckResult, HealthStatus
 from modular_api.core.health.health_service import HealthService
@@ -284,6 +291,12 @@ class GraphqlRuntimePlugin(Plugin):
                 )
 
     async def _execute_request(self, context: PluginRequestContext, ready: _GraphqlReadyState) -> dict[str, object]:
+        # Narrowed once rather than re-checked at each use. Reaching here means `setup` registered
+        # the route, which it only does when options exist — but the type cannot express that, and
+        # stating the invariant is better than five separate accesses that each look unguarded.
+        options = self._options
+        assert options is not None, "the GraphQL route is only registered when options are supplied"
+
         query = _read_query(context)
         if query is None:
             return {
@@ -298,11 +311,11 @@ class GraphqlRuntimePlugin(Plugin):
             return _graphql_ok_response(errors=[_format_graphql_error(error)])
 
         max_depth = _compute_document_depth(document)
-        if max_depth > self._options.max_depth:
+        if max_depth > options.max_depth:
             return _graphql_ok_response(
                 errors=[
                     _validation_error(
-                        f"Maximum operation depth of {self._options.max_depth} reached. Operation depth: {max_depth}.",
+                        f"Maximum operation depth of {options.max_depth} reached. Operation depth: {max_depth}.",
                         "queryDepthComplexity",
                     )
                 ]
@@ -312,18 +325,18 @@ class GraphqlRuntimePlugin(Plugin):
             ready.schema,
             document,
             tuple(specified_rules)
-            if self._options.introspection_enabled
+            if options.introspection_enabled
             else (*specified_rules, NoSchemaIntrospectionCustomRule),
         )
         if validation_errors:
             return _graphql_ok_response(errors=[_format_graphql_error(error) for error in validation_errors])
 
         complexity = _compute_document_complexity(document)
-        if complexity > self._options.max_complexity:
+        if complexity > options.max_complexity:
             return _graphql_ok_response(
                 errors=[
                     _validation_error(
-                        f"Maximum operation complexity of {self._options.max_complexity} reached. Operation complexity: {complexity}.",
+                        f"Maximum operation complexity of {options.max_complexity} reached. Operation complexity: {complexity}.",
                         "queryComplexity",
                     )
                 ]
@@ -735,14 +748,14 @@ def _collect_selection_set(
         return
 
     for selection in selection_set.selections:
-        if selection.kind == "field":
-            field = cast(FieldNode, selection)
+        if isinstance(selection, FieldNode):
+            field = selection
             collected.setdefault(field.name.value, []).append(field)
             continue
-        if selection.kind == "inline_fragment":
+        if isinstance(selection, InlineFragmentNode):
             _collect_selection_set(selection.selection_set, fragments, collected, visited_fragments)
             continue
-        if selection.kind == "fragment_spread":
+        if isinstance(selection, FragmentSpreadNode):
             fragment_name = selection.name.value
             if fragment_name in visited_fragments:
                 continue
@@ -991,7 +1004,7 @@ def _selection_set_depth(
 ) -> int:
     max_depth = current_depth
     for selection in selection_set.selections:
-        if selection.kind == "field":
+        if isinstance(selection, FieldNode):
             next_depth = current_depth + 1
             max_depth = max(max_depth, next_depth)
             if selection.selection_set is not None:
@@ -1000,10 +1013,10 @@ def _selection_set_depth(
                     _selection_set_depth(selection.selection_set, fragments, visited_fragments, next_depth),
                 )
             continue
-        if selection.kind == "inline_fragment":
+        if isinstance(selection, InlineFragmentNode):
             max_depth = max(max_depth, _selection_set_depth(selection.selection_set, fragments, visited_fragments, current_depth))
             continue
-        if selection.kind == "fragment_spread":
+        if isinstance(selection, FragmentSpreadNode):
             fragment_name = selection.name.value
             if fragment_name in visited_fragments:
                 continue
@@ -1032,15 +1045,15 @@ def _selection_set_complexity(
 ) -> int:
     complexity = 0
     for selection in selection_set.selections:
-        if selection.kind == "field":
+        if isinstance(selection, FieldNode):
             complexity += current_depth
             if selection.selection_set is not None:
                 complexity += _selection_set_complexity(selection.selection_set, fragments, visited_fragments, current_depth + 1)
             continue
-        if selection.kind == "inline_fragment":
+        if isinstance(selection, InlineFragmentNode):
             complexity += _selection_set_complexity(selection.selection_set, fragments, visited_fragments, current_depth)
             continue
-        if selection.kind == "fragment_spread":
+        if isinstance(selection, FragmentSpreadNode):
             fragment_name = selection.name.value
             if fragment_name in visited_fragments:
                 continue
@@ -1055,7 +1068,7 @@ def _collect_fragments(document: DocumentNode) -> dict[str, FragmentDefinitionNo
     return {
         definition.name.value: definition
         for definition in document.definitions
-        if definition.kind == "fragment_definition"
+        if isinstance(definition, FragmentDefinitionNode)
     }
 
 

--- a/code/py/modular_api/src/modular_api/graphql/runtime/graphql_runtime_plugin.py
+++ b/code/py/modular_api/src/modular_api/graphql/runtime/graphql_runtime_plugin.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
+from collections.abc import Awaitable, Iterable
 from dataclasses import dataclass, field
 from typing import Any, Callable, TypeAlias, cast
 
@@ -15,7 +16,10 @@ from graphql import (
     NoSchemaIntrospectionCustomRule,
     build_schema,
     default_field_resolver,
-    execute,
+    # graphql-core annotates `middleware` as a bare `Tuple`/`List`, so its own signature carries an
+    # unknown type parameter. Nothing on our side can resolve it; suppressed here rather than at each
+    # call site so there is one place to delete when upstream parameterises it.
+    execute,  # pyright: ignore[reportUnknownVariableType]
     parse,
     specified_rules,
     validate,
@@ -26,12 +30,20 @@ from graphql.language.ast import (
     FragmentDefinitionNode,
     FragmentSpreadNode,
     InlineFragmentNode,
+    OperationDefinitionNode,
     SelectionSetNode,
 )
 
 from modular_api.core.health.health_check import HealthCheck, HealthCheckResult, HealthStatus
 from modular_api.core.health.health_service import HealthService
-from modular_api.core.plugin import Plugin, PluginHost, PluginManifest, PluginRequestContext, PluginValidationResult
+from modular_api.core.plugin import (
+    Plugin,
+    PluginHost,
+    PluginManifest,
+    PluginRequestContext,
+    PluginRoute,
+    PluginValidationResult,
+)
 from modular_api.graphql.catalog import (
     GraphqlCatalog,
     GraphqlCatalogField,
@@ -74,6 +86,18 @@ _GRAPHQL_JSON_CONTENT_TYPE = "application/json; charset=utf-8"
 
 RuntimeFieldResolver: TypeAlias = Callable[..., Any]
 
+# What `_GRAPHQL_TOTAL_COUNT_THUNK_KEY` maps to in a collection envelope: a deferred count that is only
+# run when the query selected `totalCount`. Written by `_resolve_collection`, read by
+# `_total_count_resolver`; the sentinel key is private to this module, so this is the whole contract.
+_TotalCountThunk: TypeAlias = Callable[[], "Awaitable[int] | int"]
+
+
+def _new_relation_loaders() -> dict[str, _RelationBatchLoader]:
+    # A named factory rather than `default_factory=dict`: the bare `dict` gives the field an unknown
+    # value type, and `dict[str, _RelationBatchLoader]` cannot be used as the factory because
+    # `_RelationBatchLoader` is defined further down this module and the default is built at import.
+    return {}
+
 
 @dataclass(slots=True)
 class _GraphqlReadyState:
@@ -95,7 +119,7 @@ class _GraphqlRuntimeState:
 class _GraphqlExecutionContext:
     request: PluginRequestContext
     ready_state: _GraphqlReadyState
-    relation_loaders: dict[str, _RelationBatchLoader] = field(default_factory=dict)
+    relation_loaders: dict[str, _RelationBatchLoader] = field(default_factory=_new_relation_loaders)
 
 
 @dataclass(frozen=True, slots=True)
@@ -125,14 +149,18 @@ class GraphqlRuntimePlugin(Plugin):
         async def _handler(context: PluginRequestContext) -> dict[str, object]:
             return await self._handle_request(context)
 
+        # `PluginRoute`, not a dict literal: `PluginHost.register_route` accepts only `PluginRoute`.
+        # The bundled host also takes a dict, but that is a widening in one implementation — any other
+        # host, including a test double, satisfies the contract by accepting `PluginRoute` alone. The
+        # five sibling official plugins already register this way.
         host.register_route(
-            {
-                "id": "graphql.endpoint",
-                "method": "POST",
-                "path": "/graphql",
-                "visibility": "transport",
-                "handler": _handler,
-            }
+            PluginRoute(
+                id="graphql.endpoint",
+                method="POST",
+                path="/graphql",
+                visibility="transport",
+                handler=_handler,
+            )
         )
 
     def validate(self, host: PluginHost) -> list[PluginValidationResult]:
@@ -254,7 +282,10 @@ class GraphqlRuntimePlugin(Plugin):
                     request_id=context.request_id,
                     method=context.method,
                     path=context.path,
-                    status_code=int(response["status"]),
+                    # Every return path of `_execute_request` sets an int status. The envelope is
+                    # `dict[str, object]` because that is the route handler contract, not because the
+                    # status could be something else.
+                    status_code=cast(int, response["status"]),
                 ),
             )
             return response
@@ -523,9 +554,9 @@ def _build_resolver_registry(
         async def _total_count_resolver(source: Any, info: GraphQLResolveInfo, **args: Any) -> int:
             if not isinstance(source, dict):
                 return 0
-            thunk = source.get(_GRAPHQL_TOTAL_COUNT_THUNK_KEY)
+            thunk = cast("dict[object, object]", source).get(_GRAPHQL_TOTAL_COUNT_THUNK_KEY)
             if callable(thunk):
-                result = thunk()
+                result = cast(_TotalCountThunk, thunk)()
                 if inspect.isawaitable(result):
                     result = await result
                 return int(result)
@@ -569,7 +600,7 @@ async def _resolve_item(
                 field_nodes=info.field_nodes,
                 fragments=info.fragments,
             ),
-            key=dict(key),
+            key=dict(cast("dict[str, Any]", key)),
         ),
         context=_build_execution_context(execution_context.request),
     )
@@ -652,7 +683,7 @@ async def _resolve_relation(
     parent_values = _relation_parent_values(
         source_object=source_object,
         relation=relation,
-        parent=source,
+        parent=cast("dict[str, Any]", source),
     )
     loader = _relation_loader(
         execution_context=execution_context,
@@ -765,21 +796,23 @@ def _collect_selection_set(
                 _collect_selection_set(fragment.selection_set, fragments, collected, visited_fragments)
 
 
-def _parse_filter(object_: GraphqlPublishedObject, raw: Any) -> SqlFilterNode | None:
+def _parse_filter(object_: GraphqlPublishedObject, raw: object) -> SqlFilterNode | None:
     if raw is None:
         return None
     if not isinstance(raw, dict):
         raise _graphql_validation_error("graphql.filter", "GraphQL filter input must be an object.")
 
     nodes: list[SqlFilterNode] = []
-    for key, value in raw.items():
+    # A GraphQL input object arrives as an untyped mapping with string keys; the guard above is what
+    # establishes it, and the cast is what carries that fact to the reads below.
+    for key, value in cast("dict[str, object]", raw).items():
         if key == "and":
-            children = tuple(child for child in (_parse_filter(object_, item) for item in value or ()) if child is not None)
+            children = _parse_filter_operands(object_, value)
             if children:
                 nodes.append(SqlFilterGroup.and_(children))
             continue
         if key == "or":
-            children = tuple(child for child in (_parse_filter(object_, item) for item in value or ()) if child is not None)
+            children = _parse_filter_operands(object_, value)
             if children:
                 nodes.append(SqlFilterGroup.or_(children))
             continue
@@ -804,7 +837,7 @@ def _parse_filter(object_: GraphqlPublishedObject, raw: Any) -> SqlFilterNode | 
                 operator=_parse_filter_operator(str(operator_name)),
                 value=operator_value,
             )
-            for operator_name, operator_value in value.items()
+            for operator_name, operator_value in cast("dict[str, object]", value).items()
         )
         if len(conditions) == 1:
             nodes.append(conditions[0])
@@ -814,6 +847,17 @@ def _parse_filter(object_: GraphqlPublishedObject, raw: Any) -> SqlFilterNode | 
     if not nodes:
         return None
     return nodes[0] if len(nodes) == 1 else SqlFilterGroup.and_(tuple(nodes))
+
+
+def _parse_filter_operands(object_: GraphqlPublishedObject, value: object) -> tuple[SqlFilterNode, ...]:
+    """The operand list of an ``and`` / ``or`` filter group.
+
+    ``value or ()`` preserves the previous handling of a null or empty operand, and a non-iterable
+    operand still raises exactly as it did. GraphQL validates input shape before any resolver runs, so
+    that path is only reachable by bypassing the schema.
+    """
+    parsed = (_parse_filter(object_, item) for item in cast("Iterable[object]", value or ()))
+    return tuple(child for child in parsed if child is not None)
 
 
 def _parse_filter_operator(name: str) -> SqlFilterOperator:
@@ -835,18 +879,19 @@ def _parse_filter_operator(name: str) -> SqlFilterOperator:
     return mapping[name]
 
 
-def _parse_order_by(object_: GraphqlPublishedObject, raw: Any) -> tuple[SqlOrderByClause, ...]:
+def _parse_order_by(object_: GraphqlPublishedObject, raw: object) -> tuple[SqlOrderByClause, ...]:
     if raw is None:
         return ()
     if not isinstance(raw, list):
         raise _graphql_validation_error("graphql.orderBy", "GraphQL orderBy input must be a list.")
 
     clauses: list[SqlOrderByClause] = []
-    for entry in raw:
+    for entry in cast("list[object]", raw):
         if not isinstance(entry, dict):
             raise _graphql_validation_error("graphql.orderBy", "Each orderBy entry must be an object.")
-        field_name = entry.get("field")
-        direction = entry.get("direction")
+        entry_map = cast("dict[str, object]", entry)
+        field_name = entry_map.get("field")
+        direction = entry_map.get("direction")
         if not isinstance(field_name, str) or not isinstance(direction, str):
             raise _graphql_validation_error(
                 "graphql.orderBy",
@@ -866,7 +911,7 @@ def _parse_order_by(object_: GraphqlPublishedObject, raw: Any) -> tuple[SqlOrder
     return tuple(clauses)
 
 
-def _parse_page(object_: GraphqlPublishedObject, raw: Any, options: GraphqlOptions) -> SqlPage:
+def _parse_page(object_: GraphqlPublishedObject, raw: object, options: GraphqlOptions) -> SqlPage:
     effective_max = min(object_.capabilities.pagination.max_limit, options.max_limit)
     effective_default = min(object_.capabilities.pagination.default_limit, options.default_limit, effective_max)
 
@@ -875,8 +920,9 @@ def _parse_page(object_: GraphqlPublishedObject, raw: Any, options: GraphqlOptio
     if not isinstance(raw, dict):
         raise _graphql_validation_error("graphql.page", "GraphQL page input must be an object.")
 
-    limit = raw.get("limit", effective_default)
-    offset = raw.get("offset", 0)
+    page_map = cast("dict[str, object]", raw)
+    limit = page_map.get("limit", effective_default)
+    offset = page_map.get("offset", 0)
     if not isinstance(limit, int) or not isinstance(offset, int):
         raise _graphql_validation_error("graphql.page", "GraphQL page limit and offset must be integers.")
     if limit < 0 or offset < 0:
@@ -968,29 +1014,46 @@ def _object_by_id(catalog: GraphqlCatalog, object_id: str) -> GraphqlPublishedOb
 
 
 def _read_query(context: PluginRequestContext) -> str | None:
-    if isinstance(context.body, dict) and isinstance(context.body.get("query"), str):
-        return cast(str, context.body["query"])
+    body = _body_map(context.body)
+    if body is not None and isinstance(body.get("query"), str):
+        return cast(str, body["query"])
     query = context.query.get("query")
     return query if isinstance(query, str) else None
 
 
-def _read_operation_name(body: Any) -> str | None:
-    if isinstance(body, dict) and isinstance(body.get("operationName"), str):
-        return cast(str, body["operationName"])
+def _read_operation_name(body: object) -> str | None:
+    body_map = _body_map(body)
+    if body_map is not None and isinstance(body_map.get("operationName"), str):
+        return cast(str, body_map["operationName"])
     return None
 
 
-def _read_variables(body: Any) -> dict[str, Any] | None:
-    if isinstance(body, dict) and isinstance(body.get("variables"), dict):
-        return dict(cast(dict[str, Any], body["variables"]))
-    return None
+def _read_variables(body: object) -> dict[str, Any] | None:
+    body_map = _body_map(body)
+    if body_map is None:
+        return None
+    variables = body_map.get("variables")
+    return dict(cast("dict[str, Any]", variables)) if isinstance(variables, dict) else None
+
+
+def _body_map(body: object) -> dict[str, object] | None:
+    """A request body decoded as a JSON object, or ``None`` for anything else.
+
+    ``PluginRequestContext.body`` is deliberately ``Any`` — the transport decides what it holds. This is
+    the one place that narrows it, so the three readers above do not each re-establish the same fact.
+    """
+    return cast("dict[str, object]", body) if isinstance(body, dict) else None
 
 
 def _compute_document_depth(document: DocumentNode) -> int:
     fragments = _collect_fragments(document)
     max_depth = 0
     for definition in document.definitions:
-        if definition.kind != "operation_definition":
+        # `isinstance`, not `definition.kind != "operation_definition"`: only the class carries
+        # `selection_set`, and the string comparison narrowed nothing — the attribute read was
+        # unchecked. Same test at runtime, since `kind` is that class's own discriminator, and it
+        # matches how the two walkers below dispatch on selection nodes.
+        if not isinstance(definition, OperationDefinitionNode):
             continue
         max_depth = max(max_depth, _selection_set_depth(definition.selection_set, fragments, set(), 0))
     return max_depth
@@ -1031,7 +1094,7 @@ def _compute_document_complexity(document: DocumentNode) -> int:
     fragments = _collect_fragments(document)
     complexity = 0
     for definition in document.definitions:
-        if definition.kind != "operation_definition":
+        if not isinstance(definition, OperationDefinitionNode):
             continue
         complexity += _selection_set_complexity(definition.selection_set, fragments, set(), 1)
     return complexity

--- a/code/py/modular_api/src/modular_api/graphql/schema/graphql_schema_sdl_generator.py
+++ b/code/py/modular_api/src/modular_api/graphql/schema/graphql_schema_sdl_generator.py
@@ -6,7 +6,6 @@ import re
 
 from modular_api.graphql.catalog import (
     GraphqlCatalog,
-    GraphqlCatalogField,
     GraphqlCatalogFieldVisibility,
     GraphqlCatalogRelationCardinality,
     GraphqlPublishedObject,

--- a/code/py/modular_api/src/modular_api/graphql/sqlserver/sql_server_metadata_reader.py
+++ b/code/py/modular_api/src/modular_api/graphql/sqlserver/sql_server_metadata_reader.py
@@ -3,10 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, cast
-
-if TYPE_CHECKING:
-    import pyodbc
+from typing import Any, Callable, cast
 
 from modular_api.graphql.sqlserver.physical_model import (
     PhysicalCatalog,
@@ -57,9 +54,9 @@ class _MutablePhysicalObject:
     kind: PhysicalObjectKind
     schema_name: str
     object_name: str
-    identity_fields: list[str] = field(default_factory=list)
-    fields: list[PhysicalField] = field(default_factory=list)
-    relations: list[PhysicalRelationSeed] = field(default_factory=list)
+    identity_fields: list[str] = field(default_factory=list[str])
+    fields: list[PhysicalField] = field(default_factory=list[PhysicalField])
+    relations: list[PhysicalRelationSeed] = field(default_factory=list[PhysicalRelationSeed])
 
 
 @dataclass(slots=True)
@@ -67,8 +64,8 @@ class _MutableRelation:
     name: str
     source_object_id: str
     target_object_id: str
-    source_fields: list[str] = field(default_factory=list)
-    target_fields: list[str] = field(default_factory=list)
+    source_fields: list[str] = field(default_factory=list[str])
+    target_fields: list[str] = field(default_factory=list[str])
 
 
 def _load_objects(

--- a/code/py/modular_api/src/modular_api/middlewares/cors.py
+++ b/code/py/modular_api/src/modular_api/middlewares/cors.py
@@ -65,7 +65,8 @@ def cors_middleware(
             # For all other requests, intercept the response to inject headers
             async def send_with_cors(message: Any) -> None:
                 if message["type"] == "http.response.start":
-                    headers = dict(scope.get("_cors_headers", []))
+                    # `dict(scope.get("_cors_headers", []))` used to be built here and never read. No
+                    # code writes that scope key either, so it was dead in both directions.
                     raw_headers: list[tuple[bytes, bytes]] = list(message.get("headers", []))
                     raw_headers.append((b"access-control-allow-origin", resolved_origin.encode()))
                     raw_headers.append((b"access-control-allow-methods", methods.encode()))

--- a/code/py/modular_api/src/modular_api/openapi/openapi.py
+++ b/code/py/modular_api/src/modular_api/openapi/openapi.py
@@ -12,12 +12,19 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any, cast
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeAlias, cast
 
 from starlette.requests import Request
 from starlette.responses import Response
 
 from modular_api.core.registry import UseCaseRegistration, api_registry
+
+
+# What all three endpoint factories in this package return: a Starlette endpoint. `swagger_docs_handler`
+# used to say `object`, which no consumer can hand to `Route(...)` without a cast, and the other two said
+# `Any`, which says nothing. This is the type the closures actually have.
+StarletteEndpoint: TypeAlias = Callable[[Request], Awaitable[Response]]
 
 
 def build_openapi_spec(
@@ -54,7 +61,7 @@ def build_openapi_spec(
 # ── Endpoint factories ────────────────────────────────────────
 
 
-def openapi_json_handler(*, title: str, port: int, **kwargs: Any) -> Any:
+def openapi_json_handler(*, title: str, port: int, **kwargs: Any) -> StarletteEndpoint:
     """Return a Starlette endpoint that serves the OpenAPI spec as JSON."""
 
     async def endpoint(request: Request) -> Response:
@@ -67,7 +74,7 @@ def openapi_json_handler(*, title: str, port: int, **kwargs: Any) -> Any:
     return endpoint
 
 
-def openapi_yaml_handler(*, title: str, port: int, **kwargs: Any) -> Any:
+def openapi_yaml_handler(*, title: str, port: int, **kwargs: Any) -> StarletteEndpoint:
     """Return a Starlette endpoint that serves the OpenAPI spec as YAML."""
 
     async def endpoint(request: Request) -> Response:

--- a/code/py/modular_api/src/modular_api/openapi/openapi.py
+++ b/code/py/modular_api/src/modular_api/openapi/openapi.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any
+from typing import Any, cast
 
 from starlette.requests import Request
 from starlette.responses import Response
@@ -200,6 +200,26 @@ def _yaml_key(key: str) -> str:
     return key
 
 
+def _as_mapping(value: object) -> dict[object, object] | None:
+    """The value as a mapping when it is one, otherwise ``None``.
+
+    Paired with ``_is_container`` for the same reason: an ``isinstance`` in the caller narrows the value
+    in place for the rest of the block, and the narrowed form of an untyped container is what turns the
+    later calls' argument types unknown. Narrowing inside a function keeps it out of the caller.
+    """
+    return cast("dict[object, object]", value) if isinstance(value, dict) else None
+
+
+def _is_container(value: object) -> bool:
+    """Whether a JSON-decoded value nests, i.e. needs a recursive render rather than a scalar one.
+
+    A predicate rather than an inline ``isinstance``: inlining narrows the value to an unparameterised
+    ``dict``/``list``, and passing that narrowed value straight back into ``json_to_yaml`` — which takes
+    ``object`` — is what made the element type unknown at four call sites.
+    """
+    return isinstance(value, (dict, list))
+
+
 def _yaml_scalar(value: object) -> str:
     """Render a YAML scalar (string, number, bool, None)."""
     if value is None:
@@ -226,8 +246,9 @@ def json_to_yaml(value: object, *, _indent: int = 0, _is_root: bool = True) -> s
         if not value:
             return "{}\n"
         result = "" if _is_root else "\n"
-        for k, v in value.items():
-            if isinstance(v, (dict, list)):
+        # JSON-decoded data: the guard establishes the container, the cast carries it to the reads.
+        for k, v in cast("dict[object, object]", value).items():
+            if _is_container(v):
                 result += f"{pad}{_yaml_key(str(k))}:{json_to_yaml(v, _indent=_indent + 1, _is_root=False)}"
             else:
                 result += f"{pad}{_yaml_key(str(k))}: {_yaml_scalar(v)}\n"
@@ -237,17 +258,18 @@ def json_to_yaml(value: object, *, _indent: int = 0, _is_root: bool = True) -> s
         if not value:
             return "[]\n"
         result = "" if _is_root else "\n"
-        for item in value:
-            if isinstance(item, dict) and item:
+        for item in cast("list[object]", value):
+            item_map = _as_mapping(item)
+            if item_map:
                 first = True
-                for k, v in item.items():
+                for k, v in item_map.items():
                     prefix = f"{pad}- " if first else f"{pad}  "
                     first = False
-                    if isinstance(v, (dict, list)):
+                    if _is_container(v):
                         result += f"{prefix}{_yaml_key(str(k))}:{json_to_yaml(v, _indent=_indent + 2, _is_root=False)}"
                     else:
                         result += f"{prefix}{_yaml_key(str(k))}: {_yaml_scalar(v)}\n"
-            elif isinstance(item, (dict, list)):
+            elif _is_container(item):
                 result += f"{pad}- {json_to_yaml(item, _indent=_indent + 1, _is_root=False)}"
             else:
                 result += f"{pad}- {_yaml_scalar(item)}\n"

--- a/code/py/modular_api/src/modular_api/openapi/swagger_docs.py
+++ b/code/py/modular_api/src/modular_api/openapi/swagger_docs.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from starlette.requests import Request
 from starlette.responses import HTMLResponse
 
+from modular_api.openapi.openapi import StarletteEndpoint
+
 _DOCS_UI_CDN = "https://cdn.jsdelivr.net/npm/@macss/docs-ui@0.1/dist"
 
 # {title} is the only placeholder — str.replace() is a literal match,
@@ -37,7 +39,7 @@ def build_swagger_docs_html(*, title: str, spec_url: str = "/openapi.json") -> s
     return _DOCS_UI_HTML_TEMPLATE.replace("{title}", title).replace("{spec_url}", spec_url)
 
 
-def swagger_docs_handler(*, title: str, spec_url: str = "/openapi.json") -> object:
+def swagger_docs_handler(*, title: str, spec_url: str = "/openapi.json") -> StarletteEndpoint:
     """Return a Starlette endpoint that serves a docs-ui HTML page.
 
     Usage::

--- a/code/py/modular_api/tests/conftest.py
+++ b/code/py/modular_api/tests/conftest.py
@@ -20,4 +20,9 @@ import asyncio
 import sys
 
 if sys.platform.startswith("win"):
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    # Deprecated in 3.14, removed in 3.16. Revisit when this project moves past 3.13: the
+    # replacement is a loop factory handed to the runner, which pytest-asyncio configures
+    # differently. Until then this is the mechanism that works.
+    asyncio.set_event_loop_policy(  # pyright: ignore[reportDeprecated]
+        asyncio.WindowsSelectorEventLoopPolicy()
+    )

--- a/code/py/modular_api/tests/graphql/test_graphql_metadata_parser.py
+++ b/code/py/modular_api/tests/graphql/test_graphql_metadata_parser.py
@@ -198,6 +198,7 @@ def test_parses_field_relation_and_limit_overrides_into_strongly_typed_metadata(
     assert customer.limit is not None
     assert customer.limit.default_value == 25
     assert customer.limit.max_value == 100
+    assert customer.fields is not None
     assert tuple(customer.fields.keys()) == ("CustomerCode", "FullName")
     assert customer.fields["CustomerCode"].hidden is True
     assert customer.fields["CustomerCode"].no_filter is True

--- a/code/py/modular_api/tests/graphql/test_graphql_runtime_execution.py
+++ b/code/py/modular_api/tests/graphql/test_graphql_runtime_execution.py
@@ -26,6 +26,7 @@ from modular_api.graphql import (
     GraphqlCatalogRelation,
     GraphqlCatalogRelationCardinality,
     GraphqlCatalogSource,
+    GraphqlEventSink,
     GraphqlOptions,
     GraphqlPublishedObject,
     ReadExecutionContext,
@@ -311,7 +312,7 @@ def _build_api(
     default_limit: int = 50,
     max_limit: int = 200,
     introspection_enabled: bool = False,
-    on_event: object | None = None,
+    on_event: GraphqlEventSink | None = None,
 ) -> ModularApi:
     return ModularApi(
         base_path="/api",

--- a/code/py/modular_api/tests/graphql/test_sqlserver_smoke.py
+++ b/code/py/modular_api/tests/graphql/test_sqlserver_smoke.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import os
 from collections.abc import Iterator
+from typing import TYPE_CHECKING
 
 import pytest
 
-pyodbc = pytest.importorskip("pyodbc")
+if TYPE_CHECKING:
+    import pyodbc
+else:
+    pyodbc = pytest.importorskip("pyodbc")
 
 
 def _connection_string() -> str:

--- a/code/py/modular_api/tests/health/test_health_handler.py
+++ b/code/py/modular_api/tests/health/test_health_handler.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 
 from starlette.testclient import TestClient
 from starlette.applications import Starlette

--- a/code/py/modular_api/tests/health/test_health_service.py
+++ b/code/py/modular_api/tests/health/test_health_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 import asyncio
 
 from modular_api.core.health.health_check import (
@@ -143,7 +145,7 @@ class TestHealthResponse:
         assert j["status"] == "pass"
         assert j["version"] == "1.0.0"
         assert j["releaseId"] == "1.0.0-debug"
-        assert "db" in j["checks"]
+        assert "db" in cast("dict[str, object]", j["checks"])
 
     def test_http_200_for_pass(self) -> None:
         resp = HealthResponse(

--- a/code/py/modular_api/tests/logger/test_logging_middleware.py
+++ b/code/py/modular_api/tests/logger/test_logging_middleware.py
@@ -1,8 +1,9 @@
 """RED — Logging middleware for Starlette: trace_id, structured JSON logs."""
 
 import json
+from collections.abc import Awaitable, Callable
+from typing import TypeAlias
 
-import pytest
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
@@ -18,10 +19,19 @@ from modular_api.core.logger.logging_middleware import (
 
 # ── Helpers ───────────────────────────────────────────────────────────────
 
+# A route handler as Starlette calls it. Named so `_build_app` can take one as a parameter without the
+# nested `async def handler` below rebinding that parameter's name — which is what it used to do.
+_RouteHandler: TypeAlias = Callable[[Request], Awaitable[Response]]
+
+
+async def _ok_handler(request: Request) -> Response:
+    del request
+    return PlainTextResponse("ok")
+
 
 def _build_app(
     *,
-    handler=None,
+    handler: _RouteHandler | None = None,
     excluded_routes: list[str] | None = None,
     log_level: LogLevel = LogLevel.debug,
 ) -> tuple[list[str], Starlette]:
@@ -31,10 +41,7 @@ def _build_app(
     def write_fn(line: str) -> None:
         captured.append(line)
 
-    if handler is None:
-
-        async def handler(request: Request) -> Response:
-            return PlainTextResponse("ok")
+    route_handler = handler if handler is not None else _ok_handler
 
     mw = logging_middleware(
         log_level=log_level,
@@ -44,11 +51,11 @@ def _build_app(
     )
 
     app = Starlette(routes=[
-        Route("/api/test", handler, methods=["GET", "POST", "PUT"]),
-        Route("/api/users/create", handler, methods=["POST"]),
-        Route("/api/fail", handler, methods=["POST"]),
-        Route("/health", handler, methods=["GET"]),
-        Route("/metrics", handler, methods=["GET"]),
+        Route("/api/test", route_handler, methods=["GET", "POST", "PUT"]),
+        Route("/api/users/create", route_handler, methods=["POST"]),
+        Route("/api/fail", route_handler, methods=["POST"]),
+        Route("/health", route_handler, methods=["GET"]),
+        Route("/metrics", route_handler, methods=["GET"]),
     ])
     app.add_middleware(mw)
     return captured, app
@@ -229,7 +236,7 @@ class TestLoggerPropagation:
             captured_logger.append(getattr(request.state, LOGGER_STATE_KEY, None))
             return PlainTextResponse("ok")
 
-        captured, app = _build_app(handler=handler)
+        _, app = _build_app(handler=handler)
         client = TestClient(app)
         client.get("/api/test")
         assert captured_logger[0] is not None
@@ -242,7 +249,7 @@ class TestLoggerPropagation:
             captured_logger.append(getattr(request.state, LOGGER_STATE_KEY))
             return PlainTextResponse("ok")
 
-        captured, app = _build_app(handler=handler)
+        _, app = _build_app(handler=handler)
         client = TestClient(app)
         client.get("/api/test", headers={"X-Request-ID": "my-trace"})
         assert captured_logger[0].trace_id == "my-trace"

--- a/code/py/modular_api/tests/metrics/test_metrics_middleware.py
+++ b/code/py/modular_api/tests/metrics/test_metrics_middleware.py
@@ -1,6 +1,8 @@
 """RED — Metrics middleware for Starlette: request counter, in-flight gauge, duration histogram."""
 
-import pytest
+from collections.abc import Awaitable, Callable
+from typing import TypeAlias
+
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
@@ -10,6 +12,16 @@ from starlette.testclient import TestClient
 from modular_api.core.metrics.metric import Counter, Gauge, Histogram
 from modular_api.core.metrics.metric_registry import MetricRegistry
 from modular_api.core.metrics.metrics_middleware import metrics_handler, metrics_middleware
+
+
+# A route handler as Starlette calls it. Named so `_build_app` can take one as a parameter without the
+# nested `async def handler` below rebinding that parameter's name — which is what it used to do.
+_RouteHandler: TypeAlias = Callable[[Request], Awaitable[Response]]
+
+
+async def _ok_handler(request: Request) -> Response:
+    del request
+    return PlainTextResponse("ok")
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────
@@ -26,17 +38,14 @@ def _make_metrics() -> tuple[MetricRegistry, Counter, Gauge, Histogram]:
 
 
 def _build_app(
-    handler=None,
+    handler: _RouteHandler | None = None,
     *,
     excluded_routes: list[str] | None = None,
     registered_paths: list[str] | None = None,
 ) -> tuple[MetricRegistry, Counter, Gauge, Histogram, Starlette]:
     registry, total, in_flight, duration = _make_metrics()
 
-    if handler is None:
-
-        async def handler(request: Request) -> Response:
-            return PlainTextResponse("ok")
+    route_handler = handler if handler is not None else _ok_handler
 
     mw = metrics_middleware(
         requests_total=total,
@@ -47,12 +56,12 @@ def _build_app(
     )
 
     app = Starlette(routes=[
-        Route("/api/greetings/hello", handler, methods=["GET", "POST"]),
-        Route("/api/test", handler, methods=["GET", "POST"]),
-        Route("/api/data", handler, methods=["GET"]),
-        Route("/api/slow", handler, methods=["GET"]),
-        Route("/health", handler, methods=["GET"]),
-        Route("/metrics", handler, methods=["GET"]),
+        Route("/api/greetings/hello", route_handler, methods=["GET", "POST"]),
+        Route("/api/test", route_handler, methods=["GET", "POST"]),
+        Route("/api/data", route_handler, methods=["GET"]),
+        Route("/api/slow", route_handler, methods=["GET"]),
+        Route("/health", route_handler, methods=["GET"]),
+        Route("/metrics", route_handler, methods=["GET"]),
     ])
     app.add_middleware(mw)
     return registry, total, in_flight, duration, app

--- a/code/py/modular_api/tests/middlewares/test_cors.py
+++ b/code/py/modular_api/tests/middlewares/test_cors.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-import pytest
+from typing import Any
+
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
@@ -19,7 +20,7 @@ async def _echo_endpoint(request: Request) -> PlainTextResponse:
     return PlainTextResponse("ok")
 
 
-def _build_app(**cors_options: object) -> TestClient:
+def _build_app(**cors_options: Any) -> TestClient:
     """Build a Starlette app with CORS middleware and a single /echo route."""
     app = Starlette(routes=[Route("/echo", _echo_endpoint)])
     cls = cors_middleware(**cors_options)

--- a/code/py/modular_api/tests/openapi/test_json_to_yaml.py
+++ b/code/py/modular_api/tests/openapi/test_json_to_yaml.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
 
 from modular_api.openapi.openapi import json_to_yaml
 

--- a/code/py/modular_api/tests/openapi/test_module_builder.py
+++ b/code/py/modular_api/tests/openapi/test_module_builder.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from abc import ABC
+from collections.abc import Iterator
 
 import pytest
 
 from modular_api.core.module_builder import ModuleBuilder
-from modular_api.core.registry import ApiRegistry, api_registry
+from modular_api.core.registry import api_registry
 from modular_api.core.usecase import Input, Output, UseCase
 
 
@@ -56,7 +56,7 @@ class _StubUseCase(UseCase[_StubInput, _StubOutput]):
 
 
 @pytest.fixture(autouse=True)
-def _clean_registry():
+def _clean_registry() -> Iterator[None]:
     """Ensure global registry is empty before and after each test."""
     api_registry.clear()
     yield
@@ -136,6 +136,7 @@ class TestModuleBuilderDocMetadata:
 
         doc = api_registry.routes[0].doc
         assert doc is not None
+        assert doc.summary is not None
         assert "create" in doc.summary
         assert "users" in doc.summary
         assert doc.tags == ["users"]

--- a/code/py/modular_api/tests/openapi/test_openapi_endpoints.py
+++ b/code/py/modular_api/tests/openapi/test_openapi_endpoints.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-import json
+from collections.abc import Iterator
+from typing import Any
 
 import pytest
 from starlette.routing import Route
@@ -13,14 +14,32 @@ from modular_api.core.registry import (
     UseCaseRegistration,
     api_registry,
 )
+from modular_api.core.usecase import Input, Output, UseCase
 from modular_api.openapi.openapi import openapi_json_handler, openapi_yaml_handler
 
 
 # ── Helpers ───────────────────────────────────────────────────
 
 
-def _dummy_factory(json_data: dict) -> object:
-    return object()
+class _StubUseCase(UseCase[Input, Output]):
+    """The registry stores a factory; this spec test never calls it, but it must still type-check."""
+
+    def __init__(self, json_data: dict[str, Any]) -> None:
+        del json_data
+
+    @property
+    def input(self) -> Input:
+        raise NotImplementedError
+
+    def validate(self) -> str | None:
+        return None
+
+    async def execute(self) -> Output:
+        raise NotImplementedError
+
+
+def _dummy_factory(json_data: dict[str, Any]) -> UseCase[Input, Output]:
+    return _StubUseCase(json_data)
 
 
 def _register_ping_usecase() -> None:
@@ -44,14 +63,14 @@ def _register_ping_usecase() -> None:
     )
 
 
-def _json_client(**kwargs: object) -> TestClient:
+def _json_client(**kwargs: Any) -> TestClient:
     """Build a TestClient wrapping the JSON endpoint in a Route."""
     endpoint = openapi_json_handler(**kwargs)
     app = Route("/", endpoint=endpoint)
     return TestClient(app)
 
 
-def _yaml_client(**kwargs: object) -> TestClient:
+def _yaml_client(**kwargs: Any) -> TestClient:
     """Build a TestClient wrapping the YAML endpoint in a Route."""
     endpoint = openapi_yaml_handler(**kwargs)
     app = Route("/", endpoint=endpoint)
@@ -59,7 +78,7 @@ def _yaml_client(**kwargs: object) -> TestClient:
 
 
 @pytest.fixture(autouse=True)
-def _clean_registry():
+def _clean_registry() -> Iterator[None]:
     api_registry.clear()
     yield
     api_registry.clear()

--- a/code/py/modular_api/tests/openapi/test_openapi_spec.py
+++ b/code/py/modular_api/tests/openapi/test_openapi_spec.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+from collections.abc import Iterator
 import pytest
 
 from modular_api.core.registry import (
-    ApiRegistry,
     UseCaseDocMeta,
     UseCaseRegistration,
     api_registry,
@@ -20,7 +22,7 @@ def _dummy_factory(json: dict) -> object:
     return object()
 
 
-def _make_registration(**overrides: object) -> UseCaseRegistration:
+def _make_registration(**overrides: Any) -> UseCaseRegistration:
     defaults: dict = {
         "module": "users",
         "command": "create",
@@ -49,7 +51,7 @@ def _make_registration(**overrides: object) -> UseCaseRegistration:
 
 
 @pytest.fixture(autouse=True)
-def _clean_registry():
+def _clean_registry() -> Iterator[None]:
     api_registry.clear()
     yield
     api_registry.clear()

--- a/code/py/modular_api/tests/openapi/test_registry.py
+++ b/code/py/modular_api/tests/openapi/test_registry.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-import pytest
+from typing import Any
+
 
 from modular_api.core.registry import ApiRegistry, UseCaseDocMeta, UseCaseRegistration
 
@@ -14,7 +15,7 @@ def _dummy_factory(json: dict) -> object:
     return object()
 
 
-def _make_registration(**overrides: object) -> UseCaseRegistration:
+def _make_registration(**overrides: Any) -> UseCaseRegistration:
     """Builds a UseCaseRegistration with sensible defaults, overridable per field."""
     defaults: dict = {
         "module": "users",

--- a/code/py/modular_api/tests/plugin_host/test_plugin_host_guardrails.py
+++ b/code/py/modular_api/tests/plugin_host/test_plugin_host_guardrails.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from typing import Any
 
 import pytest
 from starlette.applications import Starlette
-from starlette.requests import Request
-from starlette.responses import JSONResponse, Response
+from starlette.responses import JSONResponse
 from starlette.routing import Route
 from starlette.testclient import TestClient
 from starlette.types import ASGIApp, Receive, Scope, Send
@@ -20,7 +20,7 @@ from modular_api.core.usecase_handler import usecase_handler
 
 
 @pytest.fixture(autouse=True)
-def _clean_registry() -> None:
+def _clean_registry() -> Iterator[None]:
     api_registry.clear()
     yield
     api_registry.clear()

--- a/code/py/modular_api/tests/plugin_host/test_plugin_host_lifecycle.py
+++ b/code/py/modular_api/tests/plugin_host/test_plugin_host_lifecycle.py
@@ -12,6 +12,7 @@ from modular_api import (
     PluginHostError,
     PluginManifest,
     PluginRequirement,
+    PluginRoute,
     PluginValidationResult,
 )
 
@@ -209,11 +210,11 @@ class LateRegistrationPlugin(RecordingPlugin):
     def register_late_route(self) -> None:
         assert self._host is not None
         self._host.register_route(
-            {
-                "id": "late-route",
-                "method": "GET",
-                "path": "/late",
-                "visibility": "custom",
-                "handler": lambda _context: {"status": 200, "body": {"ok": True}},
-            }
+            PluginRoute(
+                id="late-route",
+                method="GET",
+                path="/late",
+                visibility="custom",
+                handler=lambda _context: {"status": 200, "body": {"ok": True}},
+            )
         )

--- a/code/py/modular_api/tests/plugin_host/test_plugin_host_middleware_slots.py
+++ b/code/py/modular_api/tests/plugin_host/test_plugin_host_middleware_slots.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Iterator
 
 import pytest
 from starlette.requests import Request
-from starlette.responses import Response
 from starlette.testclient import TestClient
 from starlette.types import ASGIApp, Receive, Scope, Send
 
@@ -26,7 +25,7 @@ from modular_api.core.registry import api_registry
 
 
 @pytest.fixture(autouse=True)
-def _clean_registry() -> None:
+def _clean_registry() -> Iterator[None]:
     api_registry.clear()
     yield
     api_registry.clear()

--- a/code/py/modular_api/tests/plugin_host/test_stage0_plugin_host_red.py
+++ b/code/py/modular_api/tests/plugin_host/test_stage0_plugin_host_red.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from starlette.testclient import TestClient
 
-from modular_api import ModularApi, Plugin, PluginHost, PluginManifest
+from modular_api import ModularApi, Plugin, PluginHost, PluginManifest, PluginRoute
 
 
 class ProbePlugin(Plugin):
@@ -17,13 +17,13 @@ class ProbePlugin(Plugin):
 
     def setup(self, host: PluginHost) -> None:
         host.register_route(
-            {
-                "id": "probe-route",
-                "method": "GET",
-                "path": "/plugin-probe",
-                "visibility": "custom",
-                "handler": lambda _context: {"status": 200, "body": {"ok": True}},
-            }
+            PluginRoute(
+                id="probe-route",
+                method="GET",
+                path="/plugin-probe",
+                visibility="custom",
+                handler=lambda _context: {"status": 200, "body": {"ok": True}},
+            )
         )
 
 

--- a/code/py/modular_api/tests/test_auto_schema.py
+++ b/code/py/modular_api/tests/test_auto_schema.py
@@ -3,10 +3,22 @@
 from __future__ import annotations
 
 import warnings
+from typing import Any, cast
 
 from pydantic import BaseModel, Field
 
 from modular_api.core.usecase import Input, Output
+
+
+# `to_schema()` returns `dict[str, object]` — a generated JSON Schema is arbitrary nested JSON, and the
+# public signature says so rather than promising a shape it cannot check. These two readers are where
+# this test states the shape it expects, once, instead of at every assertion.
+def _properties(schema: dict[str, object]) -> dict[str, Any]:
+    return cast("dict[str, Any]", schema["properties"])
+
+
+def _required(schema: dict[str, object]) -> list[str]:
+    return cast("list[str]", schema.get("required", []))
 
 
 class TestInputIsBaseModel:
@@ -31,11 +43,12 @@ class TestInputIsBaseModel:
             name: str = Field(description="Name to greet")
 
         schema = NameInput.to_schema()
+        properties = _properties(schema)
         assert schema["type"] == "object"
-        assert "name" in schema["properties"]
-        assert schema["properties"]["name"]["type"] == "string"
-        assert schema["properties"]["name"]["description"] == "Name to greet"
-        assert "name" in schema["required"]
+        assert "name" in properties
+        assert properties["name"]["type"] == "string"
+        assert properties["name"]["description"] == "Name to greet"
+        assert "name" in _required(schema)
 
     def test_simple_input_from_json(self) -> None:
         """from_json() builds an Input instance from a plain dict."""
@@ -64,9 +77,9 @@ class TestInputIsBaseModel:
             optional_field: str | None = None
 
         schema = OptInput.to_schema()
-        assert "required_field" in schema["required"]
+        assert "required_field" in _required(schema)
         # optional_field should NOT be in required
-        assert "optional_field" not in schema.get("required", [])
+        assert "optional_field" not in _required(schema)
 
 
 class TestManualToSchemaDeprecation:

--- a/code/py/modular_api/tests/test_dto_typing.py
+++ b/code/py/modular_api/tests/test_dto_typing.py
@@ -1,0 +1,67 @@
+"""``from_json`` must hand back the subclass it was called on, not the base contract.
+
+**It did not.** ``Input.from_json`` and ``Output.from_json`` were annotated ``-> Input`` / ``-> Output``,
+so for every consumer DTO the inherited factory was declared to return the base class:
+
+    class CuentaInput(Input):
+        cuenta_id: str
+
+    parsed = CuentaInput.from_json(payload)   # declared: Input
+    parsed.cuenta_id                          # error: unknown attribute on "Input"
+
+The value at runtime was always the subclass — ``cls.model_validate`` builds ``cls`` — so nothing
+misbehaved. What broke was every consumer's type checker, which had to be silenced with a cast on each
+call to reach the fields the DTO exists to carry. This is the same shape of defect as annotating a
+TypeScript constructor parameter ``unknown[]``: the safe-looking base type in a position that needs the
+polymorphic one.
+
+These tests are checked twice over, and the static half is the point:
+
+- ``assert_type`` is a no-op at runtime and an *error at type-check time* when the declared type differs,
+  so reverting ``Self`` to ``Input`` makes pyright fail here even though pytest still passes.
+- the attribute reads below only type-check if the ``assert_type`` above them holds, which is what a
+  consumer actually does with the result.
+
+Mirror of ``usecase_class_types.test.ts``, which guards the equivalent TypeScript signature.
+"""
+
+from __future__ import annotations
+
+from typing import assert_type
+
+from modular_api.core.usecase import Input, Output
+
+
+class _ProbeInput(Input):
+    name: str
+
+
+class _ProbeOutput(Output):
+    greeting: str = ""
+
+    @property
+    def status_code(self) -> int:
+        return 200
+
+
+def test_input_from_json_returns_the_subclass() -> None:
+    parsed = _ProbeInput.from_json({"name": "socia"})
+
+    assert_type(parsed, _ProbeInput)
+    assert parsed.name == "socia"
+    assert isinstance(parsed, _ProbeInput)
+
+
+def test_output_from_json_returns_the_subclass() -> None:
+    parsed = _ProbeOutput.from_json({"greeting": "hola"})
+
+    assert_type(parsed, _ProbeOutput)
+    assert parsed.greeting == "hola"
+    assert isinstance(parsed, _ProbeOutput)
+
+
+def test_the_base_classes_still_declare_the_factory() -> None:
+    # `Self` is not a way of dropping the contract: both base classes still publish `from_json`, which is
+    # what the framework's handler calls without knowing the concrete DTO.
+    assert callable(Input.from_json)
+    assert callable(Output.from_json)

--- a/code/py/modular_api/tests/test_field_example.py
+++ b/code/py/modular_api/tests/test_field_example.py
@@ -6,9 +6,22 @@ and composes a top-level example from per-field values.
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 from pydantic import Field
 
 from modular_api.core.usecase import Input, Output
+
+
+# `to_schema()` returns `dict[str, object]` — a generated JSON Schema is arbitrary nested JSON, and the
+# public signature says so rather than promising a shape it cannot check. These two readers are where
+# this test states the shape it expects, once, instead of at every assertion.
+def _properties(schema: dict[str, object]) -> dict[str, Any]:
+    return cast("dict[str, Any]", schema["properties"])
+
+
+def _required(schema: dict[str, object]) -> list[str]:
+    return cast("list[str]", schema.get("required", []))
 
 
 # ── DTOs with example values ──────────────────────────────────
@@ -42,27 +55,27 @@ class TestFieldExampleMetadata:
 
     def test_string_field_example(self) -> None:
         schema = ExampleInput.to_schema()
-        props = schema["properties"]
+        props = _properties(schema)
         assert props["name"]["example"] == "Alice"
 
     def test_integer_field_example(self) -> None:
         schema = ExampleInput.to_schema()
-        props = schema["properties"]
+        props = _properties(schema)
         assert props["age"]["example"] == 30
 
     def test_number_field_example(self) -> None:
         schema = ExampleInput.to_schema()
-        props = schema["properties"]
+        props = _properties(schema)
         assert props["score"]["example"] == 9.5
 
     def test_boolean_field_example(self) -> None:
         schema = ExampleInput.to_schema()
-        props = schema["properties"]
+        props = _properties(schema)
         assert props["active"]["example"] is True
 
     def test_array_field_example(self) -> None:
         schema = ExampleInput.to_schema()
-        props = schema["properties"]
+        props = _properties(schema)
         assert props["tags"]["example"] == ["dart", "ts"]
 
 
@@ -85,6 +98,6 @@ class TestTopLevelExample:
 
     def test_no_example_omits_key(self) -> None:
         schema = NoExampleInput.to_schema()
-        props = schema["properties"]
+        props = _properties(schema)
         assert "example" not in props["name"]
         assert "example" not in schema

--- a/code/py/modular_api/tests/test_fromjson_validation.py
+++ b/code/py/modular_api/tests/test_fromjson_validation.py
@@ -8,7 +8,6 @@ Error message contract (identical across all 3 SDKs for parity):
   - Wrong JSON type:        "Field '{name}' must be of type {type}"
 """
 
-import json
 from typing import Any
 
 import pytest

--- a/code/py/modular_api/tests/test_modular_api.py
+++ b/code/py/modular_api/tests/test_modular_api.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+from collections.abc import Iterator
 import pytest
-from starlette.requests import Request
-from starlette.responses import PlainTextResponse
 from starlette.testclient import TestClient
 
 from modular_api.core.health.health_check import HealthCheck, HealthCheckResult, HealthStatus
@@ -64,13 +65,13 @@ class _AlwaysHealthyCheck(HealthCheck):
 
 
 @pytest.fixture(autouse=True)
-def _clean_registry():
+def _clean_registry() -> Iterator[None]:
     api_registry.clear()
     yield
     api_registry.clear()
 
 
-def _make_api(**overrides: object) -> ModularApi:
+def _make_api(**overrides: Any) -> ModularApi:
     """Create a ModularApi with sensible defaults."""
     defaults: dict = {
         "base_path": "/api",
@@ -153,7 +154,7 @@ class TestModularApiMetrics:
 class TestAutoMountedEndpoints:
     """build() auto-mounts operational endpoints under the shared base_path."""
 
-    def _build_client(self, **api_options: object) -> TestClient:
+    def _build_client(self, **api_options: Any) -> TestClient:
         api = _make_api(**api_options)
         api.module("test", lambda m: m.usecase("ping", _PingUseCase.from_json))
         app = api.build()
@@ -215,7 +216,7 @@ class TestAutoMountedEndpoints:
 class TestCustomServers:
     """ModularApi propagates servers to the OpenAPI spec."""
 
-    def _build_client(self, **api_options: object) -> TestClient:
+    def _build_client(self, **api_options: Any) -> TestClient:
         api = _make_api(**api_options)
         api.module("test", lambda m: m.usecase("ping", _PingUseCase.from_json))
         app = api.build()

--- a/code/py/modular_api/tests/test_packaging.py
+++ b/code/py/modular_api/tests/test_packaging.py
@@ -1,0 +1,96 @@
+"""The ``Typing :: Typed`` classifier and the ``py.typed`` marker must agree.
+
+**They did not.** All five Python packages declare ``Typing :: Typed``, which tells PyPI and anyone
+reading the metadata that the package ships type information. Only ``macss-modular-api`` actually
+shipped the ``py.typed`` marker. Under PEP 561 a package without that file is treated as **untyped**
+regardless of how thoroughly its source is annotated — every symbol a consumer imports becomes
+``Any``, silently. The classifier was a promise four of the five wheels did not keep.
+
+Verified against built wheels before writing this, not inferred: ``python -m build --wheel`` on
+``macss-modular-api-postgres`` produced an archive with no ``py.typed`` entry at all.
+
+This test lives in the core package but checks all five, because the failure is a *repo-wide*
+inconsistency and a per-package test would have to be added five times to catch it once.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+_PY_ROOT = Path(__file__).resolve().parents[2]
+
+_PACKAGES = (
+    "modular_api",
+    "modular_api_rest_client",
+    "modular_api_postgres",
+    "modular_api_graphql_client",
+    "modular_api_sqlserver",
+)
+
+
+def _manifest(package: str) -> dict[str, object]:
+    return tomllib.loads((_PY_ROOT / package / "pyproject.toml").read_text(encoding="utf-8"))
+
+
+def _import_package_dir(package: str) -> Path:
+    """The directory that becomes the importable package, i.e. the one holding ``__init__.py``.
+
+    Found rather than assumed: the distribution name, the directory under ``src/`` and the import name
+    are three different strings in this repo, and an ``egg-info`` directory sits alongside.
+    """
+    source = _PY_ROOT / package / "src"
+    candidates = [child for child in source.iterdir() if (child / "__init__.py").is_file()]
+    assert len(candidates) == 1, f"expected exactly one importable package under {source}"
+    return candidates[0]
+
+
+@pytest.mark.parametrize("package", _PACKAGES)
+def test_a_package_claiming_to_be_typed_ships_the_marker(package: str) -> None:
+    manifest = _manifest(package)
+    project = manifest["project"]
+    assert isinstance(project, dict)
+
+    classifiers = [str(c) for c in project.get("classifiers", [])]
+    claims_typed = "Typing :: Typed" in classifiers
+    marker = _import_package_dir(package) / "py.typed"
+
+    if claims_typed:
+        assert marker.is_file(), (
+            f"{package} declares the 'Typing :: Typed' classifier but ships no py.typed marker. "
+            "Under PEP 561 a consumer's type checker treats it as untyped, so every annotation in "
+            f"the source is discarded. Create {marker}."
+        )
+    else:
+        assert not marker.is_file(), (
+            f"{package} ships a py.typed marker but does not declare 'Typing :: Typed'. "
+            "The metadata should say what the wheel does."
+        )
+
+
+@pytest.mark.parametrize("package", _PACKAGES)
+def test_the_marker_is_inside_the_importable_package(package: str) -> None:
+    # Not in `src/`, not in an `egg-info` directory, not next to `pyproject.toml`. PEP 561 looks for
+    # `<package>/py.typed`, and a marker anywhere else lands in the wheel's `dist-info` — where no
+    # type checker will look. That is the mistake this test was written after making.
+    marker = _import_package_dir(package) / "py.typed"
+
+    if marker.is_file():
+        assert marker.parent.name != "src"
+        assert not marker.parent.name.endswith(".egg-info")
+        assert (marker.parent / "__init__.py").is_file()
+
+
+def test_every_package_declares_the_typed_classifier() -> None:
+    # Recorded as its own expectation rather than left implicit in the parametrized test above: all
+    # five packages are fully annotated and all five should say so. If one legitimately should not,
+    # this is the test to change, deliberately.
+    missing = [
+        package
+        for package in _PACKAGES
+        if "Typing :: Typed" not in [str(c) for c in (_manifest(package)["project"] or {}).get("classifiers", [])]  # type: ignore[union-attr]
+    ]
+
+    assert missing == [], f"these packages do not declare 'Typing :: Typed': {missing}"

--- a/code/py/modular_api/tests/test_usecase_handler.py
+++ b/code/py/modular_api/tests/test_usecase_handler.py
@@ -2,7 +2,6 @@
 
 import json
 
-import pytest
 from starlette.applications import Starlette
 from starlette.routing import Route
 from starlette.testclient import TestClient

--- a/code/py/modular_api_graphql_client/example/example.py
+++ b/code/py/modular_api_graphql_client/example/example.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 from modular_api_graphql_client import GraphqlRequest, ServiceClientConfig, graphql_client
 
 
@@ -14,7 +16,7 @@ def main() -> None:
             document="query GetUsers { users { id } }",
             operation_name="GetUsers",
         ),
-        decoder=lambda value: dict(value or {}),
+        decoder=lambda value: dict(cast("dict[str, Any]", value or {})),
     )
 
     if result.is_success:

--- a/code/py/modular_api_graphql_client/pyproject.toml
+++ b/code/py/modular_api_graphql_client/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = []
 
 [project.optional-dependencies]
 dev = [
+    # Configured below at `typeCheckingMode = "strict"`. Declared here because a checker the
+    # repo configures and never installs is a checker that has never run.
+    "pyright>=1.1.400",
     "pytest>=8.0",
 ]
 
@@ -43,4 +46,31 @@ pythonpath = ["src"]
 
 [tool.pyright]
 pythonVersion = "3.11"
+# `src/` is checked at full strict, because it is what a consumer's own type checker sees: these
+# packages ship `py.typed`, so every annotation here becomes part of the public contract.
 typeCheckingMode = "strict"
+
+# `tests/` is strict too, minus the family that means "annotate this expression". Test code binds
+# only this repo, and most of those diagnostics come from incomplete third-party stubs — annotating
+# around them adds noise to a test without making anything more correct. Everything that can indicate
+# a real defect stays on.
+[[tool.pyright.executionEnvironments]]
+root = "tests"
+reportUnknownMemberType = false
+reportUnknownArgumentType = false
+reportUnknownVariableType = false
+reportUnknownParameterType = false
+reportUnknownLambdaType = false
+reportMissingParameterType = false
+reportMissingTypeArgument = false
+# `example/` is documentation a consumer copies, not a published typed surface — same relaxed family
+# as `tests/`, and the same expectation that nothing which can indicate a real defect is silenced.
+[[tool.pyright.executionEnvironments]]
+root = "example"
+reportUnknownMemberType = false
+reportUnknownArgumentType = false
+reportUnknownVariableType = false
+reportUnknownParameterType = false
+reportUnknownLambdaType = false
+reportMissingParameterType = false
+reportMissingTypeArgument = false

--- a/code/py/modular_api_graphql_client/src/modular_api_graphql_client/client.py
+++ b/code/py/modular_api_graphql_client/src/modular_api_graphql_client/client.py
@@ -33,7 +33,7 @@ class ServiceClientConfig:
     service_id: str
     base_url: str
     redacted_summary: str
-    default_headers: Mapping[str, str] = field(default_factory=dict)
+    default_headers: Mapping[str, str] = field(default_factory=dict[str, str])
     auth_provider: ServiceAuthProvider | None = None
     timeout: float | None = None
     retry_policy: ServiceRetryPolicy | None = None
@@ -45,7 +45,7 @@ class ServiceClientConfig:
 class ServiceOperation:
     transport_id: str
     operation_id: str
-    headers: Mapping[str, str] = field(default_factory=dict)
+    headers: Mapping[str, str] = field(default_factory=dict[str, str])
     method: str | None = None
     path: str | None = None
     query: Mapping[str, object] | None = None
@@ -165,8 +165,8 @@ class GraphqlErrorLocation:
 @dataclass(frozen=True, slots=True)
 class GraphqlError:
     message: str
-    path: list[object] = field(default_factory=list)
-    locations: list[GraphqlErrorLocation] = field(default_factory=list)
+    path: list[object] = field(default_factory=list[object])
+    locations: list[GraphqlErrorLocation] = field(default_factory=list[GraphqlErrorLocation])
     extensions: dict[str, object] | None = None
 
 
@@ -199,7 +199,7 @@ class GraphqlClient:
         decoder: GraphqlDecoder[T] | None = None,
     ) -> ServiceResult[GraphqlResponse[T]]:
         if self._closed:
-            return ServiceResult.from_failure(
+            return ServiceResult[GraphqlResponse[T]].from_failure(
                 ServiceFailure(
                     category=ServiceFailureCategory.UNEXPECTED,
                     code="client_closed",
@@ -210,7 +210,7 @@ class GraphqlClient:
             )
 
         if _is_mutation_document(request.document or ""):
-            return ServiceResult.from_failure(
+            return ServiceResult[GraphqlResponse[T]].from_failure(
                 ServiceFailure(
                     category=ServiceFailureCategory.GRAPHQL,
                     code="mutation_not_supported",
@@ -247,13 +247,13 @@ class GraphqlClient:
                 header_map = _headers_to_record(response.headers)
                 envelope = _decode_envelope(response_text, response.headers.get_content_type())
                 if isinstance(envelope, ServiceFailure):
-                    result = ServiceResult.from_failure(envelope)
+                    result = ServiceResult[GraphqlResponse[T]].from_failure(envelope)
                 else:
                     decoded = _decode_data(envelope.get("data"), decoder)
                     if isinstance(decoded, ServiceFailure):
-                        result = ServiceResult.from_failure(decoded)
+                        result = ServiceResult[GraphqlResponse[T]].from_failure(decoded)
                     else:
-                        result = ServiceResult.success(
+                        result = ServiceResult[GraphqlResponse[T]].success(
                             GraphqlResponse(
                                 data=decoded,
                                 errors=_parse_errors(envelope.get("errors")),
@@ -269,7 +269,7 @@ class GraphqlClient:
                         )
         except urllib.error.HTTPError as error:
             details = error.read().decode("utf-8")
-            result = ServiceResult.from_failure(
+            result = ServiceResult[GraphqlResponse[T]].from_failure(
                 ServiceFailure(
                     category=_category_for_status(error.code),
                     code=_code_for_status(error.code),
@@ -283,7 +283,7 @@ class GraphqlClient:
         except urllib.error.URLError as error:
             reason = error.reason
             if isinstance(reason, (TimeoutError, socket.timeout)):
-                result = ServiceResult.from_failure(
+                result = ServiceResult[GraphqlResponse[T]].from_failure(
                     ServiceFailure(
                         category=ServiceFailureCategory.TIMEOUT,
                         code="timeout",
@@ -294,7 +294,7 @@ class GraphqlClient:
                     )
                 )
             else:
-                result = ServiceResult.from_failure(
+                result = ServiceResult[GraphqlResponse[T]].from_failure(
                     ServiceFailure(
                         category=ServiceFailureCategory.TRANSPORT,
                         code="transport_error",
@@ -305,7 +305,7 @@ class GraphqlClient:
                     )
                 )
         except (TimeoutError, socket.timeout) as error:
-            result = ServiceResult.from_failure(
+            result = ServiceResult[GraphqlResponse[T]].from_failure(
                 ServiceFailure(
                     category=ServiceFailureCategory.TIMEOUT,
                     code="timeout",
@@ -316,7 +316,7 @@ class GraphqlClient:
                 )
             )
         except Exception as error:  # noqa: BLE001
-            result = ServiceResult.from_failure(
+            result = ServiceResult[GraphqlResponse[T]].from_failure(
                 ServiceFailure(
                     category=ServiceFailureCategory.UNEXPECTED,
                     code="unexpected_error",
@@ -333,7 +333,7 @@ class GraphqlClient:
 
     def close(self) -> ServiceResult[None]:
         self._closed = True
-        return ServiceResult.success(None)
+        return ServiceResult[None].success(None)
 
     def _build_headers(self, request: GraphqlRequest) -> dict[str, str]:
         headers = {
@@ -459,33 +459,46 @@ def _decode_data(
 
 
 def _parse_errors(value: object | None) -> list[GraphqlError]:
+    """Parses the ``errors`` array of a GraphQL response.
+
+    Every value here arrives from JSON, so nothing may be assumed about its shape. The narrowing was
+    already correct — each access sat behind an ``isinstance`` — but a bare ``isinstance(x, dict)``
+    narrows only to ``dict[Unknown, Unknown]``, so the checker still could not see what came out. The
+    casts below carry the shape the guard has already established; they add no runtime behaviour and
+    replace four redundant re-checks of a condition the loop had already decided.
+    """
     if not isinstance(value, list):
         return []
 
     errors: list[GraphqlError] = []
-    for entry in value:
-        error = entry if isinstance(entry, dict) else {}
-        raw_locations = error.get("locations") if isinstance(error, dict) else None
-        locations: list[GraphqlErrorLocation] = []
-        if isinstance(raw_locations, list):
-            for location in raw_locations:
-                if isinstance(location, dict):
-                    line = location.get("line")
-                    column = location.get("column")
-                    locations.append(
-                        GraphqlErrorLocation(
-                            line=line if isinstance(line, int) else 0,
-                            column=column if isinstance(column, int) else 0,
-                        )
-                    )
+    for entry in cast("list[object]", value):
+        if not isinstance(entry, dict):
+            continue
+        error = cast("dict[str, object]", entry)
 
-        message = error.get("message", "Unknown GraphQL error") if isinstance(error, dict) else "Unknown GraphQL error"
+        locations: list[GraphqlErrorLocation] = []
+        raw_locations = error.get("locations")
+        if isinstance(raw_locations, list):
+            for raw_location in cast("list[object]", raw_locations):
+                if not isinstance(raw_location, dict):
+                    continue
+                location = cast("dict[str, object]", raw_location)
+                line = location.get("line")
+                column = location.get("column")
+                locations.append(
+                    GraphqlErrorLocation(
+                        line=line if isinstance(line, int) else 0,
+                        column=column if isinstance(column, int) else 0,
+                    )
+                )
+
+        raw_path = error.get("path")
         errors.append(
             GraphqlError(
-                message=str(message),
-                path=list(error.get("path", [])) if isinstance(error, dict) and isinstance(error.get("path"), list) else [],
+                message=str(error.get("message", "Unknown GraphQL error")),
+                path=list(cast("list[object]", raw_path)) if isinstance(raw_path, list) else [],
                 locations=locations,
-                extensions=_parse_extensions(error.get("extensions")) if isinstance(error, dict) else None,
+                extensions=_parse_extensions(error.get("extensions")),
             )
         )
 
@@ -495,7 +508,7 @@ def _parse_errors(value: object | None) -> list[GraphqlError]:
 def _parse_extensions(value: object | None) -> dict[str, object] | None:
     if not isinstance(value, dict):
         return None
-    return {str(key): item for key, item in value.items()}
+    return {str(key): item for key, item in cast("dict[object, object]", value).items()}
 
 
 def _is_mutation_document(document: str) -> bool:

--- a/code/py/modular_api_graphql_client/tests/test_graphql_client.py
+++ b/code/py/modular_api_graphql_client/tests/test_graphql_client.py
@@ -5,6 +5,7 @@ import threading
 import time
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, cast
 
 from modular_api_graphql_client import (
     GraphqlClient,
@@ -69,7 +70,7 @@ def test_graphql_client_sends_a_post_request_and_decodes_the_envelope() -> None:
                 variables={"limit": 10},
                 headers={"x-request": "test"},
             ),
-            decoder=lambda value: dict(value or {}),
+            decoder=lambda value: dict(cast("dict[str, Any]", value or {})),
         )
 
         assert result.is_success is True
@@ -150,7 +151,7 @@ def test_graphql_client_injects_auth_headers_from_the_auth_provider() -> None:
                 operation_id="users.auth",
                 document="query Viewer { viewer { id } }",
             ),
-            decoder=lambda value: dict(value or {}),
+            decoder=lambda value: dict(cast("dict[str, Any]", value or {})),
         )
 
         assert result.is_success is True

--- a/code/py/modular_api_postgres/example/example.py
+++ b/code/py/modular_api_postgres/example/example.py
@@ -10,7 +10,12 @@ from modular_api_postgres import (
     DbRowSet,
     DbScalar,
     DbSessionLease,
+    DbTransactionContext,
 )
+from collections.abc import Callable
+from typing import TypeVar
+
+_T = TypeVar("_T")
 
 
 def main() -> None:
@@ -87,7 +92,9 @@ class _FakeCommandExecutor:
             )
         )
 
-    def scalar(self, session: str, command: DbCommand) -> DbResult[DbScalar[int]]:
+    # `DbScalar[object]`, matching `DbCommandExecutor`: the protocol cannot promise a narrower value
+    # type, and `DbScalar[int]` is not a `DbScalar[object]` — these containers are invariant.
+    def scalar(self, session: str, command: DbCommand) -> DbResult[DbScalar[object]]:
         del session
         return DbResult.success(
             DbScalar(
@@ -98,7 +105,13 @@ class _FakeCommandExecutor:
 
 
 class _PassthroughTransactionRunner:
-    def run(self, context, body):
+    # Generic in the body's result, like `DbTransactionRunner.run`: a runner does not decide what the
+    # body returns, it only decides whether to commit.
+    def run(
+        self,
+        context: DbTransactionContext[str],
+        body: Callable[[DbTransactionContext[str]], DbResult[_T]],
+    ) -> DbResult[_T]:
         return body(context)
 
 

--- a/code/py/modular_api_postgres/pyproject.toml
+++ b/code/py/modular_api_postgres/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = []
 
 [project.optional-dependencies]
 dev = [
+    # Configured below at `typeCheckingMode = "strict"`. Declared here because a checker the
+    # repo configures and never installs is a checker that has never run.
+    "pyright>=1.1.400",
     "pytest>=8.0",
 ]
 
@@ -43,4 +46,31 @@ pythonpath = ["src"]
 
 [tool.pyright]
 pythonVersion = "3.11"
+# `src/` is checked at full strict, because it is what a consumer's own type checker sees: these
+# packages ship `py.typed`, so every annotation here becomes part of the public contract.
 typeCheckingMode = "strict"
+
+# `tests/` is strict too, minus the family that means "annotate this expression". Test code binds
+# only this repo, and most of those diagnostics come from incomplete third-party stubs — annotating
+# around them adds noise to a test without making anything more correct. Everything that can indicate
+# a real defect stays on.
+[[tool.pyright.executionEnvironments]]
+root = "tests"
+reportUnknownMemberType = false
+reportUnknownArgumentType = false
+reportUnknownVariableType = false
+reportUnknownParameterType = false
+reportUnknownLambdaType = false
+reportMissingParameterType = false
+reportMissingTypeArgument = false
+# `example/` is documentation a consumer copies, not a published typed surface — same relaxed family
+# as `tests/`, and the same expectation that nothing which can indicate a real defect is silenced.
+[[tool.pyright.executionEnvironments]]
+root = "example"
+reportUnknownMemberType = false
+reportUnknownArgumentType = false
+reportUnknownVariableType = false
+reportUnknownParameterType = false
+reportUnknownLambdaType = false
+reportMissingParameterType = false
+reportMissingTypeArgument = false

--- a/code/py/modular_api_postgres/src/modular_api_postgres/db_client.py
+++ b/code/py/modular_api_postgres/src/modular_api_postgres/db_client.py
@@ -7,6 +7,8 @@ from enum import Enum
 from typing import Callable, Generic, Mapping, Protocol, TypeVar, cast
 
 S = TypeVar("S")
+#: Contravariant because the protocols below only ever *accept* a session, never return one.
+S_contra = TypeVar("S_contra", contravariant=True)
 T = TypeVar("T")
 R = TypeVar("R")
 _MISSING = object()
@@ -52,7 +54,7 @@ class DbConnectionSettings:
     username: str
     password: str
     ssl_mode: str
-    options: Mapping[str, object] = field(default_factory=dict)
+    options: Mapping[str, object] = field(default_factory=dict[str, object])
 
     @classmethod
     def from_environment(
@@ -203,18 +205,18 @@ class DbResult(Generic[T]):
 
     def map(self, transform: Callable[[T], R]) -> DbResult[R]:
         if self.is_failure:
-            return DbResult.from_failure(self.failure)
-        return DbResult.success(transform(self.value))
+            return DbResult[R].from_failure(self.failure)
+        return DbResult[R].success(transform(self.value))
 
     def flat_map(self, transform: Callable[[T], DbResult[R]]) -> DbResult[R]:
         if self.is_failure:
-            return DbResult.from_failure(self.failure)
+            return DbResult[R].from_failure(self.failure)
         return transform(self.value)
 
     def map_failure(self, transform: Callable[[DbFailure], DbFailure]) -> DbResult[T]:
         if self.is_success:
-            return DbResult.success(self.value)
-        return DbResult.from_failure(transform(self.failure))
+            return DbResult[T].success(self.value)
+        return DbResult[T].from_failure(transform(self.failure))
 
     def get_or_throw(self, message: str | None = None) -> T:
         if self.is_failure:
@@ -244,7 +246,7 @@ class DbSessionLease(Generic[S]):
 
     def release(self) -> DbResult[None]:
         if not self.owned_by_package:
-            return DbResult.success(None)
+            return DbResult[None].success(None)
         return self._releaser()
 
 
@@ -256,12 +258,16 @@ class DbSessionProvider(Protocol[S]):
     def describe(self) -> DbProviderDescription: ...
 
 
-class DbCommandExecutor(Protocol[S]):
-    def query(self, session: S, command: DbCommand) -> DbResult[DbRowSet]: ...
+class DbCommandExecutor(Protocol[S_contra]):
+    def query(self, session: S_contra, command: DbCommand) -> DbResult[DbRowSet]: ...
 
-    def execute(self, session: S, command: DbCommand) -> DbResult[DbExecutionSummary]: ...
+    def execute(
+        self, session: S_contra, command: DbCommand
+    ) -> DbResult[DbExecutionSummary]: ...
 
-    def scalar(self, session: S, command: DbCommand) -> DbResult[DbScalar[object]]: ...
+    def scalar(
+        self, session: S_contra, command: DbCommand
+    ) -> DbResult[DbScalar[object]]: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -276,8 +282,8 @@ class DbTransactionContext(Generic[S]):
     def execute(self, command: DbCommand) -> DbResult[DbExecutionSummary]:
         return self.command_executor.execute(self.session, command)
 
-    def scalar(self, command: DbCommand) -> DbResult[DbScalar[T]]:
-        return cast(DbResult[DbScalar[T]], self.command_executor.scalar(self.session, command))
+    def scalar(self, command: DbCommand) -> DbResult[DbScalar[object]]:
+        return self.command_executor.scalar(self.session, command)
 
 
 class DbTransactionRunner(Protocol[S]):
@@ -312,13 +318,10 @@ class DbRepository(Generic[S]):
             lambda lease: self.context.command_executor.execute(lease.session, command),
         )
 
-    def scalar(self, command: DbCommand) -> DbResult[DbScalar[T]]:
-        return cast(
-            DbResult[DbScalar[T]],
-            _with_lease(
-                self.context.session_provider,
-                lambda lease: self.context.command_executor.scalar(lease.session, command),
-            ),
+    def scalar(self, command: DbCommand) -> DbResult[DbScalar[object]]:
+        return _with_lease(
+            self.context.session_provider,
+            lambda lease: self.context.command_executor.scalar(lease.session, command),
         )
 
     def transaction(self, body: Callable[[DbTransactionContext[S]], DbResult[T]]) -> DbResult[T]:
@@ -357,19 +360,16 @@ class DbClient(Generic[S]):
             lambda lease: self.command_executor.execute(lease.session, command),
         )
 
-    def scalar(self, command: DbCommand) -> DbResult[DbScalar[T]]:
-        return cast(
-            DbResult[DbScalar[T]],
-            _with_lease(
-                self.session_provider,
-                lambda lease: self.command_executor.scalar(lease.session, command),
-            ),
+    def scalar(self, command: DbCommand) -> DbResult[DbScalar[object]]:
+        return _with_lease(
+            self.session_provider,
+            lambda lease: self.command_executor.scalar(lease.session, command),
         )
 
     def transaction(self, body: Callable[[DbTransactionContext[S]], DbResult[T]]) -> DbResult[T]:
         lease_result = self.session_provider.acquire()
         if lease_result.is_failure:
-            return DbResult.from_failure(lease_result.failure)
+            return DbResult[T].from_failure(lease_result.failure)
 
         lease = lease_result.value
         context = DbTransactionContext(
@@ -381,9 +381,9 @@ class DbClient(Generic[S]):
         release_result = lease.release()
 
         if result.is_failure:
-            return DbResult.from_failure(result.failure)
+            return DbResult[T].from_failure(result.failure)
         if release_result.is_failure:
-            return DbResult.from_failure(release_result.failure)
+            return DbResult[T].from_failure(release_result.failure)
         return result
 
     def repository_context(self) -> DbRepositoryContext[S]:
@@ -454,14 +454,14 @@ def _with_lease(
 ) -> DbResult[T]:
     lease_result = session_provider.acquire()
     if lease_result.is_failure:
-        return DbResult.from_failure(lease_result.failure)
+        return DbResult[T].from_failure(lease_result.failure)
 
     lease = lease_result.value
     operation_result = operation(lease)
     release_result = lease.release()
 
     if operation_result.is_failure:
-        return DbResult.from_failure(operation_result.failure)
+        return DbResult[T].from_failure(operation_result.failure)
     if release_result.is_failure:
-        return DbResult.from_failure(release_result.failure)
+        return DbResult[T].from_failure(release_result.failure)
     return operation_result

--- a/code/py/modular_api_postgres/tests/test_db_client.py
+++ b/code/py/modular_api_postgres/tests/test_db_client.py
@@ -4,6 +4,11 @@ from dataclasses import dataclass
 
 import pytest
 
+from collections.abc import Callable
+from typing import TypeVar, cast
+
+_T = TypeVar("_T")
+
 from modular_api_postgres import (
     DbClient,
     DbCommand,
@@ -116,6 +121,7 @@ def test_client_delegates_query_calls_and_releases_package_owned_leases() -> Non
     assert provider.acquire_count == 1
     assert provider.release_count == 1
     assert executor.last_session == "db-session"
+    assert executor.last_command is not None
     assert executor.last_command.label == "users.list"
 
 
@@ -304,6 +310,7 @@ def test_repository_helpers_stay_thin_over_the_shared_context() -> None:
 
     assert result.is_success is True
     assert result.value == 9
+    assert executor.last_command is not None
     assert executor.last_command.label == "users.count"
 
 
@@ -459,8 +466,12 @@ class _FakeTransactionRunner:
     def run(
         self,
         context: DbTransactionContext[str],
-        body: callable,
-    ) -> DbResult[object]:
+        # Two fixes in one signature. `callable` is the builtin predicate, not a type — annotating with
+        # it left this fake failing to satisfy `DbTransactionRunner[str]`, which is the whole point of a
+        # fake. And `run` is generic in the body's result: pinning it to `object` still would not have
+        # satisfied the protocol, because a runner is transparent in what the body returns.
+        body: Callable[[DbTransactionContext[str]], DbResult[_T]],
+    ) -> DbResult[_T]:
         result = body(context)
         if result.is_success:
             self.commit_count += 1
@@ -478,7 +489,9 @@ class _UserStatsRepository(DbRepository[str]):
                 label="users.count",
             )
         )
-        return result.map(lambda value: int(value.value))
+        # `scalar()` yields `DbScalar[object]`: Python cannot parameterise a method call the way Dart
+        # and TypeScript can, so a consumer narrows the value it knows its own query returns.
+        return result.map(lambda value: int(cast("int | str", value.value)))
 
 
 # --- 0.6.0: typed parameters and stored-procedure support ---

--- a/code/py/modular_api_postgres/tests/test_db_conformance.py
+++ b/code/py/modular_api_postgres/tests/test_db_conformance.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any, cast
 
 from modular_api_postgres import (
     DbCommand,
@@ -15,12 +16,14 @@ from modular_api_postgres import (
 )
 
 
-def _load_fixture() -> dict[str, object]:
-    return json.loads(
+def _load_fixture() -> dict[str, Any]:
+    # `dict[str, Any]`, not `dict[str, object]`: every read below walks into the fixture, and `object`
+    # stops at the first subscript. The values really are arbitrary JSON.
+    return cast("dict[str, Any]", json.loads(
         (Path(__file__).resolve().parents[3] / "tests" / "fixtures" / "db_client" / "postgres.json").read_text(
             encoding="utf-8"
         )
-    )
+    ))
 
 
 def test_matches_the_shared_postgres_connection_fixture() -> None:

--- a/code/py/modular_api_rest_client/pyproject.toml
+++ b/code/py/modular_api_rest_client/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = []
 
 [project.optional-dependencies]
 dev = [
+    # Configured below at `typeCheckingMode = "strict"`. Declared here because a checker the
+    # repo configures and never installs is a checker that has never run.
+    "pyright>=1.1.400",
     "pytest>=8.0",
 ]
 
@@ -43,4 +46,31 @@ pythonpath = ["src"]
 
 [tool.pyright]
 pythonVersion = "3.11"
+# `src/` is checked at full strict, because it is what a consumer's own type checker sees: these
+# packages ship `py.typed`, so every annotation here becomes part of the public contract.
 typeCheckingMode = "strict"
+
+# `tests/` is strict too, minus the family that means "annotate this expression". Test code binds
+# only this repo, and most of those diagnostics come from incomplete third-party stubs — annotating
+# around them adds noise to a test without making anything more correct. Everything that can indicate
+# a real defect stays on.
+[[tool.pyright.executionEnvironments]]
+root = "tests"
+reportUnknownMemberType = false
+reportUnknownArgumentType = false
+reportUnknownVariableType = false
+reportUnknownParameterType = false
+reportUnknownLambdaType = false
+reportMissingParameterType = false
+reportMissingTypeArgument = false
+# `example/` is documentation a consumer copies, not a published typed surface — same relaxed family
+# as `tests/`, and the same expectation that nothing which can indicate a real defect is silenced.
+[[tool.pyright.executionEnvironments]]
+root = "example"
+reportUnknownMemberType = false
+reportUnknownArgumentType = false
+reportUnknownVariableType = false
+reportUnknownParameterType = false
+reportUnknownLambdaType = false
+reportMissingParameterType = false
+reportMissingTypeArgument = false

--- a/code/py/modular_api_rest_client/src/modular_api_rest_client/client.py
+++ b/code/py/modular_api_rest_client/src/modular_api_rest_client/client.py
@@ -33,7 +33,7 @@ class ServiceClientConfig:
     service_id: str
     base_url: str
     redacted_summary: str
-    default_headers: Mapping[str, str] = field(default_factory=dict)
+    default_headers: Mapping[str, str] = field(default_factory=dict[str, str])
     auth_provider: ServiceAuthProvider | None = None
     timeout: float | None = None
     retry_policy: ServiceRetryPolicy | None = None
@@ -45,7 +45,7 @@ class ServiceClientConfig:
 class ServiceOperation:
     transport_id: str
     operation_id: str
-    headers: Mapping[str, str] = field(default_factory=dict)
+    headers: Mapping[str, str] = field(default_factory=dict[str, str])
     method: str | None = None
     path: str | None = None
     query: Mapping[str, object] | None = None
@@ -182,7 +182,7 @@ class HttpServiceClient:
         decoder: ServiceDecoder[T] | None = None,
     ) -> ServiceResult[ServiceResponse[T]]:
         if self._closed:
-            return ServiceResult.from_failure(
+            return ServiceResult[ServiceResponse[T]].from_failure(
                 ServiceFailure(
                     category=ServiceFailureCategory.UNEXPECTED,
                     code="client_closed",
@@ -193,7 +193,7 @@ class HttpServiceClient:
             )
 
         if operation.transport_id != "http" or operation.method is None or operation.path is None:
-            return ServiceResult.from_failure(
+            return ServiceResult[ServiceResponse[T]].from_failure(
                 ServiceFailure(
                     category=ServiceFailureCategory.PROTOCOL,
                     code="invalid_operation",
@@ -224,9 +224,9 @@ class HttpServiceClient:
 
                 decoded = _decode_body(response_text, response.headers.get_content_type(), decoder)
                 if isinstance(decoded, ServiceFailure):
-                    result = ServiceResult.from_failure(decoded)
+                    result = ServiceResult[ServiceResponse[T]].from_failure(decoded)
                 else:
-                    result = ServiceResult.success(
+                    result = ServiceResult[ServiceResponse[T]].success(
                         ServiceResponse(
                             data=decoded,
                             metadata=ServiceResponseMetadata(
@@ -240,7 +240,7 @@ class HttpServiceClient:
                     )
         except urllib.error.HTTPError as error:
             details = error.read().decode("utf-8")
-            result = ServiceResult.from_failure(
+            result = ServiceResult[ServiceResponse[T]].from_failure(
                 ServiceFailure(
                     category=_category_for_status(error.code),
                     code=_code_for_status(error.code),
@@ -254,7 +254,7 @@ class HttpServiceClient:
         except urllib.error.URLError as error:
             reason = error.reason
             if isinstance(reason, (TimeoutError, socket.timeout)):
-                result = ServiceResult.from_failure(
+                result = ServiceResult[ServiceResponse[T]].from_failure(
                     ServiceFailure(
                         category=ServiceFailureCategory.TIMEOUT,
                         code="timeout",
@@ -265,7 +265,7 @@ class HttpServiceClient:
                     )
                 )
             else:
-                result = ServiceResult.from_failure(
+                result = ServiceResult[ServiceResponse[T]].from_failure(
                     ServiceFailure(
                         category=ServiceFailureCategory.TRANSPORT,
                         code="transport_error",
@@ -276,7 +276,7 @@ class HttpServiceClient:
                     )
                 )
         except (TimeoutError, socket.timeout) as error:
-            result = ServiceResult.from_failure(
+            result = ServiceResult[ServiceResponse[T]].from_failure(
                 ServiceFailure(
                     category=ServiceFailureCategory.TIMEOUT,
                     code="timeout",
@@ -287,7 +287,7 @@ class HttpServiceClient:
                 )
             )
         except Exception as error:  # noqa: BLE001
-            result = ServiceResult.from_failure(
+            result = ServiceResult[ServiceResponse[T]].from_failure(
                 ServiceFailure(
                     category=ServiceFailureCategory.UNEXPECTED,
                     code="unexpected_error",
@@ -304,7 +304,7 @@ class HttpServiceClient:
 
     def close(self) -> ServiceResult[None]:
         self._closed = True
-        return ServiceResult.success(None)
+        return ServiceResult[None].success(None)
 
     def _build_headers(self, operation: ServiceOperation) -> dict[str, str]:
         headers = {

--- a/code/py/modular_api_rest_client/tests/test_http_client.py
+++ b/code/py/modular_api_rest_client/tests/test_http_client.py
@@ -6,6 +6,7 @@ import time
 import urllib.parse
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, cast
 
 from modular_api_rest_client import (
     HttpServiceClient,
@@ -61,7 +62,7 @@ def test_http_client_sends_a_get_request_decodes_json_and_preserves_metadata() -
                 query={"name": "ana"},
                 headers={"x-request": "test"},
             ),
-            decoder=lambda value: dict(value),
+            decoder=lambda value: dict(cast("dict[str, Any]", value)),
         )
 
         assert result.is_success is True
@@ -127,7 +128,7 @@ def test_http_client_injects_auth_headers_from_the_auth_provider() -> None:
                 method="GET",
                 path="/users",
             ),
-            decoder=lambda value: dict(value),
+            decoder=lambda value: dict(cast("dict[str, Any]", value)),
         )
 
         assert result.is_success is True

--- a/code/py/modular_api_sqlserver/example/example.py
+++ b/code/py/modular_api_sqlserver/example/example.py
@@ -10,7 +10,12 @@ from modular_api_sqlserver import (
     DbRowSet,
     DbScalar,
     DbSessionLease,
+    DbTransactionContext,
 )
+from collections.abc import Callable
+from typing import TypeVar
+
+_T = TypeVar("_T")
 
 
 def main() -> None:
@@ -87,7 +92,9 @@ class _FakeCommandExecutor:
             )
         )
 
-    def scalar(self, session: str, command: DbCommand) -> DbResult[DbScalar[int]]:
+    # `DbScalar[object]`, matching `DbCommandExecutor`: the protocol cannot promise a narrower value
+    # type, and `DbScalar[int]` is not a `DbScalar[object]` — these containers are invariant.
+    def scalar(self, session: str, command: DbCommand) -> DbResult[DbScalar[object]]:
         del session
         return DbResult.success(
             DbScalar(
@@ -98,7 +105,13 @@ class _FakeCommandExecutor:
 
 
 class _PassthroughTransactionRunner:
-    def run(self, context, body):
+    # Generic in the body's result, like `DbTransactionRunner.run`: a runner does not decide what the
+    # body returns, it only decides whether to commit.
+    def run(
+        self,
+        context: DbTransactionContext[str],
+        body: Callable[[DbTransactionContext[str]], DbResult[_T]],
+    ) -> DbResult[_T]:
         return body(context)
 
 

--- a/code/py/modular_api_sqlserver/pyproject.toml
+++ b/code/py/modular_api_sqlserver/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = []
 
 [project.optional-dependencies]
 dev = [
+    # Configured below at `typeCheckingMode = "strict"`. Declared here because a checker the
+    # repo configures and never installs is a checker that has never run.
+    "pyright>=1.1.400",
     "pytest>=8.0",
 ]
 
@@ -43,4 +46,31 @@ pythonpath = ["src"]
 
 [tool.pyright]
 pythonVersion = "3.11"
+# `src/` is checked at full strict, because it is what a consumer's own type checker sees: these
+# packages ship `py.typed`, so every annotation here becomes part of the public contract.
 typeCheckingMode = "strict"
+
+# `tests/` is strict too, minus the family that means "annotate this expression". Test code binds
+# only this repo, and most of those diagnostics come from incomplete third-party stubs — annotating
+# around them adds noise to a test without making anything more correct. Everything that can indicate
+# a real defect stays on.
+[[tool.pyright.executionEnvironments]]
+root = "tests"
+reportUnknownMemberType = false
+reportUnknownArgumentType = false
+reportUnknownVariableType = false
+reportUnknownParameterType = false
+reportUnknownLambdaType = false
+reportMissingParameterType = false
+reportMissingTypeArgument = false
+# `example/` is documentation a consumer copies, not a published typed surface — same relaxed family
+# as `tests/`, and the same expectation that nothing which can indicate a real defect is silenced.
+[[tool.pyright.executionEnvironments]]
+root = "example"
+reportUnknownMemberType = false
+reportUnknownArgumentType = false
+reportUnknownVariableType = false
+reportUnknownParameterType = false
+reportUnknownLambdaType = false
+reportMissingParameterType = false
+reportMissingTypeArgument = false

--- a/code/py/modular_api_sqlserver/src/modular_api_sqlserver/db_client.py
+++ b/code/py/modular_api_sqlserver/src/modular_api_sqlserver/db_client.py
@@ -4,9 +4,11 @@ import os
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Generic, Mapping, Protocol, TypeVar, cast
+from typing import Callable, Generic, Mapping, Protocol, TypeVar, cast
 
 S = TypeVar("S")
+#: Contravariant because the protocols below only ever *accept* a session, never return one.
+S_contra = TypeVar("S_contra", contravariant=True)
 T = TypeVar("T")
 R = TypeVar("R")
 _MISSING = object()
@@ -52,7 +54,7 @@ class DbConnectionSettings:
     username: str
     password: str
     driver: str
-    options: Mapping[str, object] = field(default_factory=dict)
+    options: Mapping[str, object] = field(default_factory=dict[str, object])
 
     @classmethod
     def from_environment(
@@ -206,18 +208,18 @@ class DbResult(Generic[T]):
 
     def map(self, transform: Callable[[T], R]) -> DbResult[R]:
         if self.is_failure:
-            return DbResult.from_failure(self.failure)
-        return DbResult.success(transform(self.value))
+            return DbResult[R].from_failure(self.failure)
+        return DbResult[R].success(transform(self.value))
 
     def flat_map(self, transform: Callable[[T], DbResult[R]]) -> DbResult[R]:
         if self.is_failure:
-            return DbResult.from_failure(self.failure)
+            return DbResult[R].from_failure(self.failure)
         return transform(self.value)
 
     def map_failure(self, transform: Callable[[DbFailure], DbFailure]) -> DbResult[T]:
         if self.is_success:
-            return DbResult.success(self.value)
-        return DbResult.from_failure(transform(self.failure))
+            return DbResult[T].success(self.value)
+        return DbResult[T].from_failure(transform(self.failure))
 
     def get_or_throw(self, message: str | None = None) -> T:
         if self.is_failure:
@@ -247,7 +249,7 @@ class DbSessionLease(Generic[S]):
 
     def release(self) -> DbResult[None]:
         if not self.owned_by_package:
-            return DbResult.success(None)
+            return DbResult[None].success(None)
         return self._releaser()
 
 
@@ -259,12 +261,16 @@ class DbSessionProvider(Protocol[S]):
     def describe(self) -> DbProviderDescription: ...
 
 
-class DbCommandExecutor(Protocol[S]):
-    def query(self, session: S, command: DbCommand) -> DbResult[DbRowSet]: ...
+class DbCommandExecutor(Protocol[S_contra]):
+    def query(self, session: S_contra, command: DbCommand) -> DbResult[DbRowSet]: ...
 
-    def execute(self, session: S, command: DbCommand) -> DbResult[DbExecutionSummary]: ...
+    def execute(
+        self, session: S_contra, command: DbCommand
+    ) -> DbResult[DbExecutionSummary]: ...
 
-    def scalar(self, session: S, command: DbCommand) -> DbResult[DbScalar[object]]: ...
+    def scalar(
+        self, session: S_contra, command: DbCommand
+    ) -> DbResult[DbScalar[object]]: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -279,8 +285,8 @@ class DbTransactionContext(Generic[S]):
     def execute(self, command: DbCommand) -> DbResult[DbExecutionSummary]:
         return self.command_executor.execute(self.session, command)
 
-    def scalar(self, command: DbCommand) -> DbResult[DbScalar[T]]:
-        return cast(DbResult[DbScalar[T]], self.command_executor.scalar(self.session, command))
+    def scalar(self, command: DbCommand) -> DbResult[DbScalar[object]]:
+        return self.command_executor.scalar(self.session, command)
 
 
 class DbTransactionRunner(Protocol[S]):
@@ -315,13 +321,10 @@ class DbRepository(Generic[S]):
             lambda lease: self.context.command_executor.execute(lease.session, command),
         )
 
-    def scalar(self, command: DbCommand) -> DbResult[DbScalar[T]]:
-        return cast(
-            DbResult[DbScalar[T]],
-            _with_lease(
-                self.context.session_provider,
-                lambda lease: self.context.command_executor.scalar(lease.session, command),
-            ),
+    def scalar(self, command: DbCommand) -> DbResult[DbScalar[object]]:
+        return _with_lease(
+            self.context.session_provider,
+            lambda lease: self.context.command_executor.scalar(lease.session, command),
         )
 
     def transaction(self, body: Callable[[DbTransactionContext[S]], DbResult[T]]) -> DbResult[T]:
@@ -360,19 +363,16 @@ class DbClient(Generic[S]):
             lambda lease: self.command_executor.execute(lease.session, command),
         )
 
-    def scalar(self, command: DbCommand) -> DbResult[DbScalar[T]]:
-        return cast(
-            DbResult[DbScalar[T]],
-            _with_lease(
-                self.session_provider,
-                lambda lease: self.command_executor.scalar(lease.session, command),
-            ),
+    def scalar(self, command: DbCommand) -> DbResult[DbScalar[object]]:
+        return _with_lease(
+            self.session_provider,
+            lambda lease: self.command_executor.scalar(lease.session, command),
         )
 
     def transaction(self, body: Callable[[DbTransactionContext[S]], DbResult[T]]) -> DbResult[T]:
         lease_result = self.session_provider.acquire()
         if lease_result.is_failure:
-            return DbResult.from_failure(lease_result.failure)
+            return DbResult[T].from_failure(lease_result.failure)
 
         lease = lease_result.value
         context = DbTransactionContext(
@@ -384,9 +384,9 @@ class DbClient(Generic[S]):
         release_result = lease.release()
 
         if result.is_failure:
-            return DbResult.from_failure(result.failure)
+            return DbResult[T].from_failure(result.failure)
         if release_result.is_failure:
-            return DbResult.from_failure(release_result.failure)
+            return DbResult[T].from_failure(release_result.failure)
         return result
 
     def repository_context(self) -> DbRepositoryContext[S]:
@@ -457,14 +457,14 @@ def _with_lease(
 ) -> DbResult[T]:
     lease_result = session_provider.acquire()
     if lease_result.is_failure:
-        return DbResult.from_failure(lease_result.failure)
+        return DbResult[T].from_failure(lease_result.failure)
 
     lease = lease_result.value
     operation_result = operation(lease)
     release_result = lease.release()
 
     if operation_result.is_failure:
-        return DbResult.from_failure(operation_result.failure)
+        return DbResult[T].from_failure(operation_result.failure)
     if release_result.is_failure:
-        return DbResult.from_failure(release_result.failure)
+        return DbResult[T].from_failure(release_result.failure)
     return operation_result

--- a/code/py/modular_api_sqlserver/tests/test_db_client.py
+++ b/code/py/modular_api_sqlserver/tests/test_db_client.py
@@ -4,6 +4,11 @@ from dataclasses import dataclass
 
 import pytest
 
+from collections.abc import Callable
+from typing import TypeVar, cast
+
+_T = TypeVar("_T")
+
 from modular_api_sqlserver import (
     DbClient,
     DbCommand,
@@ -114,6 +119,7 @@ def test_client_delegates_query_calls_and_releases_package_owned_leases() -> Non
     assert provider.acquire_count == 1
     assert provider.release_count == 1
     assert executor.last_session == "db-session"
+    assert executor.last_command is not None
     assert executor.last_command.label == "users.list"
 
 
@@ -302,6 +308,7 @@ def test_repository_helpers_stay_thin_over_the_shared_context() -> None:
 
     assert result.is_success is True
     assert result.value == 9
+    assert executor.last_command is not None
     assert executor.last_command.label == "users.count"
 
 
@@ -457,8 +464,12 @@ class _FakeTransactionRunner:
     def run(
         self,
         context: DbTransactionContext[str],
-        body: callable,
-    ) -> DbResult[object]:
+        # Two fixes in one signature. `callable` is the builtin predicate, not a type — annotating with
+        # it left this fake failing to satisfy `DbTransactionRunner[str]`, which is the whole point of a
+        # fake. And `run` is generic in the body's result: pinning it to `object` still would not have
+        # satisfied the protocol, because a runner is transparent in what the body returns.
+        body: Callable[[DbTransactionContext[str]], DbResult[_T]],
+    ) -> DbResult[_T]:
         result = body(context)
         if result.is_success:
             self.commit_count += 1
@@ -476,7 +487,9 @@ class _UserStatsRepository(DbRepository[str]):
                 label="users.count",
             )
         )
-        return result.map(lambda value: int(value.value))
+        # `scalar()` yields `DbScalar[object]`: Python cannot parameterise a method call the way Dart
+        # and TypeScript can, so a consumer narrows the value it knows its own query returns.
+        return result.map(lambda value: int(cast("int | str", value.value)))
 
 
 # --- 0.6.0: typed parameters and stored-procedure support ---

--- a/code/py/modular_api_sqlserver/tests/test_db_conformance.py
+++ b/code/py/modular_api_sqlserver/tests/test_db_conformance.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any, cast
 
 from modular_api_sqlserver import (
     DbCommand,
@@ -15,12 +16,14 @@ from modular_api_sqlserver import (
 )
 
 
-def _load_fixture() -> dict[str, object]:
-    return json.loads(
+def _load_fixture() -> dict[str, Any]:
+    # `dict[str, Any]`, not `dict[str, object]`: every read below walks into the fixture, and `object`
+    # stops at the first subscript. The values really are arbitrary JSON.
+    return cast("dict[str, Any]", json.loads(
         (Path(__file__).resolve().parents[3] / "tests" / "fixtures" / "db_client" / "sqlserver.json").read_text(
             encoding="utf-8"
         )
-    )
+    ))
 
 
 def test_matches_the_shared_sqlserver_connection_fixture() -> None:

--- a/code/py/typecheck.ps1
+++ b/code/py/typecheck.ps1
@@ -1,0 +1,114 @@
+# =============================================================================
+# typecheck.ps1 — pyright across the five Python packages
+#
+# Every package's pyproject.toml configures pyright in strict mode, with a
+# relaxed "annotate every expression" family under tests/ and example/. That
+# configuration was declared for a long time without pyright ever being
+# installed, so 1211 diagnostics accumulated where nobody could see them —
+# including two public annotations that named a type too weak to use.
+#
+# This script is what makes the configuration exigible: it is the Python
+# counterpart of `npm test` in the TypeScript packages, which chains
+# `tsc --noEmit` before vitest because vitest does not typecheck either.
+#
+# Usage:
+#   pwsh .\code\py\typecheck.ps1
+#   pwsh .\code\py\typecheck.ps1 -Package modular_api_postgres
+#
+# Prerequisites:
+#   - Python venv at code/py/modular_api/.venv
+#   - pyright installed into it: pip install -e "code/py/modular_api[dev]"
+#     (pyright downloads its own node runtime on first run)
+#
+# Exits non-zero if any package reports an error, so it can gate a commit,
+# a pre-push hook or a CI step.
+# =============================================================================
+
+[CmdletBinding()]
+param(
+    # Check a single package instead of all five.
+    [string] $Package
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$pyRoot = $PSScriptRoot
+$python = Join-Path $pyRoot 'modular_api\.venv\Scripts\python.exe'
+
+if (-not (Test-Path -LiteralPath $python)) {
+    Write-Error "No venv at $python. See the prerequisites at the top of this script."
+    exit 1
+}
+
+$packages = @(
+    'modular_api'
+    'modular_api_rest_client'
+    'modular_api_postgres'
+    'modular_api_graphql_client'
+    'modular_api_sqlserver'
+)
+
+if ($Package) {
+    if ($packages -notcontains $Package) {
+        Write-Error "Unknown package '$Package'. Expected one of: $($packages -join ', ')"
+        exit 1
+    }
+    $packages = @($Package)
+}
+
+$failed = @()
+
+foreach ($name in $packages) {
+    $directory = Join-Path $pyRoot $name
+    Write-Host "── $name " -NoNewline
+
+    # `--outputjson` rather than the text output: the summary line is what we
+    # report, and parsing it is more robust than scraping human-readable text.
+    Push-Location $directory
+    try {
+        $raw = & $python -m pyright --outputjson 2>$null
+    }
+    finally {
+        Pop-Location
+    }
+
+    try {
+        $report = $raw | ConvertFrom-Json
+    }
+    catch {
+        Write-Host "could not run pyright" -ForegroundColor Red
+        $failed += $name
+        continue
+    }
+
+    $errors = @($report.generalDiagnostics | Where-Object { $_.severity -eq 'error' })
+    $warnings = @($report.generalDiagnostics | Where-Object { $_.severity -eq 'warning' })
+
+    if ($errors.Count -gt 0) {
+        Write-Host "$($errors.Count) error(s)" -ForegroundColor Red
+        foreach ($diagnostic in $errors) {
+            $relative = $diagnostic.file -replace [regex]::Escape($pyRoot), ''
+            $line = $diagnostic.range.start.line + 1
+            $rule = if ($diagnostic.rule) { $diagnostic.rule } else { 'error' }
+            $message = ($diagnostic.message -split "`n")[0]
+            Write-Host "    $relative`:$line  $rule`: $message"
+        }
+        $failed += $name
+    }
+    elseif ($warnings.Count -gt 0) {
+        Write-Host "clean ($($warnings.Count) warning(s))" -ForegroundColor Yellow
+    }
+    else {
+        Write-Host "clean" -ForegroundColor Green
+    }
+}
+
+Write-Host ''
+if ($failed.Count -gt 0) {
+    Write-Host "FAILED: $($failed -join ', ')" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "All $($packages.Count) package(s) typecheck clean." -ForegroundColor Green
+exit 0

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -260,6 +260,27 @@ async def test_hello_world():
     assert output.message == "Hello, World!"
 ```
 
+### Type checking is a separate step from `pytest`
+
+`python -m pytest` does not typecheck, in the same way `vitest run` does not and `dart test` does not
+run the analyzer. Every Python package configures pyright in strict mode — with the "annotate every
+expression" family relaxed under `tests/` and `example/` — but a configuration nothing runs is not a
+check:
+
+```powershell
+pwsh .\code\py\typecheck.ps1                               # all five packages
+pwsh .\code\py\typecheck.ps1 -Package modular_api_postgres  # just one
+```
+
+It exits non-zero if any package reports an error, so it can gate a commit, a pre-push hook or a CI
+step. The TypeScript packages chain the equivalent into `npm test` (`tsc --noEmit && vitest run`);
+Dart's is `dart analyze`.
+
+**Run it, not only the suite.** Some expectations can only fail statically. A test may use
+`typing.assert_type`, which does nothing at runtime and is an error at check time when the declared
+type differs — `tests/test_dto_typing.py` pins `Input.from_json` returning the subclass that way.
+Reverting that annotation leaves `pytest` entirely green and turns this script red.
+
 ## Summary
 
 | Test type | When to use | How |


### PR DESCRIPTION
Los cinco paquetes de Python declaraban pyright en modo `strict` en su `pyproject.toml`. pyright no
estaba instalado y nada lo ejecutaba. Al instalarlo aparecieron **1211 diagnósticos**; esta rama los
lleva a **0** y deja el chequeo exigible.

## Lo que no eran anotaciones faltantes

Dos anotaciones públicas nombraban un tipo demasiado débil para usarse:

**`Input.from_json` / `Output.from_json` devolvían `Input` / `Output`.** Toda DTO de consumidor hereda
esa factory, así que la llamada quedaba declarada devolviendo la clase base:

```python
class CuentaInput(Input):
    cuenta_id: str

parsed = CuentaInput.from_json(payload)   # declarado: Input
parsed.cuenta_id                          # error: atributo desconocido en "Input"
```

En ejecución el valor siempre fue la subclase — `cls.model_validate` construye `cls` — así que nada se
comportaba mal. Lo que se rompía era el chequeo de tipos de cada consumidor, que había que silenciar con
un cast en cada llamada. Ni Dart ni TypeScript lo tienen: allí cada DTO escribe su propia `fromJson`
estática y no hay factory heredada que pueda nombrar mal su retorno. Es específico de Python. Misma forma
de defecto que anotar `unknown[]` en un constructor de TypeScript (PR #30).

**`UseCase.logger` decía `object | None`.** El framework siempre inyecta algo que satisface
`ModularLogger` — `PluginRequestContext.logger` ya nombraba ese protocolo — y con `object` lo único que un
caso de uso hace con el logger, `self.logger.info(...)`, no chequeaba. Al tiparlo apareció el defecto real
detrás: los dos casos de uso de `example/` lo llamaban **sin comprobar None**, cuando el propio comentario
del campo dice que es None sin middleware. Dart y TypeScript ya escribían `logger?.info(...)`; Python era
el único que habría lanzado `AttributeError`.

**El plugin oficial de GraphQL registraba su ruta con un dict literal.** `PluginHost.register_route`
declara `PluginRoute`; solo la implementación incluida acepta además un dict, y eso es una ampliación de
una implementación, no una promesa del contrato. Cualquier otro host — incluido un doble de prueba — lo
cumple aceptando `PluginRoute` a secas. Los cinco plugins oficiales hermanos y el ejemplo del README ya
registraban así.

**Un atributo se leía sin verificar.** `_compute_document_depth` y `_compute_document_complexity`
filtraban con `definition.kind != "operation_definition"` y después leían `definition.selection_set`. La
comparación de cadenas no acota nada: solo `OperationDefinitionNode` tiene ese atributo. Con `isinstance`
la prueba es la misma en ejecución y coincide con cómo despachan los dos recorridos que están debajo.

**`swagger_docs_handler` devolvía `object`**, que ningún consumidor puede pasar a `Route(...)` sin un
cast — el error que su propia prueba encontró. Los otros dos factories de endpoint devolvían `Any`, que no
dice nada.

**Un `scalar()` prometía seguridad que Python no puede entregar.** `-> DbResult[DbScalar[T]]`, con `T` solo
en el retorno y un cast haciendo el trabajo por debajo. En Dart y TypeScript el llamador escribe
`scalar<int>(command)`; Python no tiene sintaxis para parametrizar la llamada a un método, así que `T`
nunca pudo ser vinculado por nadie. El protocolo del executor ya decía `DbScalar[object]`.

**Código muerto y acoplamientos:** `cors.py` construía un dict que nunca leía, y ningún código escribe esa
clave del scope tampoco. `Counter.collect()` leía `child._labels`, privado de otra clase y de otro objeto.
`logging_middleware` importaba `_default_write`, privado de otro módulo. `_resolve_maybe_awaitable` pasaba
cualquier awaitable a `asyncio.run`, que solo acepta corrutinas. Veinte imports muertos.

**En `tests/`:** un fake anotaba `body: callable` — el predicado incorporado, no un tipo — y por eso no
satisfacía el protocolo, que es lo único que un fake tiene que hacer. Nueve fixtures generadoras estaban
anotadas `-> None` mientras hacían `yield`. Dos helpers tomaban `handler=None` y definían dentro un
`async def handler` que reasignaba ese mismo parámetro. Tres aserciones leían atributos opcionales sin
comprobarlos, así que un fallo habría sido un `TypeError` en vez de una expectativa fallida.

## El patrón que explicaba el resto

Acotar con `isinstance` en el sitio deja el valor acotado — un contenedor sin parametrizar — para todo el
bloque, y eso viaja a cada llamada posterior. Tres predicados (`_is_container`, `_as_mapping`,
`_sequence_operand`) mueven el acotamiento dentro de una función, donde no contamina al llamador.

Y una trampa que costó un primer intento equivocado: `reportUnknownVariableType` reporta el tipo de la
**expresión asignada**, no el declarado del target. `decoded: object = json5.loads(...)` no lo silencia;
`decoded = cast(object, json5.loads(...))` sí. **Anotar una variable no es lo mismo que tipar el valor.**

`**kwargs: object` en un helper de paso: `object` no es asignable a ninguno de los parámetros tipados a los
que reenvía. `Any` es la anotación honesta para argumentos que se reenvían intactos y nunca se leen — el
mismo razonamiento que ya estaba anotado en `Output.__init_subclass__`.

## La compuerta

`python -m pytest` no chequea tipos, igual que `vitest run` no lo hace y `dart test` no corre el
analizador. Una configuración que nada ejecuta no es un chequeo, y eso es precisamente cómo se acumularon
1211 diagnósticos sin que nadie los viera.

```powershell
pwsh .\code\py\typecheck.ps1                               # los cinco paquetes
pwsh .\code\py\typecheck.ps1 -Package modular_api_postgres  # uno solo
```

**Verificado por perturbación, no por lectura.** Revertir `Self` a `Input` en `Input.from_json` pone el
script en 15 errores y exit 1 — incluidos los dos `example/`, que es la prueba independiente de que ese
defecto era visible para un consumidor — mientras `pytest` sigue **completamente verde**. Esa es la clase
de expectativa que solo puede fallar estáticamente: `tests/test_dto_typing.py` la fija con `assert_type`,
que no hace nada en ejecución y es un error en chequeo si el tipo declarado difiere. Se escribió en ese
orden: la prueba estaba roja con el mensaje exacto antes de la corrección.

## Tres reglas apagadas, solo en `tests/`, con la razón al lado

| Regla | Por qué |
|---|---|
| `reportUnusedFunction` | pytest llama las fixtures por nombre en la colección, nunca por una referencia que el checker pueda ver |
| `reportUnusedClass` | una prueba de warnings tiene que definir una clase que luego no menciona — el `__init_subclass__` es el sujeto |
| `reportPrivateUsage` | una prueba sí tiene derecho a ejercitar lo interno. En `src/` esta misma regla encontró acoplamiento real y se **corrigió** en vez de silenciarse |

`reportUnusedImport` y `reportUnusedVariable` quedan encendidas en todas partes: esas sí encuentran código
muerto, y lo encontraron.

## Estado

Los 1211 iniciales se midieron como total agregado, así que el desglose de partida por paquete no está
registrado; el de llegada sí.

| Paquete | `src/` | `tests/` | `example/` | Suite |
|---|---|---|---|---|
| `modular_api` | **0** | **0** | **0** | 410 ✅ |
| `modular_api_rest_client` | **0** | **0** | **0** | 7 ✅ |
| `modular_api_postgres` | **0** | **0** | **0** | 25 ✅ |
| `modular_api_graphql_client` | **0** | **0** | **0** | 7 ✅ |
| `modular_api_sqlserver` | **0** | **0** | **0** | 25 ✅ |

**1211 → 0.** 474 pruebas, todas verdes.

`src/` en strict completo. Los `example/` ejecutados, no solo chequeados: los dos de base de datos siguen
imprimiendo `Total users: 42`.

## Queda una decisión que no es mía

Este repositorio no tiene ningún workflow de CI que corra pruebas — solo los quince de publicación. El
script está listo para engancharse a uno, pero crear ese workflow gasta minutos de Actions de la cuenta y
es una decisión del dueño del repositorio.

Se excluyen de la corrida los dos archivos de smoke de SQL Server, que necesitan el contenedor. `7e9fef4`
en `feat/tracing-otlp` ya corrige el que fallen en vez de omitirse, para Dart y TypeScript; Python sigue
pendiente y no es de esta rama.
