### PR TITLE
chore(deps): los lockfiles resuelven 0.7.0 desde los registros

### DIFF
--- a/code/ts/modular_api_graphql_client/package-lock.json
+++ b/code/ts/modular_api_graphql_client/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@macss/modular-api-rest-client": "^0.6.0"
+        "@macss/modular-api-rest-client": "^0.7.0"
       },
       "devDependencies": {
         "@types/node": "^22.19.11",
@@ -23,10 +23,22 @@
       "license": "MIT"
     },
     "node_modules/@macss/modular-api-rest-client": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@macss/modular-api-rest-client/-/modular-api-rest-client-0.6.0.tgz",
-      "integrity": "sha512-Jj5pJoSJnpBdObiG0BhtnEwQJ12vrWTqEkRSItwBXSClrMla0OIuQdMqb7FtctLMT5YRS89A0IQSsFGxXbVHBQ==",
-      "license": "MIT"
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@macss/modular-api-rest-client/-/modular-api-rest-client-0.7.0.tgz",
+      "integrity": "sha512-mqIQSd2qcr5KpxO6JtAjfG6CEW7QTyTUccJFUyXcHsCRXY25wkflrpgjBre6o48L8yBXFmj5XK8mb0ngeOZ+fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/@oxc-project/types": {
       "version": "0.133.0",


### PR DESCRIPTION
Limpieza posterior a la publicación de `0.7.0`.

Durante el dogfood hicieron falta overrides locales porque `0.7.0` no existía todavía en los registros. Ya existe, así que se van:

- Borrados los dos `pubspec_overrides.yaml` de Dart (`modular_api_sqlserver`, `modular_api_graphql_client`) — nunca estuvieron versionados, la ruta era de la máquina.
- Regenerado el `package-lock.json` del `modular_api_graphql_client` de TypeScript. Venía pinneando `0.4.7` contra un `^0.6.0` declarado, y en el commit del bump quedó en `0.6.0` porque `0.7.0` aún no se había publicado. Ahora sí es consistente con lo declarado.

Verificado que resuelven desde el registro y no desde una ruta:

| Paquete | Resuelve | Verificación |
|---|---|---|
| dart `modular_api_sqlserver` | `modular_api 0.7.0` (pub.dev) | analyze limpio, 25 pruebas |
| dart `modular_api_graphql_client` | `modular_api_rest_client 0.7.0` (pub.dev) | analyze limpio, 7 pruebas |
| ts `modular_api_graphql_client` | `@macss/modular-api-rest-client 0.7.0` (npm) | 7 pruebas |

El cambio a `npm ci` en los jobs de publicación —que es lo que habría detectado el lockfile viejo— está anotado en la [issue #32](https://github.com/ccisnedev/modular_api/issues/32).