### PR TITLE
fix(py): el extra dev de rest_client no declaraba el SDK que sus pruebas importan

### DIFF
--- a/code/py/modular_api_rest_client/pyproject.toml
+++ b/code/py/modular_api_rest_client/pyproject.toml
@@ -30,6 +30,12 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    # `tests/test_tracing.py` imports `opentelemetry.sdk.trace`: the API alone is no-op, so asserting
+    # that spans are emitted needs an SDK. A test dependency, not a runtime one — the published package
+    # still declares only the API (ADR-0005 A1/A2). `modular_api_postgres` already declared this; this
+    # package did not, which is why its publish job failed with `No module named 'opentelemetry.sdk'`
+    # once the workflow started installing what each package declares.
+    "opentelemetry-sdk>=1.44,<2",
     # Configured below at `typeCheckingMode = "strict"`. Declared here because a checker the
     # repo configures and never installs is a checker that has never run.
     "pyright>=1.1.400",


### PR DESCRIPTION
`v0.7.0` está en **14 de 15**. Falta `macss-modular-api-rest-client` en PyPI.

## Qué pasó

[#33](https://github.com/ccisnedev/modular_api/pull/33) hizo que el workflow instalara lo que cada paquete declara (`pip install -e ".[dev]"`), y eso expuso una asimetría que antes quedaba tapada:

| Paquete | Sus tests importan `opentelemetry.sdk` | Su extra `dev` lo declara |
|---|---|---|
| `modular_api` | sí | ✅ |
| `modular_api_postgres` | sí | ✅ |
| **`modular_api_rest_client`** | **sí** | **❌** |
| `modular_api_graphql_client` | no | — |
| `modular_api_sqlserver` | no | — |

`tests/test_tracing.py` importa `opentelemetry.sdk.trace`, pero el extra `dev` solo tenía `pyright` y `pytest`. El job falló con `No module named 'opentelemetry.sdk'`.

Es dependencia **de prueba**, no de runtime: el paquete publicado sigue declarando solo la API de OpenTelemetry (ADR-0005 A1/A2). La API sola es no-op, así que afirmar que se emiten spans necesita un SDK — y por eso va en el extra y no en `dependencies`.

## Corrección a mi verificación de #33

En #33 escribí "verificado en un venv limpio". **No lo estaba.** Instalé los cinco paquetes en el *mismo* venv, así que el `opentelemetry-sdk` que trajo el extra de `postgres` quedó disponible para `rest_client`, y sus 24 pruebas pasaron por contagio. El venv era limpio para el primer paquete y no para los siguientes — que es exactamente la clase de falso verde que #33 venía a eliminar.

Esta vez cada paquete se probó en **su propio venv**, creado y destruido por paquete:

| Paquete | Resultado |
|---|---|
| `modular_api` | 532 passed, 2 skipped |
| `modular_api_rest_client` | 24 passed |
| `modular_api_graphql_client` | 7 passed |
| `modular_api_postgres` | 55 passed |
| `modular_api_sqlserver` | 25 passed |

## Cómo completar la publicación

`rest_client 0.7.0` nunca se publicó, así que no hay problema de inmutabilidad y no hace falta subir la versión. Después de mergear:

```
gh workflow run release.yml --ref main -f version=0.7.0
```

Los 14 ya publicados se saltean con aviso; solo sale el que falta.
