### PR TITLE
fix(release): el workflow de Python no instalaba el paquete que probaba

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -547,6 +547,16 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         run: python -m pip install --upgrade build twine
 
+      - name: Install package under test
+        if: steps.check.outputs.skip != 'true'
+        run: python -m pip install -e ".[dev]"
+
+      # The core was published without running its suite — the only one of the fifteen with no test
+      # gate, and the package the other four depend on.
+      - name: Run tests
+        if: steps.check.outputs.skip != 'true'
+        run: python -m pytest
+
       - name: Build package
         if: steps.check.outputs.skip != 'true'
         run: python -m build
@@ -598,7 +608,17 @@ jobs:
 
       - name: Install build tooling
         if: steps.check.outputs.skip != 'true'
-        run: python -m pip install --upgrade build twine pytest
+        run: python -m pip install --upgrade build twine
+
+      # The package and its declared dependencies, not only the build tooling. pytest imports through
+      # `pythonpath = ["src"]`, so tests used to run against a package whose dependencies were never
+      # installed — which held only while these packages had none. 0.7.0 gave two of them their first
+      # runtime dependency (`opentelemetry-api`) and both jobs failed after 13 packages had already
+      # published irreversibly. The `dev` extra is the declaration of what testing needs; using it means
+      # this workflow does not restate it.
+      - name: Install package under test
+        if: steps.check.outputs.skip != 'true'
+        run: python -m pip install -e ".[dev]"
 
       - name: Run tests
         if: steps.check.outputs.skip != 'true'
@@ -655,7 +675,17 @@ jobs:
 
       - name: Install build tooling
         if: steps.check.outputs.skip != 'true'
-        run: python -m pip install --upgrade build twine pytest
+        run: python -m pip install --upgrade build twine
+
+      # The package and its declared dependencies, not only the build tooling. pytest imports through
+      # `pythonpath = ["src"]`, so tests used to run against a package whose dependencies were never
+      # installed — which held only while these packages had none. 0.7.0 gave two of them their first
+      # runtime dependency (`opentelemetry-api`) and both jobs failed after 13 packages had already
+      # published irreversibly. The `dev` extra is the declaration of what testing needs; using it means
+      # this workflow does not restate it.
+      - name: Install package under test
+        if: steps.check.outputs.skip != 'true'
+        run: python -m pip install -e ".[dev]"
 
       - name: Run tests
         if: steps.check.outputs.skip != 'true'
@@ -712,7 +742,17 @@ jobs:
 
       - name: Install build tooling
         if: steps.check.outputs.skip != 'true'
-        run: python -m pip install --upgrade build twine pytest
+        run: python -m pip install --upgrade build twine
+
+      # The package and its declared dependencies, not only the build tooling. pytest imports through
+      # `pythonpath = ["src"]`, so tests used to run against a package whose dependencies were never
+      # installed — which held only while these packages had none. 0.7.0 gave two of them their first
+      # runtime dependency (`opentelemetry-api`) and both jobs failed after 13 packages had already
+      # published irreversibly. The `dev` extra is the declaration of what testing needs; using it means
+      # this workflow does not restate it.
+      - name: Install package under test
+        if: steps.check.outputs.skip != 'true'
+        run: python -m pip install -e ".[dev]"
 
       - name: Run tests
         if: steps.check.outputs.skip != 'true'
@@ -769,7 +809,17 @@ jobs:
 
       - name: Install build tooling
         if: steps.check.outputs.skip != 'true'
-        run: python -m pip install --upgrade build twine pytest
+        run: python -m pip install --upgrade build twine
+
+      # The package and its declared dependencies, not only the build tooling. pytest imports through
+      # `pythonpath = ["src"]`, so tests used to run against a package whose dependencies were never
+      # installed — which held only while these packages had none. 0.7.0 gave two of them their first
+      # runtime dependency (`opentelemetry-api`) and both jobs failed after 13 packages had already
+      # published irreversibly. The `dev` extra is the declaration of what testing needs; using it means
+      # this workflow does not restate it.
+      - name: Install package under test
+        if: steps.check.outputs.skip != 'true'
+        run: python -m pip install -e ".[dev]"
 
       - name: Run tests
         if: steps.check.outputs.skip != 'true'


### PR DESCRIPTION
`v0.7.0` publicó **13 de 15** paquetes. Los dos que faltan son de PyPI:

| Registro | Estado |
|---|---|
| npm | ✅ 5/5 en `0.7.0` |
| pub.dev | ✅ 5/5 en `0.7.0` |
| PyPI | ⚠️ 3/5 — faltan `macss-modular-api-rest-client` y `macss-modular-api-postgres` |

La paridad entre lenguajes está rota para esos dos paquetes hasta que esto se mergee y se re-corra la publicación.

## Qué pasó

Los dos jobs cayeron con `ModuleNotFoundError: No module named 'opentelemetry'`. La causa **no** era una dependencia mal declarada — los dos declaran `opentelemetry-api>=1.44,<2` correctamente. **Nunca se instalaba.**

Los cuatro jobs de satélites instalaban solo herramientas de build:

```yaml
run: python -m pip install --upgrade build twine pytest
```

…y después corrían `python -m pytest`. Las pruebas importan por `pythonpath = ["src"]` de pytest, así que el paquete era importable **sin estar instalado** y sus dependencias de runtime nunca llegaban al runner.

Eso se sostuvo mientras esos paquetes no tuvieran ninguna dependencia de runtime. `0.7.0` le dio a dos de ellos su primera —`opentelemetry-api`, por ADR-0005— y la compuerta se derrumbó. Con 13 paquetes ya publicados de forma irreversible.

**Y el core de Python no corría pruebas en absoluto.** Su job iba de instalar herramientas directo a `build` y `publish`. Era el único de los quince sin compuerta de pruebas, y es el paquete del que dependen los otros cuatro.

## El arreglo

Los cinco jobs instalan el paquete bajo prueba antes de probarlo:

```yaml
- name: Install package under test
  run: python -m pip install -e ".[dev]"
```

El extra `dev` ya es la declaración de lo que hace falta para probar cada paquete —incluye `opentelemetry-sdk`, que las pruebas de tracing necesitan—, así que el workflow la usa en vez de repetirla. Y `py-core` gana el paso de pruebas que no tenía.

## Verificado reproduciendo el runner

No por lectura. En un venv limpio, dentro de `modular_api_postgres`:

- **Paso viejo** (`build twine pytest`): falla con los mismos **3 errores de colección** que en CI.
- **Paso nuevo** (`-e ".[dev]"`): los cinco paquetes pasan — core **532**, rest_client **24**, postgres **55**, graphql_client **7**, sqlserver **25**.

## Cómo completar la publicación de 0.7.0

Re-correr el tag no sirve: `gh run rerun` vuelve a correr el mismo commit, que es el que tiene el workflow roto. Después de mergear esto:

```
gh workflow run release.yml --ref main -f version=0.7.0
```

La publicación es idempotente: los 13 paquetes ya publicados se saltean con aviso y solo se publican los dos que faltan.

## Nota

Es la tercera compuerta de esta serie que parecía verificar algo que no podía verificar, junto con **G4** —marcada como cumplida sin estar implementada— y el `npm install` que dejaba el lockfile de TypeScript sin autoridad al publicar. Las tres se encontraron mirando, no leyendo el checkmark. El cambio a `npm ci` está anotado en la [issue #32](https://github.com/ccisnedev/modular_api/issues/32) (ADR-0006).
